### PR TITLE
fix: use lower case for all severity values

### DIFF
--- a/src/extensions/nginx-app-protect/monitoring/processor/nap.go
+++ b/src/extensions/nginx-app-protect/monitoring/processor/nap.go
@@ -460,7 +460,7 @@ func setValue(napConfig *NAPConfig, key, value string, logger *logrus.Entry) err
 	case requestStatus:
 		napConfig.RequestStatus = value
 	case severity:
-		napConfig.Severity = value
+		napConfig.Severity = strings.ToLower(value)
 	case sigSetNames:
 		napConfig.SigSetNames = replaceEncodedList(value, listSeperator)
 	case threatCampaignNames:

--- a/test/component/nginx-app-protect/monitoring/testData/events-out/expanded_nap_waf.log.txt.out
+++ b/test/component/nginx-app-protect/monitoring/testData/events-out/expanded_nap_waf.log.txt.out
@@ -1,8 +1,8 @@
 
 j
-Agent$c9f9fc06-6071-11ed-8415-5671f551701b4355056874564592513"×ª°›€òÃ×*ERROR2Nginx:
+Agent$638d54bc-6135-11ed-8afe-5671f551701b4355056874564592513"€»µ›€–¾Ï*ERROR2Nginx:
 AppProtect 
-app_protect_default_policy4355056874564592513REJECTED"SECURITY_WAF_VIOLATION*N/A2GET:HTTPBN/AJ/RHTTP/1.1bblockedjBlockedz1-localhost:1-/‚	127.0.0.1Š61478’80šŽHTTP protocol compliance failed,Illegal meta character in value,Attack signature detected,Violation Rating Threat detected,Bot Client Detected¢?HTTP protocol compliance failed:Host header contains IP addressª5²u{Cross Site Scripting Signatures;High Accuracy Signatures},{Cross Site Scripting Signatures;High Accuracy Signatures}º,ÂUntrusted BotÊN/AÒN/AÚCriticalâN/AêN/AòHTTP LibraryúN/A‚curlŠ	parameter’u
+app_protect_default_policy4355056874564592513REJECTED"SECURITY_WAF_VIOLATION*N/A2GET:HTTPBN/AJ/RHTTP/1.1bblockedjBlockedz1-localhost:1-/‚	127.0.0.1Š61478’80šŽHTTP protocol compliance failed,Illegal meta character in value,Attack signature detected,Violation Rating Threat detected,Bot Client Detected¢?HTTP protocol compliance failed:Host header contains IP addressª5²u{Cross Site Scripting Signatures;High Accuracy Signatures},{Cross Site Scripting Signatures;High Accuracy Signatures}º,ÂUntrusted BotÊN/AÒN/AÚcriticalâN/AêN/AòHTTP LibraryúN/A‚curlŠ	parameter’u
 VIOL_ATTACK_SIGNATURE	parameter
 a<script>" 
 	2000014753

--- a/test/component/nginx-app-protect/monitoring/testData/events-out/xml_header_data.log.txt.out
+++ b/test/component/nginx-app-protect/monitoring/testData/events-out/xml_header_data.log.txt.out
@@ -1,7 +1,7 @@
 
 j
-Agent$cff2dc2c-6071-11ed-8415-5671f551701b4355056874564592514"áª°›€Ìˆá*ERROR2Nginx:
+Agent$6986d064-6135-11ed-8afe-5671f551701b4355056874564592514"Š»µ›Àý¹Ú*ERROR2Nginx:
 AppProtectì
-app_protect_default_policy4355056874564592514REJECTED"SECURITY_WAF_VIOLATION*N/A2GET:HTTPBN/AJ/R^GET /?a=<script> HTTP/1.1\r\nHost: 127.0.0.1\r\nUser-Agent: curl/7.64.1\r\nAccept: */*\r\n\r\nbblockedjBlockedz1-localhost:1-/‚	127.0.0.1Š61478’80šŽHTTP protocol compliance failed,Illegal meta character in value,Attack signature detected,Violation Rating Threat detected,Bot Client Detected¢?HTTP protocol compliance failed:Host header contains IP addressª5²u{Cross Site Scripting Signatures;High Accuracy Signatures},{Cross Site Scripting Signatures;High Accuracy Signatures}º,ÂUntrusted BotÊN/AÒN/AÚCriticalâN/AêN/AòHTTP LibraryúN/A‚curlŠheader’6
+app_protect_default_policy4355056874564592514REJECTED"SECURITY_WAF_VIOLATION*N/A2GET:HTTPBN/AJ/R^GET /?a=<script> HTTP/1.1\r\nHost: 127.0.0.1\r\nUser-Agent: curl/7.64.1\r\nAccept: */*\r\n\r\nbblockedjBlockedz1-localhost:1-/‚	127.0.0.1Š61478’80šŽHTTP protocol compliance failed,Illegal meta character in value,Attack signature detected,Violation Rating Threat detected,Bot Client Detected¢?HTTP protocol compliance failed:Host header contains IP addressª5²u{Cross Site Scripting Signatures;High Accuracy Signatures},{Cross Site Scripting Signatures;High Accuracy Signatures}º,ÂUntrusted BotÊN/AÒN/AÚcriticalâN/AêN/AòHTTP LibraryúN/A‚curlŠheader’6
 VIOL_ATTACK_SIGNATUREheader
 Fooecho<!-- #echo

