### PR TITLE
Fix docs url to link to GitHub

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -63,8 +63,7 @@ jobs:
             console.log(`The next version is v${version}`)
             const footer = `
               ## Resources
-              - Documentation -- https://docs.nginx.com/nginx-instance-manager/nginx-agent/
-              - Upgrade Steps -- https://docs.nginx.com/nginx-instance-manager/installation/upgrade-guide/#upgrade-nginx-agent
+              - Documentation -- https://github.com/nginx/agent#readme
             `
             const release_notes = (await github.rest.repos.generateReleaseNotes({
               owner: context.payload.repository.owner.login,

--- a/scripts/packages/nginx-agent.service
+++ b/scripts/packages/nginx-agent.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=NGINX Agent
-Documentation=https://www.nginx.com/products/nginx-agent/
+Documentation=https://github.com/nginx/agent#readme
 After=network.target
 Wants=network-online.target
 StartLimitIntervalSec=15


### PR DESCRIPTION
### Proposed changes

* Fix agent package to link to GitHub docs instead of docs website.
* Fix release draft to link to same

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
