### PR TITLE
WIP: Remove the default gRPC configuration for the nginx-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ sudo touch /etc/nginx-agent/agent-dynamic.conf
 ```
 
 ### Enabling the gRPC interface
-Update the `/etc/nginx-agent/nginx-agent.conf` file to include the following settings:
+Add the the following settings to `/etc/nginx-agent/nginx-agent.conf`:
 
 ```yaml
 server:
@@ -169,7 +169,7 @@ tls:
 ```
 
 ### Enabling the REST interface
-The NGINX Agent REST interface can be exposed by adding the following lines to the `nginx-agent.conf` file.
+The NGINX Agent REST interface can be exposed by validating the following lines in the `/etc/nginx-agent/nginx-agent.conf` file are present:
 
 ```yaml
 api:

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -48,7 +48,7 @@ sudo touch /etc/nginx-agent/agent-dynamic.conf
 
 ### Enabling the gRPC interface
 
-Update the `/etc/nginx-agent/nginx-agent.conf` file to include the following settings:
+Add the the following settings to `/etc/nginx-agent/nginx-agent.conf`:
 
 ```nginx
 server:
@@ -63,7 +63,7 @@ tls:
 
 ### Enabling the REST interface
 
-The NGINX Agent REST interface can be exposed by adding the following lines to the `nginx-agent.conf` file.
+The NGINX Agent REST interface can be exposed by validating the following lines in the `/etc/nginx-agent/nginx-agent.conf` file are present:
 
 ```nginx
 api:

--- a/nginx-agent.conf
+++ b/nginx-agent.conf
@@ -7,14 +7,6 @@
 # are additional agent configuration values that are set via the API and agent install script
 # which can be found in /etc/nginx-agent/agent-dynamic.conf. 
 
-# specify the server grpc port to connect to
-server:
-  # host of the control plane
-  host: 127.0.0.1
-  grpcPort: 54789
-  # provide servername overrides if using SNI
-  # metrics: ""
-  # command: ""
 # tls options
 tls:
   # enable tls in the nginx-agent setup for grpcs

--- a/nginx-agent.conf
+++ b/nginx-agent.conf
@@ -7,22 +7,6 @@
 # are additional agent configuration values that are set via the API and agent install script
 # which can be found in /etc/nginx-agent/agent-dynamic.conf. 
 
-# tls options
-tls:
-  # enable tls in the nginx-agent setup for grpcs
-  # default to enable to connect with tls connection but without client cert for mtls
-  enable: false
-  # specify the absolute path to the CA certificate file to use for verifying
-  # the server certificate (also requires 'skip_verify: false' below)
-  # by default, this will be the trusted root CAs found in the OS CA store
-  # ca: /etc/nginx-agent/ca.pem
-  # specify the absolute path to the client cert, when mtls is enabled
-  # cert: /etc/nginx-agent/client.crt
-  # specify the absolute path to the client cert key, when mtls is enabled
-  # key: /etc/nginx-agent/client.key
-  # controls whether the server certificate chain and host name are verified.
-  # for production use, see instructions for configuring TLS
-  skip_verify: true
 log:
   # set log level (panic, fatal, error, info, debug, trace; default "info")
   level: info


### PR DESCRIPTION
### Proposed changes
Remove the default gRPC configuration. This uses REST by default

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
