### PR TITLE
Prevent the example server from crashing when NGINX is not running

### DIFF
--- a/src/plugins/comms.go
+++ b/src/plugins/comms.go
@@ -50,7 +50,6 @@ func (r *Comms) Close() {
 	log.Info("Comms is wrapping up")
 	r.started.Store(false)
 	r.readyToSend.Store(false)
-	r.wait.Done()
 }
 
 func (r *Comms) Info() *core.Info {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/comms.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/comms.go
@@ -50,7 +50,6 @@ func (r *Comms) Close() {
 	log.Info("Comms is wrapping up")
 	r.started.Store(false)
 	r.readyToSend.Store(false)
-	r.wait.Done()
 }
 
 func (r *Comms) Info() *core.Info {


### PR DESCRIPTION
Added a fix for the example server crashing when NGINX is not running. Removed the Waitgroup in comms.go Close, as if no active Waitgroup can cause a negative count.

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
