### PR TITLE
Fix arch of apk packages

### DIFF
--- a/Makefile.packaging
+++ b/Makefile.packaging
@@ -55,7 +55,7 @@ package: gpg-key $(PACKAGES_DIR) ## Create final packages for all supported dist
 	
 	@for arch in $(APK_ARCHS); do \
 		goarch=amd64; \
-		if [ $${arch} == aarch64 ]; then goarch=arm64; fi; \
+		if [ "$$arch" = "aarch64" ]; then goarch="arm64"; fi; \
 		GOWORK=off CGO_ENABLED=0 GOARCH=$${goarch} GOOS=linux go build -ldflags=${LDFLAGS} -o ./build/nginx-agent; \
 		for version in $(APK_VERSIONS); do \
 			if [ ! -d "$(PACKAGES_DIR)/apk/v$${version}/$${arch}" ]; then mkdir -p $(PACKAGES_DIR)/apk/v$${version}/$${arch}; fi; \


### PR DESCRIPTION
### Proposed changes

Fix architecture of arm apk packages

### Bug

First noticed in pipeline runs:

#### Before
```
# Create apk packages
/bin/sh: 3: [: aarch64: unexpected operator
using apk packager...
created package: ./build/packages/apk/v3.13/aarch64/nginx-agent-2.19.0.apk
using apk packager...
created package: ./build/packages/apk/v3.14/aarch64/nginx-agent-2.19.0.apk
using apk packager...
created package: ./build/packages/apk/v3.15/aarch64/nginx-agent-2.19.0.apk
using apk packager...
created package: ./build/packages/apk/v3.16/aarch64/nginx-agent-2.19.0.apk
/bin/sh: 3: [: x86_64: unexpected operator
using apk packager...
created package: ./build/packages/apk/v3.13/x86_64/nginx-agent-2.19.0.apk
using apk packager...
created package: ./build/packages/apk/v3.14/x86_64/nginx-agent-2.19.0.apk
using apk packager...
created package: ./build/packages/apk/v3.15/x86_64/nginx-agent-2.19.0.apk
using apk packager...
created package: ./build/packages/apk/v3.16/x86_64/nginx-agent-2.19.0.apk
```

#### After
Ref: https://github.com/nginx/agent/actions/runs/3650619616/jobs/6166828489#step:7:64
```
# Create apk packages
using apk packager...
created package: ./build/packages/apk/v3.13/aarch64/nginx-agent-2.19.0.apk
using apk packager...
created package: ./build/packages/apk/v3.14/aarch64/nginx-agent-2.19.0.apk
using apk packager...
created package: ./build/packages/apk/v3.15/aarch64/nginx-agent-2.19.0.apk
using apk packager...
created package: ./build/packages/apk/v3.16/aarch64/nginx-agent-2.19.0.apk
using apk packager...
created package: ./build/packages/apk/v3.13/x86_64/nginx-agent-2.19.0.apk
using apk packager...
created package: ./build/packages/apk/v3.14/x86_64/nginx-agent-2.19.0.apk
using apk packager...
created package: ./build/packages/apk/v3.15/x86_64/nginx-agent-2.19.0.apk
using apk packager...
created package: ./build/packages/apk/v3.16/x86_64/nginx-agent-2.19.0.apk
```

Failing if condition resulted in `amd64` binaries placed in `arm` package

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
