### PR TITLE
Handle nginx instance with no config args

### DIFF
--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	withWithPrefix   = "with-"
-	withModuleSuffix = "module"
+	withWithPrefix        = "with-"
+	withModuleSuffix      = "module"
+	defaultNginxOssPrefix = "/usr/local/nginx"
 )
 
 var (
@@ -576,7 +577,9 @@ func (n *NginxBinaryType) getNginxInfoFromBuffer(exePath string, buffer *bytes.B
 		}
 	}
 
-	if info.cfgf["prefix"] != nil {
+	if info.cfgf["prefix"] == nil {
+		info.prefix = defaultNginxOssPrefix
+	} else {
 		info.prefix = info.cfgf["prefix"].(string)
 	}
 

--- a/src/core/nginx_test.go
+++ b/src/core/nginx_test.go
@@ -202,6 +202,23 @@ func TestGetNginxInfoFromBuffer(t *testing.T) {
 				modulesPath:     "",
 			},
 		},
+		{
+			name: "custom nginx install no config args",
+			input: `nginx version: nginx/1.19.10
+			TLS SNI support enabled
+			configure arguments: `,
+			expectedNginxInfo: &nginxInfo{
+				prefix:          "/usr/local/nginx",
+				confPath:        "/usr/local/nginx/conf/nginx.conf",
+				version:         "1.19.10",
+				plusver:         "",
+				source:          "",
+				cfgf:            map[string]interface{}{},
+				configureArgs:   []string{""},
+				loadableModules: nil,
+				modulesPath:     "",
+			},
+		},
 	}
 
 	err := os.Mkdir("/tmp/modules", 0700)

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	withWithPrefix   = "with-"
-	withModuleSuffix = "module"
+	withWithPrefix        = "with-"
+	withModuleSuffix      = "module"
+	defaultNginxOssPrefix = "/usr/local/nginx"
 )
 
 var (
@@ -576,7 +577,9 @@ func (n *NginxBinaryType) getNginxInfoFromBuffer(exePath string, buffer *bytes.B
 		}
 	}
 
-	if info.cfgf["prefix"] != nil {
+	if info.cfgf["prefix"] == nil {
+		info.prefix = defaultNginxOssPrefix
+	} else {
 		info.prefix = info.cfgf["prefix"].(string)
 	}
 


### PR DESCRIPTION
### Proposed changes

Updated getNginxInfoFromBuffer function to handle the scenario where nginx has no config arguments

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
