### PR TITLE
fix: clean up, so we don't send empty metrics report

### DIFF
--- a/src/core/metrics/aggregate.go
+++ b/src/core/metrics/aggregate.go
@@ -13,6 +13,7 @@ type PerDimension struct {
 	Dimensions    []*proto.Dimension
 	RunningSumMap map[string]float64
 }
+
 type MetricsHandler func(float64, int) float64
 
 type Collections struct {
@@ -72,7 +73,7 @@ func GenerateMetricsReport(metricsCollections Collections) *proto.MetricsReport 
 
 	return &proto.MetricsReport{
 		Meta: &proto.Metadata{},
-		Type: 0,
+		Type: proto.MetricsReport_SYSTEM,
 		Data: results,
 	}
 }
@@ -315,17 +316,17 @@ func getAggregatedSimpleMetric(count int, internalMap map[string]float64) (simpl
 
 	for name, value := range internalMap {
 		if calculation, ok := calcFn[name]; ok {
-			aggegatedValue := calculation(value, count)
+			aggregatedValue := calculation(value, count)
 
 			// Only aggregate metrics when the aggregation method is defined
 			simpleMetrics = append(simpleMetrics, &proto.SimpleMetric{
 				Name:  name,
-				Value: aggegatedValue,
+				Value: aggregatedValue,
 			})
 		} else {
-			for reg, calculation := range variableMetrics {
+			for reg, cal := range variableMetrics {
 				if reg.MatchString(name) {
-					result := calculation(value, count)
+					result := cal(value, count)
 
 					simpleMetrics = append(simpleMetrics, &proto.SimpleMetric{
 						Name:  name,

--- a/src/plugins/advanced_metrics.go
+++ b/src/plugins/advanced_metrics.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/nginx/agent/sdk/v2/proto"
 	"github.com/nginx/agent/v2/src/core"
 	"github.com/nginx/agent/v2/src/core/config"
@@ -14,7 +16,6 @@ import (
 	advanced_metrics "github.com/nginx/agent/v2/src/extensions/advanced-metrics/pkg/advanced-metrics"
 	"github.com/nginx/agent/v2/src/extensions/advanced-metrics/pkg/publisher"
 	"github.com/nginx/agent/v2/src/extensions/advanced-metrics/pkg/schema"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -214,7 +215,9 @@ func (m *AdvancedMetrics) run() {
 				return
 			}
 			now := types.TimestampNow()
-			m.pipeline.Process(core.NewMessage(core.CommMetrics, []core.Payload{toMetricReport(mr, now, commonDimensions)}))
+			if report := toMetricReport(mr, now, commonDimensions); len(report.Data) > 0 {
+				m.pipeline.Process(core.NewMessage(core.CommMetrics, []core.Payload{report}))
+			}
 		case <-m.pipeline.Context().Done():
 			return
 		}

--- a/src/plugins/metrics_throlling.go
+++ b/src/plugins/metrics_throlling.go
@@ -130,9 +130,11 @@ func (r *MetricsThrottle) metricsReportGoroutine(ctx context.Context, wg *sync.W
 			return
 		case <-r.ticker.C:
 			aggregatedReport := r.getAggregatedReport()
-			r.messagePipeline.Process(
-				core.NewMessage(core.CommMetrics, []core.Payload{aggregatedReport}),
-			)
+			if len(aggregatedReport.Data) > 0 {
+				r.messagePipeline.Process(
+					core.NewMessage(core.CommMetrics, []core.Payload{aggregatedReport}),
+				)
+			}
 			if r.firstRun {
 				// for the first run, we added the staggering time in report cycle, reset it back to regular
 				r.ticker = time.NewTicker(r.conf.AgentMetrics.ReportInterval)


### PR DESCRIPTION
### Proposed changes
- clean up, use generated enum instead of 0 int for proto type
- check for non-empty report before sending, this should fix the empty report on the consumer side

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
