### PR TITLE
Changing extension back to pkg instead of txz for freebsd packages

### DIFF
--- a/scripts/packages/packager/local-entrypoint.sh
+++ b/scripts/packages/packager/local-entrypoint.sh
@@ -27,9 +27,11 @@ pkg -o ABI="FreeBSD:13:amd64" create --format txz  \
     -p /staging/plist \
     -o ./build/; \
 
-# Renaming file extension from pkg to txz. In older versions of pkg the extension would represent the format of the file 
+# Creating symbolic link from txz to pkg. In older versions of pkg the extension would represent the format of the file 
 # but since version 1.17.0 pkg will now always create a file with the extesion pkg no matter what the format is. 
 # See 1.17.0 release notes for more info: https://cgit.freebsd.org/ports/commit/?id=e497a16a286972bfcab908209b11ee6a13d99dc9
-mv ./build/nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT.pkg ./build/nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT.txz 
+cd build/
+ln -s nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT.pkg nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT.txz 
+cd ..
 
 rm -rf /staging

--- a/scripts/packages/packager/signed-entrypoint.sh
+++ b/scripts/packages/packager/signed-entrypoint.sh
@@ -34,10 +34,12 @@ for freebsd_abi in $FREEBSD_DISTROS; do \
         -o ./build/packages/txz/"$freebsd_abi"; \
     # create freebsd pkg repo layout
     pkg repo ./build/packages/txz/"$freebsd_abi" .key.rsa; \
-    # Renaming file extension from pkg to txz. In older versions of pkg the extension would represent the format of the file 
+    # Creating symbolic link from txz to pkg. In older versions of pkg the extension would represent the format of the file 
     # but since version 1.17.0 pkg will now always create a file with the extesion pkg no matter what the format is. 
     # See 1.17.0 release notes for more info: https://cgit.freebsd.org/ports/commit/?id=e497a16a286972bfcab908209b11ee6a13d99dc9
-    mv ./build/packages/txz/"$freebsd_abi"/nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')".pkg ./build/packages/txz/"$freebsd_abi"/nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')".txz; \
+    cd build/packages/txz/"$freebsd_abi" \
+    ln -s nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')".pkg nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')".txz; \
+    cd ../../../../ \
 done; \
 
 rm -rf /staging


### PR DESCRIPTION
### Proposed changes

Changing extension back to pkg instead of txz for freebsd packages. Introducing a symbolic link instead.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
