### PR TITLE
feat: podman support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ certs: ## Generate TLS certificates
 image: ## Build agent container image for NGINX Plus, need nginx-repo.crt and nginx-repo.key in build directory
 	@echo Building image with $(CONTAINER_CLITOOL); \
 	$(CONTAINER_BUILDENV) $(CONTAINER_CLITOOL) build -t ${IMAGE_TAG} . \
-		--no-cache -f ./scripts/docker/${OS_RELEASE}/Dockerfile \
+		--no-cache -f ./scripts/docker/nginx-plus/${OS_RELEASE}/Dockerfile \
 		--secret id=nginx-crt,src=build/nginx-repo.crt \
 		--secret id=nginx-key,src=build/nginx-repo.key \
 		--build-arg AGENT_CONF="$$(cat nginx-agent.conf)" \

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,8 @@ help: ## Show help message
 
 show-var-%:
 	@{ \
-		if [ -n "$($*)" ]; then v="$($*)"; else v="(undefined)"; fi; \
+		escaped_v="$(subst ",\",$($*))" ; \
+		if [ -n "$$escaped_v" ]; then v="$$escaped_v"; else v="(undefined)"; fi; \
 		printf "%-20s %s\n" "$*" "$$v"; \
 	}
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ DATE = $(shell date +%F_%H-%M-%S)
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 OS_RELEASE:=ubuntu
 OS_VERSION:=22.04
-DOCKER_IMAGE="${OS_RELEASE}:${OS_VERSION}"
+DOCKER_IMAGE="docker.io/${OS_RELEASE}:${OS_VERSION}"
 DOCKER_TAG=agent_${OS_RELEASE}_${OS_VERSION}
 
 LDFLAGS = "-w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}"
@@ -32,7 +32,8 @@ DEBUG_LDFLAGS = "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.dat
 CERTS_DIR          := ./build/certs
 PACKAGE_PREFIX	   := nginx-agent
 PACKAGES_REPO	   := "pkgs.nginx.com"
