### PR TITLE
Removing reference to mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,6 @@ Minimum system sizing recommendations for Agent:
 
 - Our [GitHub issues page](https://github.com/nginx/agent/issues) offers space for a more technical discussion at your own pace.
 
-- Subscribe to the Agent [mailing list](https://mailman.nginx.org/mailman/listinfo/agent) for release notifications.
 
 # Contributing
 Get involved with the project by contributing! Please see our [contributing guide](docs/CONTRIBUTING.md) for details.


### PR DESCRIPTION
Need to remove the reference to the email list from the README to avoid confusion

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
