### PR TITLE
Update FreeBSD rc.d script

### DIFF
--- a/scripts/packages/nginx-agent
+++ b/scripts/packages/nginx-agent
@@ -12,30 +12,12 @@
 
 name=nginx_agent
 rcvar=${name}_enable
-command="/usr/local/bin/nginx-agent"
+nginx_agent_command="/usr/local/bin/nginx-agent"
 pidfile="/var/run/${name}.pid"
-
-start_cmd="start_agent"
-stop_cmd="stop_agent"
-status_cmd="status_agent"
-
-start_agent() {
-    PATH=$PATH:/usr/local/sbin
-    /usr/sbin/daemon -f -p ${pidfile} ${command} 
-}
-
-stop_agent() {
-    /bin/kill -2 "$(cat $pidfile)"
-}
-
-status_agent() {
-    if [ -e $pidfile ]; then
-        echo $name is running on PID "$(cat $pidfile)"
-    else 
-        echo $name is not running
-        return 1
-    fi
-}
+command="/usr/sbin/daemon"
+command_args="-P ${pidfile} -r -f ${nginx_agent_command}"
 
 load_rc_config $name
+: ${nginx_agent_enable:="NO"}
+
 run_rc_command "$1"


### PR DESCRIPTION
### Proposed changes

Updates the FreeBSD rc.d script to use the standard FreeBSD rc.subr template. This reduces the complexity of the file and fixes some errors that occurs when running `service nginx-agent restart`
```
freebsd@testenv-3dd5fc2a-data-1:~ $ sudo service nginx-agent restart
nginx_agent already running?  (pid=3902).
freebsd@testenv-3dd5fc2a-data-1:~ $ sudo service nginx-agent restart
cat: /var/run/nginx_agent.pid: No such file or directory
kill: illegal process id: 
freebsd@testenv-3dd5fc2a-data-1:~ $ echo $?
1
```
Updated script
```
freebsd@testenv-3dd5fc2a-data-1:~ $ sudo service nginx-agent restart
Stopping nginx_agent.
Waiting for PIDS: 4081, 4081.
Starting nginx_agent.
freebsd@testenv-3dd5fc2a-data-1:~ $ echo $?
0
```


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