--- a/test/component/nginx-app-protect/monitoring/testData/events-out/xml_parameter_data.log.txt.out
+++ b/test/component/nginx-app-protect/monitoring/testData/events-out/xml_parameter_data.log.txt.out
@@ -1,7 +1,7 @@
 
 j
-Agent$cc5dd738-6071-11ed-8415-5671f551701b4355056874564592515"Ûª°›€Ÿ¦Ü*ERROR2Nginx:
+Agent$65f12080-6135-11ed-8afe-5671f551701b4355056874564592515"„»µ›À¾ãÓ*ERROR2Nginx:
 AppProtect™
-app_protect_default_policy4355056874564592515REJECTED"SECURITY_WAF_VIOLATION*N/A2GET:HTTPBN/AJ/R^GET /?a=<script> HTTP/1.1\r\nHost: 127.0.0.1\r\nUser-Agent: curl/7.64.1\r\nAccept: */*\r\n\r\nbblockedjBlockedz1-localhost:1-/‚	127.0.0.1Š61478’80šŽHTTP protocol compliance failed,Illegal meta character in value,Attack signature detected,Violation Rating Threat detected,Bot Client Detected¢?HTTP protocol compliance failed:Host header contains IP addressª5²u{Cross Site Scripting Signatures;High Accuracy Signatures},{Cross Site Scripting Signatures;High Accuracy Signatures}º,ÂUntrusted BotÊN/AÒN/AÚCriticalâN/AêN/AòHTTP LibraryúN/A‚curlŠ	parameter’`
+app_protect_default_policy4355056874564592515REJECTED"SECURITY_WAF_VIOLATION*N/A2GET:HTTPBN/AJ/R^GET /?a=<script> HTTP/1.1\r\nHost: 127.0.0.1\r\nUser-Agent: curl/7.64.1\r\nAccept: */*\r\n\r\nbblockedjBlockedz1-localhost:1-/‚	127.0.0.1Š61478’80šŽHTTP protocol compliance failed,Illegal meta character in value,Attack signature detected,Violation Rating Threat detected,Bot Client Detected¢?HTTP protocol compliance failed:Host header contains IP addressª5²u{Cross Site Scripting Signatures;High Accuracy Signatures},{Cross Site Scripting Signatures;High Accuracy Signatures}º,ÂUntrusted BotÊN/AÒN/AÚcriticalâN/AêN/AòHTTP LibraryúN/A‚curlŠ	parameter’`
 VIOL_ATTACK_SIGNATURE	parameterf5paramautotest>"(
 	3000001107=f5paramautotest>"1*15

--- a/test/component/nginx-app-protect/monitoring/testData/events-out/xml_parameter_data_as_param_data.log.txt.out
+++ b/test/component/nginx-app-protect/monitoring/testData/events-out/xml_parameter_data_as_param_data.log.txt.out
@@ -1,7 +1,7 @@
 
 j
-Agent$cec1156c-6071-11ed-8415-5671f551701b4355056874564592516"ßª°›€º”ß*ERROR2Nginx:
+Agent$6854ee9c-6135-11ed-8afe-5671f551701b4355056874564592516"ˆ»µ›ÀëÅØ*ERROR2Nginx:
 AppProtectï
