### PR TITLE
Skip pkg cache for golangci/golangci-lint-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Lint Agent Code
-        uses: golangci/golangci-lint-action@v3.3.0
+        uses: golangci/golangci-lint-action@v3
         with:
           version: "${{ env.GOLANGCI_LINT_VERSION }}"
           args: -c ./scripts/.golangci.yml
           skip-pkg-cache: true
       - name: Lint SDK Code
-        uses: golangci/golangci-lint-action@v3.3.0
+        uses: golangci/golangci-lint-action@v3
         with:
           version: "${{ env.GOLANGCI_LINT_VERSION }}"
           working-directory: sdk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,14 @@ jobs:
         with:
           version: "${{ env.GOLANGCI_LINT_VERSION }}"
           args: -c ./scripts/.golangci.yml
+          skip-pkg-cache: true
       - name: Lint SDK Code
         uses: golangci/golangci-lint-action@v3.3.0
         with:
           version: "${{ env.GOLANGCI_LINT_VERSION }}"
           working-directory: sdk
           args: -c ../scripts/.golangci.yml
+          skip-pkg-cache: true
 
   unit-test:
     name: Unit Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Lint Agent Code
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v3.3.0
         with:
           version: "${{ env.GOLANGCI_LINT_VERSION }}"
           args: -c ./scripts/.golangci.yml
       - name: Lint SDK Code
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v3.3.0
         with:
           version: "${{ env.GOLANGCI_LINT_VERSION }}"
           working-directory: sdk


### PR DESCRIPTION
### Proposed changes

There are currently errors being observed with the `golangci/golangci-lint-action` github action. The errors seem to be related to caching in the github action, so for now we will skip the caching until a fix is made to the github action.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
