### PR TITLE
fix: change agent-config back to previous values

### DIFF
--- a/nginx-agent.conf
+++ b/nginx-agent.conf
@@ -11,7 +11,7 @@
 server:
   # host of the control plane
   host: 127.0.0.1
-  grpcPort: 54789
+  grpcPort: 443
   # provide servername overrides if using SNI
   # metrics: ""
   # command: ""
@@ -19,7 +19,7 @@ server:
 tls:
   # enable tls in the nginx-agent setup for grpcs
   # default to enable to connect with tls connection but without client cert for mtls
-  enable: false
+  enable: true
   # specify the absolute path to the CA certificate file to use for verifying
   # the server certificate (also requires 'skip_verify: false' below)
   # by default, this will be the trusted root CAs found in the OS CA store


### PR DESCRIPTION
### Proposed changes

- unset the conf changes from https://github.com/nginx/agent/pull/127, which is currently breaking automation, change looks accidental as there were no mention of it in the PR description


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [0] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