-app_protect_default_policy4355056874564592516REJECTED"SECURITY_WAF_VIOLATION*N/A2GET:HTTPBN/AJ/R^GET /?a=<script> HTTP/1.1\r\nHost: 127.0.0.1\r\nUser-Agent: curl/7.64.1\r\nAccept: */*\r\n\r\nbblockedjBlockedz1-localhost:1-/‚	127.0.0.1Š61478’80šŽHTTP protocol compliance failed,Illegal meta character in value,Attack signature detected,Violation Rating Threat detected,Bot Client Detected¢?HTTP protocol compliance failed:Host header contains IP addressª5²u{Cross Site Scripting Signatures;High Accuracy Signatures},{Cross Site Scripting Signatures;High Accuracy Signatures}º,ÂUntrusted BotÊN/AÒN/AÚCriticalâN/AêN/AòHTTP LibraryúN/A‚curlŠ	parameter’6
+app_protect_default_policy4355056874564592516REJECTED"SECURITY_WAF_VIOLATION*N/A2GET:HTTPBN/AJ/R^GET /?a=<script> HTTP/1.1\r\nHost: 127.0.0.1\r\nUser-Agent: curl/7.64.1\r\nAccept: */*\r\n\r\nbblockedjBlockedz1-localhost:1-/‚	127.0.0.1Š61478’80šŽHTTP protocol compliance failed,Illegal meta character in value,Attack signature detected,Violation Rating Threat detected,Bot Client Detected¢?HTTP protocol compliance failed:Host header contains IP addressª5²u{Cross Site Scripting Signatures;High Accuracy Signatures},{Cross Site Scripting Signatures;High Accuracy Signatures}º,ÂUntrusted BotÊN/AÒN/AÚcriticalâN/AêN/AòHTTP LibraryúN/A‚curlŠ	parameter’6
 VIOL_JSON_MALFORMED	parameter
 json{ "a": "ÖÖ"}

--- a/test/component/nginx-app-protect/monitoring/testData/events-out/xml_parameter_data_empty_context.log.txt.out
+++ b/test/component/nginx-app-protect/monitoring/testData/events-out/xml_parameter_data_empty_context.log.txt.out
@@ -1,8 +1,8 @@
 
 j
-Agent$cd8f6360-6071-11ed-8415-5671f551701b4355056874564592517"Ýª°›À¬ÝÝ*ERROR2Nginx:
+Agent$672307c0-6135-11ed-8afe-5671f551701b4355056874564592517"†»µ›€Õ”Ö*ERROR2Nginx:
 AppProtectà
-app_protect_default_policy4355056874564592517REJECTED"SECURITY_WAF_VIOLATION*N/A2GET:HTTPBN/AJ/R^GET /?a=<script> HTTP/1.1\r\nHost: 127.0.0.1\r\nUser-Agent: curl/7.64.1\r\nAccept: */*\r\n\r\nbblockedjBlockedz1-localhost:1-/‚	127.0.0.1Š61478’80šŽHTTP protocol compliance failed,Illegal meta character in value,Attack signature detected,Violation Rating Threat detected,Bot Client Detected¢?HTTP protocol compliance failed:Host header contains IP addressª5²u{Cross Site Scripting Signatures;High Accuracy Signatures},{Cross Site Scripting Signatures;High Accuracy Signatures}º,ÂUntrusted BotÊN/AÒN/AÚCriticalâN/AêN/AòHTTP LibraryúN/A‚curl’
+app_protect_default_policy4355056874564592517REJECTED"SECURITY_WAF_VIOLATION*N/A2GET:HTTPBN/AJ/R^GET /?a=<script> HTTP/1.1\r\nHost: 127.0.0.1\r\nUser-Agent: curl/7.64.1\r\nAccept: */*\r\n\r\nbblockedjBlockedz1-localhost:1-/‚	127.0.0.1Š61478’80šŽHTTP protocol compliance failed,Illegal meta character in value,Attack signature detected,Violation Rating Threat detected,Bot Client Detected¢?HTTP protocol compliance failed:Host header contains IP addressª5²u{Cross Site Scripting Signatures;High Accuracy Signatures},{Cross Site Scripting Signatures;High Accuracy Signatures}º,ÂUntrusted BotÊN/AÒN/AÚcriticalâN/AêN/AòHTTP LibraryúN/A‚curl’
 VIOL_PARAMETER
 x1’
 VIOL_PARAMETER

--- a/test/component/nginx-app-protect/monitoring/testData/events-out/xml_signature_data.log.txt.out
+++ b/test/component/nginx-app-protect/monitoring/testData/events-out/xml_signature_data.log.txt.out
@@ -1,8 +1,8 @@
 
 j
-Agent$d124a6ac-6071-11ed-8415-5671f551701b4355056874564592518"„™∞õÄﬁ¸‚*ERROR2Nginx:
+Agent$6ab883d8-6135-11ed-8afe-5671f551701b4355056874564592518"åªµõ¿èÆ‹*ERROR2Nginx:
 AppProtectÎ
