### PR TITLE
fix: move go installation step

### DIFF
--- a/hugo/content/getting-started.md
+++ b/hugo/content/getting-started.md
@@ -12,15 +12,19 @@ doctypes: ["task"]
 
 Follow these steps to configure and run NGINX Agent and a mock interface ("control plane") to which the NGINX Agent will report.
 
-## Install NGINX and NGINX Agent
+## Install NGINX
 
-Follow the steps in the [Installation]({{< relref "/installation.md" >}}) section to download, install, and run NGINX and NGINX Agent.
+Follow the steps in the [Installation]({{< relref "/installation.md" >}}) section to download, install, and run NGINX.
 
 ## Clone the NGINX Agent Repository
 
 Using your preferred method, clone the NGINX Agent repository into your development directory. See [Cloning a GitHub Repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) for additional help.
 
-## Start the Mock Control Plane
+## Install Go
+
+NGINX Agent and the Mock Control Plane are written in Go. Go 1.19 or higher is required to build and run either application from the source code directory. You can [download Go from the official website](https://go.dev/dl/). 
+
+## Start the gRPC Mock Control Plane
 
 Start the mock control plane by running the following command from the `agent` source code root directory:
 
@@ -46,11 +50,11 @@ Create the `agent-dynamic.conf` file in the `/etc/nginx-agent/` directory, which
 sudo touch /etc/nginx-agent/agent-dynamic.conf
 ```
 
-### Enabling the gRPC interface
+### Enable the gRPC interface
 
 Add the the following settings to `/etc/nginx-agent/nginx-agent.conf`:
 
-```nginx
+```yaml
 server:
   host: 127.0.0.1 # mock control plane host
   grpcPort: 54789 # mock control plane gRPC port
@@ -61,7 +65,9 @@ tls:
   skip_verify: true
 ```
 
-### Enabling the REST interface
+For more information, see [Agent Protocol Definitions and Documentation](https://github.com/nginx/agent/tree/main/docs/proto/README.md)
+
+### Enable the REST interface
 
 The NGINX Agent REST interface can be exposed by validating the following lines in the `/etc/nginx-agent/nginx-agent.conf` file are present:
 
@@ -75,6 +81,15 @@ api:
 ```
 
 The mock control plane can use either gRPC or REST protocols to communicate with NGINX Agent.
+
+## Launch Swagger UI
+Swagger UI requires goswagger be installed. See [instructions for installing goswagger](https://goswagger.io/install.html) for additional help.
+
+To launch the Swagger UI for the REST interface run the following command
+
+```bash
+make launch-swagger-ui
+```
 
 ## Start NGINX Agent
 

--- a/hugo/content/installation.md
+++ b/hugo/content/installation.md
@@ -14,10 +14,6 @@ doctypes: ["task"]
 
 NGINX Agent interfaces directly with an NGINX server process installed on the same system. If you don't have it already, follow these steps to install [NGINX Open Source](https://www.nginx.com/resources/wiki/start/topics/tutorials/install/) or [NGINX Plus](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/). Once installed, ensure the NGINX instance is running.
 
-## Install Go
-
-NGINX Agent is written in Go and requires Go 1.19 or higher to be installed. You can [download Go from the official website](https://go.dev/dl/). 
-
 ## Install Agent from Package Files
 
 To install NGINX Agent on your system, go to [Releases](https://github.com/nginx/agent/releases) and download `nginx-agent.tar.gz`. Create a new subdirectory and extract the archive into it. Change into the subdirectory matching the package manager format appropriate for your operating system distribution.


### PR DESCRIPTION
### Proposed changes

Based on the changes from https://github.com/nginx/agent/pull/208

Move the Go installation step to a different section.