-UNAME_M	            = $(shell uname -m)
+OS                 := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+OSARCH             := $(shell uname -m)
 TEST_BUILD_DIR	   := build/test
 PACKAGE_NAME	   := ${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v')-SNAPSHOT-${COMMIT}
 # override this value if you want to change the architecture. GOOS options here: https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63
@@ -47,12 +48,22 @@ CERT_SERVER_INT_CN := server-int.local
 CERT_SERVER_EE_CN  := server-ee.local
 CERT_SERVER_DNS    := tls.example.com
 
+include Makefile.containers
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Developer Targets                                                                                               #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 help: ## Show help message
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\033[36m\033[0m\n"} /^[$$()% 0-9a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+show-var-%:
+	@{ \
+		if [ -n "$($*)" ]; then v="$($*)"; else v="(undefined)"; fi; \
+		printf "%-20s %s\n" "$*" "$$v"; \
+	}
+
+SHOW_ENV_VARS = VERSION COMMIT DATE OS OSARCH $(CONTAINER_VARS)
+show-env: $(addprefix show-var-, $(SHOW_ENV_VARS)) ## Show environment
 
 all: clean build run ## Compile and run code.
 
@@ -113,18 +124,18 @@ local-rpm-package: ## Create local rpm package
 
 local-txz-package: ## Create local txz package
 	GOWORK=off CGO_ENABLED=0 GOARCH=${LOCAL_ARCH} GOOS=freebsd go build -ldflags=${DEBUG_LDFLAGS} -o ./build/nginx-agent
-	docker run -v ${PWD}:/nginx-agent/ build-local-packager:1.0.0
+	$(CONTAINER_CLITOOL) run -v ${PWD}:/nginx-agent/$(CONTAINER_VOLUME_FLAGS) build-local-packager:1.0.0
 
 build-txz-packager-docker: ## Builds txz packager docker image
 	@echo Building Local Packager; \
-	DOCKER_BUILDKIT=1 docker build -t build-local-packager:1.0.0 --build-arg package_type=local-package . --no-cache -f ./scripts/packages/packager/Dockerfile
+	$(CONTAINER_BUILDENV) $(CONTAINER_CLITOOL) build -t build-local-packager:1.0.0 --build-arg package_type=local-package . --no-cache -f ./scripts/packages/packager/Dockerfile
 
 include Makefile.packaging
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Testing                                                                                                         #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-generate-mocks: # Regenerate all needed mocks, in order to add new mocks generation add //go:generate mockgen to file from witch mocks should be generated
+generate-mocks: ## Regenerate all needed mocks, in order to add new mocks generation add //go:generate mockgen to file from witch mocks should be generated
 	GOWORK=off go generate ./...
 
 test: unit-test performance-test component-test ## Run all tests
@@ -158,14 +169,14 @@ test-component-build: ## Compile component tests
 	GOWORK=off CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test ./test/component -c -o component.test
 
 test-docker-component: ## Run integration tests in docker
-	for container in ${docker ps -aqf "name=^nginx-agent_"}; do echo && docker ps -f "id=$$container" --format "{{.Image}}" && docker exec $$container ./tmp/component.test -test.v; done
+	for container in ${$(CONTAINER_CLITOOL) ps -aqf "name=^nginx-agent_"}; do echo && $(CONTAINER_CLITOOL) ps -f "id=$$container" --format "{{.Image}}" && $(CONTAINER_CLITOOL) exec $$container ./tmp/component.test -test.v; done
 
 test-component-run: ## Run component tests
 	GOWORK=off CGO_ENABLED=0 go test -v ./test/component/...
 
 # Performance tests
 performance-test: ## Run performance tests
-	docker run -v ${PWD}:/home/nginx/ --rm nginx-agent-benchmark:1.0.0
+	$(CONTAINER_CLITOOL) run -v ${PWD}:/home/nginx/$(CONTAINER_VOLUME_FLAGS) --rm nginx-agent-benchmark:1.0.0
 
 integration-test: local-deb-package
 	PACKAGE=${PACKAGE_NAME} DOCKER_IMAGE=${DOCKER_IMAGE} go test ./test/integration/api 
@@ -176,7 +187,7 @@ test-bench: ## Run benchmark tests
 	cd test/performance && GOWORK=off CGO_ENABLED=0 go test -mod=vendor -count 5 -timeout 2m -bench=. -benchmem plugins_test.go
 
 build-benchmark-docker: ## Build benchmark test docker image for NGINX Plus, need nginx-repo.crt and nginx-repo.key in build directory
-	DOCKER_BUILDKIT=1 docker build --no-cache -t nginx-agent-benchmark:1.0.0 \
+	$(CONTAINER_BUILDENV) $(CONTAINER_CLITOOL) build --no-cache -t nginx-agent-benchmark:1.0.0 \
 		--secret id=nginx-crt,src=build/nginx-repo.crt \
 		--secret id=nginx-key,src=build/nginx-repo.key \
 		-f test/docker/Dockerfile .
@@ -218,9 +229,9 @@ certs: ## Generate TLS certificates
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Docker Helper Targets                                                                                           #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-build-docker: # Build agent docker image for NGINX Plus, need nginx-repo.crt and nginx-repo.key in build directory
+build-docker: ## Build agent docker image for NGINX Plus, need nginx-repo.crt and nginx-repo.key in build directory
 	@echo Building Docker; \
-	DOCKER_BUILDKIT=1 docker build -t ${DOCKER_TAG} . \
+	$(CONTAINER_BUILDENV) $(CONTAINER_CLITOOL) build -t ${DOCKER_TAG} . \
 		--no-cache -f ./scripts/docker/nginx-plus/${OS_RELEASE}/Dockerfile \
 		--secret id=nginx-crt,src=build/nginx-repo.crt \
 		--secret id=nginx-key,src=build/nginx-repo.key \
@@ -232,7 +243,7 @@ build-docker: # Build agent docker image for NGINX Plus, need nginx-repo.crt and
 
 run-docker: ## Run docker container from specified DOCKER_TAG
 	@echo Running Docker; \
-		docker run ${DOCKER_TAG}
+		$(CONTAINER_CLITOOL) run ${DOCKER_TAG}
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Dashboard Targets                                                                                               #

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ performance-test: ## Run performance tests
 	$(CONTAINER_CLITOOL) run -v ${PWD}:/home/nginx/$(CONTAINER_VOLUME_FLAGS) --rm nginx-agent-benchmark:1.0.0
 
 integration-test: local-deb-package
-	PACKAGE=${PACKAGE_NAME} DOCKER_IMAGE=${DOCKER_IMAGE} go test ./test/integration/api 
+	PACKAGE=${PACKAGE_NAME} BASE_IMAGE=${BASE_IMAGE} go test ./test/integration/api
 
 test-bench: ## Run benchmark tests
 	cd test/performance && GOWORK=off CGO_ENABLED=0 go test -mod=vendor -count 5 -timeout 2m -bench=. -benchmem metrics_test.go

--- a/Makefile.containers
+++ b/Makefile.containers
@@ -1,0 +1,35 @@
+#!/usr/bin/make -f
+
+ifndef CONTAINER_CLITOOL
+ifeq ($(shell docker -v >/dev/null 2>&1 || echo FAIL),)
+CONTAINER_CLITOOL = docker
+else ifeq ($(shell podman -v >/dev/null 2>&1 || echo FAIL),)
+CONTAINER_CLITOOL = podman
+endif
+endif
+
+ifeq ($(CONTAINER_CLITOOL), docker)
+CONTAINER_BUILDENV ?= DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain
+ifeq ($(shell docker-compose -v >/dev/null 2>&1 || echo FAIL),)
+CONTAINER_COMPOSE = docker-compose
+endif
+else ifeq ($(CONTAINER_CLITOOL), podman)
+ifeq ($(shell podman-compose -v >/dev/null 2>&1 || echo FAIL),)
+CONTAINER_COMPOSE = podman-compose --podman-rm-args=--depend
+endif
+else ifdef CONTAINER_CLITOOL
+CONTAINER_COMPOSE = $(error Invalid CONTAINER_CLITOOL: $(CONTAINER_CLITOOL) (supported values: docker, podman))
+endif
+
+ifdef CONTAINER_COMPOSE
+CONTAINER_COMPOSETOOL = $(CONTAINER_COMPOSE)
+ifeq ($(OS), linux)
+CONTAINER_VOLUME_FLAGS = :z
+else
+CONTAINER_VOLUME_FLAGS =
+endif
+else
+CONTAINER_COMPOSETOOL = $(error Neither docker-compose nor podman-compose found)
+endif
+
+CONTAINER_VARS = CONTAINER_CLITOOL CONTAINER_COMPOSE CONTAINER_BUILDENV

--- a/Makefile.packaging
+++ b/Makefile.packaging
@@ -52,8 +52,8 @@ package: gpg-key $(PACKAGES_DIR) $(GITHUB_PACKAGES_DIR) ## Create final packages
 		elif [ "$$rpm_distro" = "amazon" ] && [ "$$rpm_major" = "2" ]; then rpm_codename="amzn$$rpm_major"; fi; \
 		if [ "$$rpm_distro" = "suse" ]; then rpm_codename="sles$$rpm_major"; fi; \
 		if [ "$$rpm_codename" != "na" ]; then \
-			VERSION=$(shell echo ${VERSION} | tr -d 'v') ARCH=amd64 nfpm pkg --config .nfpm.yaml --packager rpm --target $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.${UNAME_M}.rpm; \
-            cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.${UNAME_M}.rpm ${GITHUB_PACKAGES_DIR}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.${UNAME_M}.rpm; \
+			VERSION=$(shell echo ${VERSION} | tr -d 'v') ARCH=amd64 nfpm pkg --config .nfpm.yaml --packager rpm --target $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$(OSARCH).rpm; \
+			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$(OSARCH).rpm ${GITHUB_PACKAGES_DIR}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$(OSARCH).rpm; \
 		fi; \
 	done; \
 	rm -rf ./build/nginx-agent

--- a/scripts/docker/nginx-oss/ubuntu/Dockerfile
+++ b/scripts/docker/nginx-oss/ubuntu/Dockerfile
@@ -1,5 +1,5 @@
-ARG DOCKER_IMAGE
-FROM ${DOCKER_IMAGE} as install
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as install
 LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
 
 ARG PACKAGE

--- a/scripts/docker/nginx-plus/alpine/Dockerfile
+++ b/scripts/docker/nginx-plus/alpine/Dockerfile
@@ -1,5 +1,5 @@
-ARG DOCKER_IMAGE
-FROM ${DOCKER_IMAGE} as install
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as install
 LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
 
 ARG PACKAGES_REPO

--- a/scripts/docker/nginx-plus/amazonlinux/Dockerfile
+++ b/scripts/docker/nginx-plus/amazonlinux/Dockerfile
@@ -1,8 +1,8 @@
-ARG DOCKER_IMAGE
-FROM ${DOCKER_IMAGE} as install
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as install
 LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
 
-ARG DOCKER_IMAGE
+ARG BASE_IMAGE
 ARG PACKAGES_REPO
 # note if OS_VERSION is 1, there will be an issues in the yum.repos.d folder
 ARG OS_VERSION
@@ -32,7 +32,7 @@ sslclientkey=/etc/ssl/nginx/nginx-repo.key \n\
 gpgcheck=1 \n\
 enabled=1 \n\
 sslverify=true \n\
-gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-plus-$DOCKER_IMAGE.repo \
+gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-plus-$BASE_IMAGE.repo \
     && printf "[nginx-agent] \n\
 name=nginx-agent repo \n\
 baseurl=https://$PACKAGES_REPO/nginx-agent/amzn$OS_VERSION/\$releasever/\$basearch \n\
@@ -41,7 +41,7 @@ sslclientkey=/etc/ssl/nginx/nginx-repo.key \n\
 gpgcheck=1 \n\
 enabled=1 \n\
 sslverify=true \n\
-gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-agent-$DOCKER_IMAGE.repo \
+gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-agent-$BASE_IMAGE.repo \
     && yum install -y $nginxPackages \
     && yum clean all \
     && rm -rf /var/cache/yum /etc/yum.repos.d/* /etc/ssl/nginx

--- a/scripts/docker/nginx-plus/amazonlinux/Dockerfile
+++ b/scripts/docker/nginx-plus/amazonlinux/Dockerfile
@@ -11,12 +11,12 @@ WORKDIR /agent
 COPY ./scripts/docker/nginx-plus/entrypoint.sh /agent/entrypoint.sh
 COPY ./nginx-agent.conf /agent/nginx-agent.conf
 
-RUN --mount=type=secret,id=nginx-crt,dst=nginx-repo.crt \
-    --mount=type=secret,id=nginx-key,dst=nginx-repo.key \
+RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt \
+    --mount=type=secret,id=nginx-key,dst=/nginx-repo.key \
     set -x \
     && mkdir -p /etc/ssl/nginx \
-    && cat nginx-repo.crt > /etc/ssl/nginx/nginx-repo.crt \
-    && cat nginx-repo.key > /etc/ssl/nginx/nginx-repo.key \
+    && cat /nginx-repo.crt > /etc/ssl/nginx/nginx-repo.crt \
+    && cat /nginx-repo.key > /etc/ssl/nginx/nginx-repo.key \
     && yum install -y --setopt=tsflags=nodocs wget ca-certificates bind-utils wget bind-utils vim-minimal shadow-utils \
     && groupadd --system --gid 101 nginx \
     && adduser -g nginx --system --no-create-home --home /nonexistent --shell /bin/false --uid 101 nginx \

--- a/scripts/docker/nginx-plus/centos/Dockerfile
+++ b/scripts/docker/nginx-plus/centos/Dockerfile
@@ -1,8 +1,8 @@
-ARG DOCKER_IMAGE
-FROM ${DOCKER_IMAGE} as install
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as install
 LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
 
-ARG DOCKER_IMAGE
+ARG BASE_IMAGE
 ARG PACKAGES_REPO
 ARG OS_RELEASE
 ARG OS_VERSION
@@ -30,7 +30,7 @@ sslclientkey=/etc/ssl/nginx/nginx-repo.key \n\
 gpgcheck=1 \n\
 enabled=1 \n\
 sslverify=true \n\
-gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-plus-$DOCKER_IMAGE.repo \
+gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-plus-$BASE_IMAGE.repo \
     && printf "[nginx-agent] \n\
 name=nginx-agent repo \n\
 baseurl=https://$PACKAGES_REPO/nginx-agent/$OS_RELEASE/$OS_VERSION/\$basearch \n\
@@ -39,7 +39,7 @@ sslclientkey=/etc/ssl/nginx/nginx-repo.key \n\
 gpgcheck=1 \n\
 enabled=1 \n\
 sslverify=true \n\
-gpgkey=https://nginx.org/keys/nginx_signing.key">> /etc/yum.repos.d/nginx-agent-$DOCKER_IMAGE.repo \
+gpgkey=https://nginx.org/keys/nginx_signing.key">> /etc/yum.repos.d/nginx-agent-$BASE_IMAGE.repo \
     && nginxPackages=" \
         nginx-agent \
         nginx-plus \

--- a/scripts/docker/nginx-plus/centos/Dockerfile
+++ b/scripts/docker/nginx-plus/centos/Dockerfile
@@ -11,12 +11,12 @@ WORKDIR /agent
 COPY ./scripts/docker/nginx-plus/entrypoint.sh /agent/entrypoint.sh
 COPY ./nginx-agent.conf /agent/nginx-agent.conf
 
-RUN --mount=type=secret,id=nginx-crt,dst=nginx-repo.crt \
-    --mount=type=secret,id=nginx-key,dst=nginx-repo.key \
+RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt \
+    --mount=type=secret,id=nginx-key,dst=/nginx-repo.key \
     set -x \
     && mkdir -p /etc/ssl/nginx \
-    && cat nginx-repo.crt > /etc/ssl/nginx/nginx-repo.crt \
-    && cat nginx-repo.key > /etc/ssl/nginx/nginx-repo.key \
+    && cat /nginx-repo.crt > /etc/ssl/nginx/nginx-repo.crt \
+    && cat /nginx-repo.key > /etc/ssl/nginx/nginx-repo.key \
     && yum install -y --setopt=tsflags=nodocs wget ca-certificates bind-utils wget bind-utils vim-minimal shadow-utils procps \
     && groupadd --system --gid 101 nginx \
     && adduser -g nginx --system --no-create-home --home /nonexistent --shell /bin/false --uid 101 nginx \

--- a/scripts/docker/nginx-plus/debian/Dockerfile
+++ b/scripts/docker/nginx-plus/debian/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /agent
 COPY ./scripts/docker/nginx-plus/entrypoint.sh /agent/entrypoint.sh
 COPY ./nginx-agent.conf /agent/nginx-agent.conf
 
-RUN --mount=type=secret,id=nginx-crt,dst=nginx-repo.crt \
-    --mount=type=secret,id=nginx-key,dst=nginx-repo.key \
+RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt \
+    --mount=type=secret,id=nginx-key,dst=/nginx-repo.key \
     set -x \
 # Create nginx user/group first, to be consistent throughout Docker variants
     && addgroup --system --gid 101 nginx \
@@ -45,8 +45,8 @@ RUN --mount=type=secret,id=nginx-crt,dst=nginx-repo.crt \
     && printf "deb https://$PACKAGES_REPO/plus/debian/ `lsb_release -cs` nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
     && printf "deb https://$PACKAGES_REPO/nginx-agent/debian/ `lsb_release -cs` nginx-plus\n" > /etc/apt/sources.list.d/nginx-agent.list \
     && mkdir -p /etc/ssl/nginx \
-    && cat nginx-repo.crt > /etc/ssl/nginx/nginx-repo.crt \
-    && cat nginx-repo.key > /etc/ssl/nginx/nginx-repo.key \
+    && cat /nginx-repo.crt > /etc/ssl/nginx/nginx-repo.crt \
+    && cat /nginx-repo.key > /etc/ssl/nginx/nginx-repo.key \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
                         $nginxPackages \

--- a/scripts/docker/nginx-plus/debian/Dockerfile
+++ b/scripts/docker/nginx-plus/debian/Dockerfile
@@ -1,5 +1,5 @@
-ARG DOCKER_IMAGE
-FROM ${DOCKER_IMAGE} as install
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as install
 LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
 
 ARG PACKAGES_REPO

--- a/scripts/docker/nginx-plus/oraclelinux/Dockerfile
+++ b/scripts/docker/nginx-plus/oraclelinux/Dockerfile
@@ -1,9 +1,9 @@
 
-ARG DOCKER_IMAGE
-FROM ${DOCKER_IMAGE} as install
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as install
 LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
 
-ARG DOCKER_IMAGE
+ARG BASE_IMAGE
 ARG PACKAGES_REPO
 ARG OS_VERSION
 
@@ -34,7 +34,7 @@ sslclientkey=/etc/ssl/nginx/nginx-repo.key \n\
 gpgcheck=1 \n\
 enabled=1 \n\
 sslverify=true \n\
-gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-plus-$DOCKER_IMAGE.repo \
+gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-plus-$BASE_IMAGE.repo \
     && printf "[nginx-agent] \n\
 name=nginx-agent repo \n\
 baseurl=https://$PACKAGES_REPO/nginx-agent/centos/$OS_VERSION/\$basearch \n\
@@ -43,7 +43,7 @@ sslclientkey=/etc/ssl/nginx/nginx-repo.key \n\
 gpgcheck=1 \n\
 enabled=1 \n\
 sslverify=true \n\
-gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-agent-$DOCKER_IMAGE.repo \
+gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-agent-$BASE_IMAGE.repo \
     && yum install -y $nginxPackages \
     && yum clean all \
     && rm -rf /var/cache/yum /etc/yum.repos.d/* /etc/ssl/nginx

--- a/scripts/docker/nginx-plus/oraclelinux/Dockerfile
+++ b/scripts/docker/nginx-plus/oraclelinux/Dockerfile
@@ -11,12 +11,12 @@ WORKDIR /agent
 COPY ./scripts/docker/nginx-plus/entrypoint.sh /agent/entrypoint.sh
 COPY ./nginx-agent.conf /agent/nginx-agent.conf
 
-RUN --mount=type=secret,id=nginx-crt,dst=nginx-repo.crt \
-    --mount=type=secret,id=nginx-key,dst=nginx-repo.key \
+RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt \
+    --mount=type=secret,id=nginx-key,dst=/nginx-repo.key \
     set -x \
     && mkdir -p /etc/ssl/nginx \
-    && cat nginx-repo.crt > /etc/ssl/nginx/nginx-repo.crt \
-    && cat nginx-repo.key > /etc/ssl/nginx/nginx-repo.key \
+    && cat /nginx-repo.crt > /etc/ssl/nginx/nginx-repo.crt \
+    && cat /nginx-repo.key > /etc/ssl/nginx/nginx-repo.key \
     && yum install -y --setopt=tsflags=nodocs wget ca-certificates bind-utils wget bind-utils vim-minimal shadow-utils \
     && groupadd --system --gid 101 nginx \
     && adduser -g nginx --system --no-create-home --home /nonexistent --shell /bin/false --uid 101 nginx \

--- a/scripts/docker/nginx-plus/redhatenterprise/Dockerfile
+++ b/scripts/docker/nginx-plus/redhatenterprise/Dockerfile
@@ -10,12 +10,12 @@ WORKDIR /agent
 COPY ./scripts/docker/nginx-plus/entrypoint.sh /agent/entrypoint.sh
 COPY ./nginx-agent.conf /agent/nginx-agent.conf
 
-RUN --mount=type=secret,id=nginx-crt,dst=nginx-repo.crt \
-    --mount=type=secret,id=nginx-key,dst=nginx-repo.key \
+RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt \
+    --mount=type=secret,id=nginx-key,dst=/nginx-repo.key \
     set -x \
     && mkdir -p /etc/ssl/nginx \
-    && cat nginx-repo.crt > /etc/ssl/nginx/nginx-repo.crt \
-    && cat nginx-repo.key > /etc/ssl/nginx/nginx-repo.key \
+    && cat /nginx-repo.crt > /etc/ssl/nginx/nginx-repo.crt \
+    && cat /nginx-repo.key > /etc/ssl/nginx/nginx-repo.key \
     && yum install -y --setopt=tsflags=nodocs wget ca-certificates bind-utils wget bind-utils vim-minimal shadow-utils procps \
     && groupadd --system --gid 101 nginx \
     && adduser -g nginx --system --no-create-home --home /nonexistent --shell /bin/false --uid 101 nginx \

--- a/scripts/docker/nginx-plus/redhatenterprise/Dockerfile
+++ b/scripts/docker/nginx-plus/redhatenterprise/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi$OS_VERSION/ubi:latest as install
 LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
 
 ARG PACKAGES_REPO
-ARG DOCKER_IMAGE
+ARG BASE_IMAGE
 ARG OS_VERSION
 
 WORKDIR /agent
@@ -33,7 +33,7 @@ sslclientkey=/etc/ssl/nginx/nginx-repo.key \n\
 gpgcheck=1 \n\
 enabled=1 \n\
 sslverify=true \n\
-gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-plus-$DOCKER_IMAGE.repo \
+gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-plus-$BASE_IMAGE.repo \
     && printf "[nginx-agent] \n\
 name=nginx-agent repo \n\
 baseurl=https://$PACKAGES_REPO/nginx-agent/centos/$OS_VERSION/\$basearch \n\
@@ -42,7 +42,7 @@ sslclientkey=/etc/ssl/nginx/nginx-repo.key \n\
 gpgcheck=1 \n\
 enabled=1 \n\
 sslverify=true \n\
-gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-agent-$DOCKER_IMAGE.repo \
+gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-agent-$BASE_IMAGE.repo \
     && yum install -y $nginxPackages \
     && yum clean all \
     && rm -rf /var/cache/yum /etc/yum.repos.d/* /etc/ssl/nginx

--- a/scripts/docker/nginx-plus/suse/Dockerfile
+++ b/scripts/docker/nginx-plus/suse/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
 
 ARG OS_VERSION
 ARG PACKAGES_REPO
-ARG DOCKER_IMAGE
+ARG BASE_IMAGE
 
 WORKDIR /agent
 COPY ./scripts/docker/nginx-plus/entrypoint.sh /agent/entrypoint.sh

--- a/scripts/docker/nginx-plus/suse/Dockerfile
+++ b/scripts/docker/nginx-plus/suse/Dockerfile
@@ -12,12 +12,12 @@ WORKDIR /agent
 COPY ./scripts/docker/nginx-plus/entrypoint.sh /agent/entrypoint.sh
 COPY ./nginx-agent.conf /agent/nginx-agent.conf
 
-RUN --mount=type=secret,id=nginx-crt,dst=nginx-repo.crt \
-    --mount=type=secret,id=nginx-key,dst=nginx-repo.key \
+RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt \
+    --mount=type=secret,id=nginx-key,dst=/nginx-repo.key \
     set -x \
     && mkdir -p /etc/ssl/nginx \
-    && cat nginx-repo.crt > /etc/ssl/nginx/nginx-repo.crt \
-    && cat nginx-repo.key > /etc/ssl/nginx/nginx-repo.key \
+    && cat /nginx-repo.crt > /etc/ssl/nginx/nginx-repo.crt \
+    && cat /nginx-repo.key > /etc/ssl/nginx/nginx-repo.key \
     && cat /etc/ssl/nginx/nginx-repo.crt /etc/ssl/nginx/nginx-repo.key > /etc/ssl/nginx/nginx-repo-bundle.crt \
     && zypper install ca-certificates \
     && nginxPackages=" \

--- a/scripts/docker/nginx-plus/ubuntu/Dockerfile
+++ b/scripts/docker/nginx-plus/ubuntu/Dockerfile
@@ -1,5 +1,5 @@
-ARG DOCKER_IMAGE
-FROM ${DOCKER_IMAGE} as install
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as install
 LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
 
 ARG PACKAGES_REPO

--- a/scripts/docker/nginx-plus/ubuntu/Dockerfile
+++ b/scripts/docker/nginx-plus/ubuntu/Dockerfile
@@ -9,8 +9,8 @@ WORKDIR /agent
 COPY ./scripts/docker/nginx-plus/entrypoint.sh /agent/entrypoint.sh
 COPY ./nginx-agent.conf /agent/nginx-agent.conf
 
-RUN --mount=type=secret,id=nginx-crt,dst=nginx-repo.crt \
-    --mount=type=secret,id=nginx-key,dst=nginx-repo.key \
+RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt \
+    --mount=type=secret,id=nginx-key,dst=/nginx-repo.key \
     set -x \
     && addgroup --system --gid 101 nginx \
     && adduser --system --disabled-login --ingroup nginx --no-create-home --home /nonexistent --gecos "nginx user" --shell /bin/false --uid 101 nginx \
@@ -48,8 +48,8 @@ RUN --mount=type=secret,id=nginx-crt,dst=nginx-repo.crt \
     && printf "deb https://$PACKAGES_REPO/plus/ubuntu/ `lsb_release -cs` nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
     && printf "deb https://$PACKAGES_REPO/nginx-agent/ubuntu/ `lsb_release -cs` nginx-plus\n" > /etc/apt/sources.list.d/nginx-agent.list \
     && mkdir -p /etc/ssl/nginx \
-    && cat nginx-repo.crt > /etc/ssl/nginx/nginx-repo.crt \
-    && cat nginx-repo.key > /etc/ssl/nginx/nginx-repo.key \
+    && cat /nginx-repo.crt > /etc/ssl/nginx/nginx-repo.crt \
+    && cat /nginx-repo.key > /etc/ssl/nginx/nginx-repo.key \
     && apt-get update \
     && apt-get install $nginxPackages -y  \
     && rm /etc/ssl/nginx/nginx-repo.crt /etc/ssl/nginx/nginx-repo.key

--- a/scripts/packages/packager/Dockerfile
+++ b/scripts/packages/packager/Dockerfile
@@ -1,6 +1,6 @@
 ARG package_type
 
-FROM golang:1.19-bullseye AS base
+FROM docker.io/golang:1.19-bullseye AS base
 
 ARG PKG_VER="1.17.5"
 ARG PKG_DIR="/tmp/pkg"

--- a/test/integration/api/api_test.go
+++ b/test/integration/api/api_test.go
@@ -34,7 +34,7 @@ func TestAPI_setupTestContainer(t *testing.T) {
 	assert.NoError(t, comp.
 		WaitForService("agent", wait.ForLog("OneTimeRegistration completed")).WithEnv(map[string]string{
 		"PACKAGE":      os.Getenv("PACKAGE"),
-		"DOCKER_IMAGE": os.Getenv("DOCKER_IMAGE"),
+		"BASE_IMAGE": os.Getenv("BASE_IMAGE"),
 	}).
 		Up(ctx, compose.Wait(true)), "compose.Up()")
 }

--- a/test/integration/api/docker-compose.yml
+++ b/test/integration/api/docker-compose.yml
@@ -6,12 +6,12 @@ networks:
 
 services:
   agent:
-    build: 
+    build:
       context: ../../../
       dockerfile: ./scripts/docker/nginx-oss/ubuntu/Dockerfile
       args:
         PACKAGE: ${PACKAGE}
-        DOCKER_IMAGE: ${DOCKER_IMAGE}
+        BASE_IMAGE: ${BASE_IMAGE}
         AGENT_CONF: "./test/testdata/configs/integration/api/nginx-agent.conf"
         NGINX_CONF: "./test/testdata/configs/integration/api/nginx.conf"
         ENTRY_POINT: "./scripts/docker/nginx-oss/entrypoint.sh"
@@ -19,4 +19,3 @@ services:
       - 9091:9091
     networks:
       - monitoring
-      


### PR DESCRIPTION
### Proposed changes

This change introduces an ability to use [podman](https://podman.io) container management tool in addition to docker, which remains the default. Podman provides daemonless architecture and allows to run containers in unprivileged mode natively on Linux.

On systems with both docker and podman installed, the `CONTAINER_CLITOOL` environment variable can be used to choose a desired option.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))

### Details on performed tests

Platform / versions, Docker:
```
Host - MacOS on M1 pro

% sw_vers 
ProductName:	macOS
ProductVersion:	12.6.1
BuildVersion:	21G217

% docker version
Client:
 Cloud integration: v1.0.29
 Version:           20.10.21
 API version:       1.41
 Go version:        go1.18.7
 Git commit:        baeda1f
 Built:             Tue Oct 25 18:01:18 2022
 OS/Arch:           darwin/arm64
 Context:           default
 Experimental:      true

Server: Docker Desktop 4.15.0 (93002)
 Engine:
  Version:          20.10.21
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.18.7
  Git commit:       3056208
  Built:            Tue Oct 25 17:59:41 2022
  OS/Arch:          linux/arm64
  Experimental:     false
 containerd:
  Version:          1.6.10
  GitCommit:        770bd0108c32f3fb5c73ae1264f7e503fe7b2661
 runc:
  Version:          1.1.4
  GitCommit:        v1.1.4-0-g5fd4c4d
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

Platform / versions, podman:
```
Host - Fedora Linux (x86_64)

$ cat /etc/os-release 
NAME="Fedora Linux"
VERSION="36 (Cloud Edition)"
ID=fedora
VERSION_ID=36
VERSION_CODENAME=""
PLATFORM_ID="platform:f36"
PRETTY_NAME="Fedora Linux 36 (Cloud Edition)"
ANSI_COLOR="0;38;2;60;110;180"
LOGO=fedora-logo-icon
CPE_NAME="cpe:/o:fedoraproject:fedora:36"
HOME_URL="https://fedoraproject.org/"
DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/f36/system-administrators-guide/"
SUPPORT_URL="https://ask.fedoraproject.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Fedora"
REDHAT_BUGZILLA_PRODUCT_VERSION=36
REDHAT_SUPPORT_PRODUCT="Fedora"
REDHAT_SUPPORT_PRODUCT_VERSION=36
PRIVACY_POLICY_URL="https://fedoraproject.org/wiki/Legal:PrivacyPolicy"
SUPPORT_END=2023-05-16
VARIANT="Cloud Edition"
VARIANT_ID=cloud

$ podman version
Client:       Podman Engine
Version:      4.3.1
API Version:  4.3.1
Go Version:   go1.18.7
Built:        Fri Nov 11 15:24:13 2022
OS/Arch:      linux/amd64
```

Targets tested with both docker and podman (rootless):
 - `make build-docker`
 - `make build-benchmark-docker`
 - `make build-txz-packager-docker`
 - `make local-txz-package`

Targets tested with podman (rootless) only:
 - `make performance-test` (fails with docker on M1)

Untested targets:
 - `make test-docker-component` (it's unclear from Makefile how to create proper environment)

### Additional findings

https://github.com/containers/podman/issues/16969