-app_protect_default_policy4355056874564592518REJECTED"SECURITY_WAF_VIOLATION*N/A2GET:HTTPBN/AJ/R^GET /?a=<script> HTTP/1.1\r\nHost: 127.0.0.1\r\nUser-Agent: curl/7.64.1\r\nAccept: */*\r\n\r\nbblockedjBlockedz1-localhost:1-/Ç	127.0.0.1ä61478í80öéHTTP protocol compliance failed,Illegal meta character in value,Attack signature detected,Violation Rating Threat detected,Bot Client Detected¢?HTTP protocol compliance failed:Host header contains IP address™5≤u{Cross Site Scripting Signatures;High Accuracy Signatures},{Cross Site Scripting Signatures;High Accuracy Signatures}∫,¬Untrusted Bot N/A“N/A⁄Critical‚N/AÍN/AÚHTTP Library˙N/AÇcurlíΩ
+app_protect_default_policy4355056874564592518REJECTED"SECURITY_WAF_VIOLATION*N/A2GET:HTTPBN/AJ/R^GET /?a=<script> HTTP/1.1\r\nHost: 127.0.0.1\r\nUser-Agent: curl/7.64.1\r\nAccept: */*\r\n\r\nbblockedjBlockedz1-localhost:1-/Ç	127.0.0.1ä61478í80öéHTTP protocol compliance failed,Illegal meta character in value,Attack signature detected,Violation Rating Threat detected,Bot Client Detected¢?HTTP protocol compliance failed:Host header contains IP address™5≤u{Cross Site Scripting Signatures;High Accuracy Signatures},{Cross Site Scripting Signatures;High Accuracy Signatures}∫,¬Untrusted Bot N/A“N/A⁄critical‚N/AÍN/AÚHTTP Library˙N/AÇcurlíΩ
 VIOL_ATTACK_SIGNATURE"ô
 	2000210944ÄConnection: keep-alive
 Host: a.com

--- a/test/component/nginx-app-protect/monitoring/testData/events-out/xml_violation_name.log.txt.out
+++ b/test/component/nginx-app-protect/monitoring/testData/events-out/xml_violation_name.log.txt.out
@@ -1,8 +1,8 @@
 
 j
-Agent$cb2bd36a-6071-11ed-8415-5671f551701b4355056874564592519"Ùª°›ÀˆõÙ*ERROR2Nginx:
+Agent$64bf3aa8-6135-11ed-8afe-5671f551701b4355056874564592519"‚»µ›€¨²Ñ*ERROR2Nginx:
 AppProtectž
-app_protect_default_policy4355056874564592519REJECTED"SECURITY_WAF_VIOLATION*N/A2GET:HTTPBN/AJ/R^GET /?a=<script> HTTP/1.1\r\nHost: 127.0.0.1\r\nUser-Agent: curl/7.64.1\r\nAccept: */*\r\n\r\nbblockedjBlockedz1-localhost:1-/‚	127.0.0.1Š61478’80šŽHTTP protocol compliance failed,Illegal meta character in value,Attack signature detected,Violation Rating Threat detected,Bot Client Detected¢?HTTP protocol compliance failed:Host header contains IP addressª5²u{Cross Site Scripting Signatures;High Accuracy Signatures},{Cross Site Scripting Signatures;High Accuracy Signatures}º,ÂUntrusted BotÊN/AÒN/AÚCriticalâN/AêN/AòHTTP LibraryúN/A‚curl’
+app_protect_default_policy4355056874564592519REJECTED"SECURITY_WAF_VIOLATION*N/A2GET:HTTPBN/AJ/R^GET /?a=<script> HTTP/1.1\r\nHost: 127.0.0.1\r\nUser-Agent: curl/7.64.1\r\nAccept: */*\r\n\r\nbblockedjBlockedz1-localhost:1-/‚	127.0.0.1Š61478’80šŽHTTP protocol compliance failed,Illegal meta character in value,Attack signature detected,Violation Rating Threat detected,Bot Client Detected¢?HTTP protocol compliance failed:Host header contains IP addressª5²u{Cross Site Scripting Signatures;High Accuracy Signatures},{Cross Site Scripting Signatures;High Accuracy Signatures}º,ÂUntrusted BotÊN/AÒN/AÚcriticalâN/AêN/AòHTTP LibraryúN/A‚curl’
 VIOL_ASM_COOKIE_MODIFIED’
 VIOL_ASM_COOKIE_MODIFIED’
 VIOL_ASM_COOKIE_MODIFIED’


### PR DESCRIPTION
### Proposed changes

Due to the case-sensitive nature of the API filters, this will set the value of `severity` to be always lowercase. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
