### PR TITLE
fix: Adds Support For NAP 3.12

### DIFF
--- a/src/extensions/nginx-app-protect/nap/nap_release.go
+++ b/src/extensions/nginx-app-protect/nap/nap_release.go
@@ -14,6 +14,7 @@ import (
 func NewNAPReleaseMap() *NAPReleaseMap {
 	return &NAPReleaseMap{
 		ReleaseMap: map[string]NAPRelease{
+			"3.12":  NAPRelease3_12(),
 			"3.11":  NAPRelease3_11(),
 			"3.10":  NAPRelease3_10(),
 			"3.9.1": NAPRelease3_9_1(),

--- a/src/extensions/nginx-app-protect/nap/releases.go
+++ b/src/extensions/nginx-app-protect/nap/releases.go
@@ -1,5 +1,36 @@
 package nap
 
+// NAPRelease3_12 returns information regarding packages and versioning for NAP release
+// version 3.12.
+func NAPRelease3_12() NAPRelease {
+	return NAPRelease{
+		NAPPackages: NAPReleasePackages{
+			Alpine310:    "",
+			AmazonLinux2: "app-protect-27+3.1088.1-1.el7.ngx.x86_64.rpm",
+			Centos7:      "app-protect-27+3.1088.1-1.el7.ngx.x86_64.rpm",
+			Debian9:      "",
+			Debian10:     "app-protect_27+3.1088.1~buster_amd64.deb",
+			Redhat7:      "app-protect-27+3.1088.1-1.el7.ngx.x86_64.rpm",
+			Redhat8:      "app-protect-27+3.1088.1-1.el8.ngx.x86_64.rpm",
+			Ubuntu1804:   "app-protect_27+3.1088.1~bionic_amd64.deb",
+			Ubuntu2004:   "app-protect_27+3.1088.1~focal_amd64.deb",
+		},
+		NAPCompilerPackages:   NAPReleasePackages{},
+		NAPEnginePackages:     NAPReleasePackages{},
+		NAPPluginPackages:     NAPReleasePackages{},
+		NAPPlusModulePackages: NAPReleasePackages{},
+		VersioningDetails: NAPVersioningDetails{
+			NAPBuild:      "3.1088.1",
+			NAPCompiler:   "10.139.1",
+			NAPEngine:     "10.139.1",
+			NAPPlugin:     "3.1088.1",
+			NAPPlusModule: "27+3.1088.1",
+			NAPRelease:    "3.12",
+			NginxPlus:     "27",
+		},
+	}
+}
+
 // NAPRelease3_11 returns information regarding packages and versioning for NAP release
 // version 3.11.
 func NAPRelease3_11() NAPRelease {


### PR DESCRIPTION
### Proposed changes
This PR updates the build version to release version mapping to support `NGINX App Protect 3.12`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
