### PR TITLE
fix: detect nginx upgrade

### DIFF
--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -162,7 +162,7 @@ func (n *NginxBinaryType) sanitizeProcessPath(nginxProcess *Process) bool {
 		defaulted = true
 	}
 	if strings.Contains(nginxProcess.Path, execDeleted) {
-		log.Infof("nginx was upgraded (process), using new info")
+		log.Debugf("nginx was upgraded (process), using new info")
 		nginxProcess.Path = sanitizeExecDeletedPath(nginxProcess.Path)
 	}
 	return defaulted

--- a/src/core/nginx_test.go
+++ b/src/core/nginx_test.go
@@ -744,3 +744,30 @@ func buildConfig(rootDirectory string) (*proto.NginxConfig, error) {
 
 	return nginxConfig, nil
 }
+
+// TestNginxBinaryType_sanitizeProcessPath validate correct parsing of the nginx path when nginx binary has been updated.
+func TestNginxBinaryType_sanitizeProcessPath(t *testing.T) {
+	type testDef struct {
+		desc      string
+		path      string
+		expect    string
+		defaulted bool
+	}
+
+	// no test case for process lookup, that would require running nginx or proc some where
+	for _, def := range []testDef{
+		{desc: "deleted path", path: "/usr/sbin/nginx (deleted)", expect: "/usr/sbin/nginx"},
+		{desc: "no change path", path: "/usr/sbin/nginx", expect: "/usr/sbin/nginx"},
+	} {
+		t.Run(def.desc, func(tt *testing.T) {
+			p := Process{
+				Path: def.path,
+			}
+			binary := NginxBinaryType{
+				env: &EnvironmentType{},
+			}
+			assert.Equal(tt, def.defaulted, binary.sanitizeProcessPath(&p))
+			assert.Equal(tt, def.expect, p.Path)
+		})
+	}
+}

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/nginx.go
@@ -326,7 +326,7 @@ func (n *Nginx) applyConfig(cmd *proto.Command, cfg *proto.Command_NginxConfig) 
 							status.NginxConfigResponse.Status = newErrStatus(fmt.Sprintf("Config apply failed (preflight): not able to read WAF file in metadata %v", config.GetConfigData())).CmdStatus
 							return status
 						}
-						if n.wafVersion != napMetaData.NapVersion {
+						if napMetaData.NapVersion != "" && n.wafVersion != napMetaData.NapVersion {
 							status.NginxConfigResponse.Status = newErrStatus(fmt.Sprintf("Config apply failed (preflight): config metadata mismatch %v", config.GetConfigData())).CmdStatus
 							return status
 						}


### PR DESCRIPTION
### Proposed changes

In proc, if the process symlink path has `(deleted)`, it's an indication that the process was deleted. Since we already have binary change detection, this change deletes the "deleted" in the exec path, and trim out the "deleted" so the exec path is valid for the original binary, which could have an updated binary.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
