### PR TITLE
fix: check if app_protect_metadata's nap version is empty first.

### DIFF
--- a/src/plugins/nginx.go
+++ b/src/plugins/nginx.go
@@ -326,7 +326,7 @@ func (n *Nginx) applyConfig(cmd *proto.Command, cfg *proto.Command_NginxConfig) 
 							status.NginxConfigResponse.Status = newErrStatus(fmt.Sprintf("Config apply failed (preflight): not able to read WAF file in metadata %v", config.GetConfigData())).CmdStatus
 							return status
 						}
-						if n.wafVersion != napMetaData.NapVersion {
+						if napMetaData.NapVersion != "" && n.wafVersion != napMetaData.NapVersion {
 							status.NginxConfigResponse.Status = newErrStatus(fmt.Sprintf("Config apply failed (preflight): config metadata mismatch %v", config.GetConfigData())).CmdStatus
 							return status
 						}


### PR DESCRIPTION
There is a case where the DPM sends an empty app_protect_metadata to erase the old meta when the user no longer uses NAP.

### Proposed changes

Check if app_protect_metadata's nap version is empty first before we compare the installed NAP version and the metadata NAP version and throw error.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
