### PR TITLE
added features key to config to list features for NGINX Agent

### DIFF
--- a/src/core/config/defaults.go
+++ b/src/core/config/defaults.go
@@ -97,6 +97,7 @@ const (
 	InstanceGroupKey  = "instance_group"
 	ConfigDirsKey     = "config_dirs"
 	TagsKey           = "tags"
+	FeaturesKey       = "features"
 
 	// viper keys used in config
 	LogKey = "log"
@@ -220,6 +221,10 @@ var (
 		&StringSliceFlag{
 			Name:  TagsKey,
 			Usage: "A comma-separated list of tags to add to the current instance or machine, to be used for inventory purposes.",
+		},
+		&StringSliceFlag{
+			Name:  FeaturesKey,
+			Usage: "A comma-separated list of features enabled for the agent.",
 		},
 		// NGINX Config
 		&StringFlag{

--- a/src/core/config/types.go
+++ b/src/core/config/types.go
@@ -19,6 +19,7 @@ type Config struct {
 	Dataplane             Dataplane           `mapstructure:"dataplane" yaml:"-"`
 	AgentMetrics          AgentMetrics        `mapstructure:"metrics" yaml:"-"`
 	Tags                  []string            `mapstructure:"tags" yaml:"tags,omitempty"`
+	Features              []string            `mapstructure:"features" yaml:"features,omitempty"`
 	Updated               time.Time           `yaml:"-"` // update time of the config file
 	AllowedDirectoriesMap map[string]struct{} `yaml:"-"`
 	DisplayName           string              `mapstructure:"display_name" yaml:"display_name,omitempty"`

--- a/src/plugins/commander.go
+++ b/src/plugins/commander.go
@@ -74,9 +74,9 @@ func (c *Commander) agentRegistered(cmd *proto.Command) {
 		if agtCfg := commandData.AgentConnectResponse.AgentConfig; agtCfg != nil &&
 			agtCfg.Configs != nil && len(agtCfg.Configs.Configs) > 0 {
 
-			// Update config tags if they were out of sync between Manager and Agent
-			if agtCfg.Details != nil && len(agtCfg.Details.Tags) > 0 {
-				configUpdated, err := config.UpdateAgentConfig(c.config.ClientID, agtCfg.Details.Tags)
+			// Update config tags and features if they were out of sync between Manager and Agent
+			if agtCfg.Details != nil && (len(agtCfg.Details.Tags) > 0 || len(agtCfg.Details.Features) > 0) {
+				configUpdated, err := config.UpdateAgentConfig(c.config.ClientID, agtCfg.Details.Tags, agtCfg.Details.Features)
 				if err != nil {
 					log.Errorf("Failed updating Agent config - %v", err)
 				}

--- a/src/plugins/config_reader.go
+++ b/src/plugins/config_reader.go
@@ -68,7 +68,7 @@ func (r *ConfigReader) Subscriptions() []string {
 func (r *ConfigReader) updateAgentConfig(cmd *proto.Command) {
 	switch commandData := cmd.Data.(type) {
 	case *proto.Command_AgentConfig:
-		configUpdated, err := config.UpdateAgentConfig(r.config.ClientID, commandData.AgentConfig.Details.Tags)
+		configUpdated, err := config.UpdateAgentConfig(r.config.ClientID, commandData.AgentConfig.Details.Tags, commandData.AgentConfig.Details.Features)
 		if err != nil {
 			log.Errorf("Failed updating Agent config - %v", err)
 		}

--- a/src/plugins/config_reader_test.go
+++ b/src/plugins/config_reader_test.go
@@ -145,7 +145,8 @@ func TestUpdateAgentConfig(t *testing.T) {
 				Data: &proto.Command_AgentConfig{
 					AgentConfig: &proto.AgentConfig{
 						Details: &proto.AgentDetails{
-							Tags: curConf.Tags,
+							Tags:     curConf.Tags,
+							Features: curConf.Features,
 						},
 					},
 				},

--- a/src/plugins/dataplane_status_test.go
+++ b/src/plugins/dataplane_status_test.go
@@ -158,7 +158,7 @@ func TestDPSSyncAgentConfigChange(t *testing.T) {
 			assert.Equal(t, tc.config.Tags, *dataPlaneStatus.tags)
 
 			// Attempt update & check results
-			updated, err := config.UpdateAgentConfig("12345", tc.expUpdatedConfig.Tags)
+			updated, err := config.UpdateAgentConfig("12345", tc.expUpdatedConfig.Tags, tc.expUpdatedConfig.Features)
 			assert.Nil(t, err)
 			assert.Equal(t, updated, tc.updatedTags)
 

--- a/src/plugins/metrics_test.go
+++ b/src/plugins/metrics_test.go
@@ -250,7 +250,7 @@ func TestMetrics_Process_AgentConfigChanged(t *testing.T) {
 			assert.Equal(t, tutils.InitialConfTags, metricsPlugin.conf.Tags)
 
 			// Attempt update & check results
-			updated, err := config.UpdateAgentConfig("12345", tc.expUpdatedConfig.Tags)
+			updated, err := config.UpdateAgentConfig("12345", tc.expUpdatedConfig.Tags, tc.expUpdatedConfig.Features)
 			assert.Nil(t, err)
 			assert.Equal(t, updated, tc.updatedTags)
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/defaults.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/defaults.go
@@ -97,6 +97,7 @@ const (
 	InstanceGroupKey  = "instance_group"
 	ConfigDirsKey     = "config_dirs"
 	TagsKey           = "tags"
+	FeaturesKey       = "features"
 
 	// viper keys used in config
 	LogKey = "log"
@@ -220,6 +221,10 @@ var (
 		&StringSliceFlag{
 			Name:  TagsKey,
 			Usage: "A comma-separated list of tags to add to the current instance or machine, to be used for inventory purposes.",
+		},
+		&StringSliceFlag{
+			Name:  FeaturesKey,
+			Usage: "A comma-separated list of features enabled for the agent.",
 		},
 		// NGINX Config
 		&StringFlag{

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/types.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/types.go
@@ -19,6 +19,7 @@ type Config struct {
 	Dataplane             Dataplane           `mapstructure:"dataplane" yaml:"-"`
 	AgentMetrics          AgentMetrics        `mapstructure:"metrics" yaml:"-"`
 	Tags                  []string            `mapstructure:"tags" yaml:"tags,omitempty"`
+	Features              []string            `mapstructure:"features" yaml:"features,omitempty"`
 	Updated               time.Time           `yaml:"-"` // update time of the config file
 	AllowedDirectoriesMap map[string]struct{} `yaml:"-"`
 	DisplayName           string              `mapstructure:"display_name" yaml:"display_name,omitempty"`

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/commander.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/commander.go
@@ -74,9 +74,9 @@ func (c *Commander) agentRegistered(cmd *proto.Command) {
 		if agtCfg := commandData.AgentConnectResponse.AgentConfig; agtCfg != nil &&
 			agtCfg.Configs != nil && len(agtCfg.Configs.Configs) > 0 {
 
-			// Update config tags if they were out of sync between Manager and Agent
-			if agtCfg.Details != nil && len(agtCfg.Details.Tags) > 0 {
-				configUpdated, err := config.UpdateAgentConfig(c.config.ClientID, agtCfg.Details.Tags)
+			// Update config tags and features if they were out of sync between Manager and Agent
+			if agtCfg.Details != nil && (len(agtCfg.Details.Tags) > 0 || len(agtCfg.Details.Features) > 0) {
+				configUpdated, err := config.UpdateAgentConfig(c.config.ClientID, agtCfg.Details.Tags, agtCfg.Details.Features)
 				if err != nil {
 					log.Errorf("Failed updating Agent config - %v", err)
 				}

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/config_reader.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/config_reader.go
@@ -68,7 +68,7 @@ func (r *ConfigReader) Subscriptions() []string {
 func (r *ConfigReader) updateAgentConfig(cmd *proto.Command) {
 	switch commandData := cmd.Data.(type) {
 	case *proto.Command_AgentConfig:
-		configUpdated, err := config.UpdateAgentConfig(r.config.ClientID, commandData.AgentConfig.Details.Tags)
+		configUpdated, err := config.UpdateAgentConfig(r.config.ClientID, commandData.AgentConfig.Details.Tags, commandData.AgentConfig.Details.Features)
 		if err != nil {
 			log.Errorf("Failed updating Agent config - %v", err)
 		}

--- a/test/performance/vendor/github.com/nginx/agent/v2/test/utils/process.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/test/utils/process.go
@@ -18,7 +18,7 @@ func StartFakeProcesses(names []string, fakeProcsDuration string) func() {
 		_ = pCmd.Start()
 
 		// Arbitrary sleep to ensure process has time to come up
-		time.Sleep(time.Millisecond * 100)
+		time.Sleep(time.Millisecond * 150)
 
 		pList = append(pList, pCmd.Process)
 	}

--- a/test/utils/process.go
+++ b/test/utils/process.go
@@ -18,7 +18,7 @@ func StartFakeProcesses(names []string, fakeProcsDuration string) func() {
 		_ = pCmd.Start()
 
 		// Arbitrary sleep to ensure process has time to come up
-		time.Sleep(time.Millisecond * 100)
+		time.Sleep(time.Millisecond * 150)
 
 		pList = append(pList, pCmd.Process)
 	}


### PR DESCRIPTION
### Proposed changes
Update the dynamic config file with the features received in the `AgentDetails` message. Proposed list of features planned to be supported:

* registration
* nginx-config
* nginx-ssl-config
* nginx-counting
* metrics (core)
* metrics-throttle
* dataplanestatus
* process-watcher
* file-watcher
* activity-events

These changes will be used to support feature toggling where different use cases are enabled/disabled based on the feature list either in the nginx-agent.conf file or through the Proto Command populating the AgentDetails message. 
For example, a client can opt out of uploading their nginx-config or the ssl information present in their nginx-config

This initial PR will focus on nginx-config and nginx-ssl-config use cases. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
