### PR TITLE
Update swap.go to only log once on startup if swap metrics can't be collected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ local-deb-package: ## Create local deb package
 
 local-rpm-package: ## Create local rpm package
 	GOWORK=off CGO_ENABLED=0 GOARCH=${LOCAL_ARCH} GOOS=linux go build -ldflags=${DEBUG_LDFLAGS} -o ./build/nginx-agent
-	VERSION=$(shell echo ${VERSION} | tr -d 'v') nfpm pkg --config ./scripts/.local-nfpm.yaml --packager rpm --target ./build/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v')-SNAPSHOT.rpm;
+	VERSION=$(shell echo ${VERSION} | tr -d 'v') nfpm pkg --config ./scripts/.local-nfpm.yaml --packager rpm --target ./build/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v')-SNAPSHOT-${COMMIT}.rpm;
 
 local-txz-package: ## Create local txz package
 	GOWORK=off CGO_ENABLED=0 GOARCH=${LOCAL_ARCH} GOOS=freebsd go build -ldflags=${DEBUG_LDFLAGS} -o ./build/nginx-agent

--- a/scripts/packages/packager/local-entrypoint.sh
+++ b/scripts/packages/packager/local-entrypoint.sh
@@ -19,7 +19,7 @@ cp build/nginx-agent /staging/usr/local/bin
 
 chmod +x /staging/usr/local/etc/rc.d/nginx-agent
 
-VERSION="$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')-SNAPSHOT" envsubst < scripts/packages/manifest > /staging/+MANIFEST
+VERSION="$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')-SNAPSHOT-$(git rev-parse --short HEAD)" envsubst < scripts/packages/manifest > /staging/+MANIFEST
 
 pkg -o ABI="FreeBSD:13:amd64" create --format txz  \
     -m /staging \
@@ -31,7 +31,7 @@ pkg -o ABI="FreeBSD:13:amd64" create --format txz  \
 # but since version 1.17.0 pkg will now always create a file with the extesion pkg no matter what the format is. 
 # See 1.17.0 release notes for more info: https://cgit.freebsd.org/ports/commit/?id=e497a16a286972bfcab908209b11ee6a13d99dc9
 cd build/
-ln -s nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT.pkg nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT.txz 
+ln -s nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT-"$(git rev-parse --short HEAD)".pkg nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT-"$(git rev-parse --short HEAD)".txz 
 cd ..
 
 rm -rf /staging

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/extensions/nginx-app-protect/monitoring/processor/nap.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/extensions/nginx-app-protect/monitoring/processor/nap.go
@@ -460,7 +460,7 @@ func setValue(napConfig *NAPConfig, key, value string, logger *logrus.Entry) err
 	case requestStatus:
 		napConfig.RequestStatus = value
 	case severity:
-		napConfig.Severity = value
+		napConfig.Severity = strings.ToLower(value)
 	case sigSetNames:
 		napConfig.SigSetNames = replaceEncodedList(value, listSeperator)
 	case threatCampaignNames:


### PR DESCRIPTION
### Proposed changes

Updated swap.go to only log once on startup if swap metrics can't be collected.
Also updated the Makefile to correctly add the commit id to all local package names.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
