### PR TITLE
Print NginxConfig in JSON format for debug and trace levels

### DIFF
--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -318,7 +318,7 @@ func hasConfPath(files []*proto.File, confPath string) bool {
 
 func (n *NginxBinaryType) WriteConfig(config *proto.NginxConfig) (*sdk.ConfigApply, error) {
 	jsonConfig, _ := json.Marshal(config)
-	log.Tracef("Writing config: %+v\n", jsonConfig)
+	log.Tracef("Writing config: %+v\n", string(jsonConfig))
 	details, ok := n.nginxDetailsMap[config.ConfigData.NginxId]
 	if !ok || details == nil {
 		return nil, fmt.Errorf("NGINX instance %s not found", config.ConfigData.NginxId)

--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -318,10 +318,14 @@ func hasConfPath(files []*proto.File, confPath string) bool {
 
 func (n *NginxBinaryType) WriteConfig(config *proto.NginxConfig) (*sdk.ConfigApply, error) {
 	if log.IsLevelEnabled(log.TraceLevel) {
-		jsonConfig, _ := json.Marshal(config)
-		log.Tracef("Writing config: %+v\n", string(jsonConfig))
+		jsonConfig, err := json.Marshal(config)
+		if err != nil {
+			log.Tracef("Writing raw config: %+v", config)
+		} else {
+			log.Tracef("Writing JSON config: %+v", string(jsonConfig))
+		}
 	}
-	
+
 	details, ok := n.nginxDetailsMap[config.ConfigData.NginxId]
 	if !ok || details == nil {
 		return nil, fmt.Errorf("NGINX instance %s not found", config.ConfigData.NginxId)

--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -317,8 +317,11 @@ func hasConfPath(files []*proto.File, confPath string) bool {
 }
 
 func (n *NginxBinaryType) WriteConfig(config *proto.NginxConfig) (*sdk.ConfigApply, error) {
-	jsonConfig, _ := json.Marshal(config)
-	log.Tracef("Writing config: %+v\n", string(jsonConfig))
+	if log.IsLevelEnabled(log.TraceLevel) {
+		jsonConfig, _ := json.Marshal(config)
+		log.Tracef("Writing config: %+v\n", string(jsonConfig))
+	}
+	
 	details, ok := n.nginxDetailsMap[config.ConfigData.NginxId]
 	if !ok || details == nil {
 		return nil, fmt.Errorf("NGINX instance %s not found", config.ConfigData.NginxId)

--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -10,6 +10,7 @@ package core
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -316,7 +317,8 @@ func hasConfPath(files []*proto.File, confPath string) bool {
 }
 
 func (n *NginxBinaryType) WriteConfig(config *proto.NginxConfig) (*sdk.ConfigApply, error) {
-	log.Tracef("Writing config: %+v\n", config)
+	jsonConfig, _ := json.Marshal(config)
+	log.Tracef("Writing config: %+v\n", jsonConfig)
 	details, ok := n.nginxDetailsMap[config.ConfigData.NginxId]
 	if !ok || details == nil {
 		return nil, fmt.Errorf("NGINX instance %s not found", config.ConfigData.NginxId)

--- a/src/plugins/nginx.go
+++ b/src/plugins/nginx.go
@@ -389,7 +389,7 @@ func (n *Nginx) writeConfigAndReloadNginx(correlationId string, config *proto.Ng
 	}
 
 	jsonConfig, _ := json.Marshal(config)
-	log.Debugf("WriteConfig start %v", jsonConfig)
+	log.Debugf("WriteConfig start %v", string(jsonConfig))
 	configApply, err := n.nginxBinary.WriteConfig(config)
 	if err != nil {
 		if configApply != nil {

--- a/src/plugins/nginx.go
+++ b/src/plugins/nginx.go
@@ -388,7 +388,8 @@ func (n *Nginx) writeConfigAndReloadNginx(correlationId string, config *proto.Ng
 		return n.handleErrorStatus(status, message)
 	}
 
-	log.Debugf("WriteConfig start %v", config)
+	jsonConfig, _ := json.Marshal(config)
+	log.Debugf("WriteConfig start %v", jsonConfig)
 	configApply, err := n.nginxBinary.WriteConfig(config)
 	if err != nil {
 		if configApply != nil {

--- a/src/plugins/nginx.go
+++ b/src/plugins/nginx.go
@@ -388,8 +388,6 @@ func (n *Nginx) writeConfigAndReloadNginx(correlationId string, config *proto.Ng
 		return n.handleErrorStatus(status, message)
 	}
 
-	jsonConfig, _ := json.Marshal(config)
-	log.Debugf("WriteConfig start %v", string(jsonConfig))
 	configApply, err := n.nginxBinary.WriteConfig(config)
 	if err != nil {
 		if configApply != nil {


### PR DESCRIPTION
### Proposed changes

This PR changes the `log.traceF` and `log.debugF` function arguments in those cases where we log the `NginxConfig` protobuf message. Instead of the raw message (which is harder to parse and read when doing troubleshooting), the JSON version of the object is now logged.

Closes #209 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
