### PR TITLE
fix: Handle case when NAP metadata directory doesn't exist

### DIFF
--- a/src/extensions/nginx-app-protect/nap/nap_metadata.go
+++ b/src/extensions/nginx-app-protect/nap/nap_metadata.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 
 	"github.com/nginx/agent/sdk/v2"
 	"github.com/nginx/agent/sdk/v2/proto"
@@ -88,8 +89,18 @@ func UpdateMetadata(
 	if err != nil {
 		return err
 	}
-	log.Debugf("Writing NAP Metadata %s", m)
 
+	// Make dir if not exists
+	directory := filepath.Dir(wafLocation)
+	_, err = os.Stat(directory)
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(directory, 0755)
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Debugf("Writing NAP Metadata %s", m)
 	return os.WriteFile(wafLocation, m, 0644)
 }
 

--- a/src/extensions/nginx-app-protect/nap/nap_metadata_test.go
+++ b/src/extensions/nginx-app-protect/nap/nap_metadata_test.go
@@ -19,7 +19,9 @@ import (
 
 const (
 	configFile   = "/tmp/testdata/nginx.conf"
-	metadataFile = "/tmp/testdata/app_protect_metadata.json"
+	basePath     = "/tmp/testdata"
+	metadataPath = "/tmp/testdata/nms"
+	metadataFile = "/tmp/testdata/nms/app_protect_metadata.json"
 
 	nginxID  = "1"
 	systemID = "2"
@@ -106,6 +108,12 @@ func TestUpdateNapMetadata(t *testing.T) {
 		expected   string
 	}{
 		{
+			testName:   "NoMetadataDir",
+			meta:       "",
+			precompPub: false,
+			expected:   expectedFalse,
+		},
+		{
 			testName:   "NoMetadataFile",
 			meta:       "",
 			precompPub: false,
@@ -135,7 +143,14 @@ func TestUpdateNapMetadata(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			defer tearDownTestDirectory()
 
-			if tc.testName != "NoMetadataFile" {
+			switch tc.testName {
+			case "NoMetadataDir":
+				err := os.MkdirAll(basePath, 0755)
+				assert.NoError(t, err)
+			case "NoMetadataFile":
+				err := os.MkdirAll(metadataPath, 0755)
+				assert.NoError(t, err)
+			default:
 				err := setUpFile(metadataFile, []byte(tc.meta))
 				assert.NoError(t, err)
 			}

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/extensions/nginx-app-protect/nap/nap_metadata.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/extensions/nginx-app-protect/nap/nap_metadata.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 
 	"github.com/nginx/agent/sdk/v2"
 	"github.com/nginx/agent/sdk/v2/proto"
@@ -88,8 +89,18 @@ func UpdateMetadata(
 	if err != nil {
 		return err
 	}
-	log.Debugf("Writing NAP Metadata %s", m)
 
+	// Make dir if not exists
+	directory := filepath.Dir(wafLocation)
+	_, err = os.Stat(directory)
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(directory, 0755)
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Debugf("Writing NAP Metadata %s", m)
 	return os.WriteFile(wafLocation, m, 0644)
 }
 


### PR DESCRIPTION
When writing NAP metadata, create the metadata directory if it doesn't exist.

### Proposed changes

- Create NAP metadata directory if it doesn't already exist
- Expanded unit test to cover this case

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
