### PR TITLE
Fix architecture and uname variable

### DIFF
--- a/src/core/environment_test.go
+++ b/src/core/environment_test.go
@@ -331,6 +331,8 @@ func TestNewHostInfo(t *testing.T) {
 	assert.GreaterOrEqual(t, len(host.Partitons), 1)
 	assert.GreaterOrEqual(t, len(host.Network.Interfaces), 1)
 	assert.GreaterOrEqual(t, len(host.Processor), 1)
+	assert.NotEmpty(t, host.Processor[0].Architecture)
+	assert.Equal(t, env.GetUnixName(), host.Uname)
 	assert.NotEmpty(t, host.Release)
 	assert.Equal(t, tags, host.Tags)
 }
@@ -370,9 +372,12 @@ func TestVirtualization(t *testing.T) {
 }
 
 func TestProcessors(t *testing.T) {
-	processorInfo := processors()
+	processorInfo := processors("arm64")
 	// at least one network interface
 	assert.GreaterOrEqual(t, processorInfo[0].GetCpus(), int32(1))
+	// non empty architecture
+	assert.NotEmpty(t, processorInfo[0].GetArchitecture())
+	assert.GreaterOrEqual(t, processorInfo[0].GetArchitecture(), "arm64")
 }
 
 func TestProcesses(t *testing.T) {


### PR DESCRIPTION
### Proposed changes

Currently `architecture` is an empty string, and `uname` is `uname -m`

As part of this PR, 

Fix to populate `architecture` as uname -m using host information and `uname` as uname -a.

Updated tests to test changes.

#### Call-Out
- Different platforms have different Utsname struct definition.
https://cs.opensource.google/search?q=utsname&ss=go%2Fx%2Fsys&start=11
https://cs.opensource.google/search?q=utsname&ss=go%2Fx%2Fsys&start=1

I cannot find any supported wrapper/util in gopsutil or unix binary that would return `Utsname` struct variables in platform-agnostic manner.
So I have added `GetUnixName` function. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
