### PR TITLE
Fix docs to reference packages in current release

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ NGINX Agent allows a gRPC connected control system to register a listener for a 
 NGINX Agent interfaces directly with an NGINX server process installed on the same system. If you don't have it already, follow these steps to install [NGINX Open Source](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/) or [NGINX Plus](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/). Once installed, ensure the NGINX instance is running.
 
 ## Installing NGINX Agent from Package Files
-To install NGINX Agent on your system, go to [Releases](https://github.com/nginx/agent/releases) and download a package supported by your OS distribution and CPU architecture.
+To install NGINX Agent on your system, go to [Releases](https://github.com/nginx/agent/releases) and download the latest package supported by your OS distribution and CPU architecture.
 
 Use your system's package manager to install the package. Some examples:
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ NGINX Agent allows a gRPC connected control system to register a listener for a 
 NGINX Agent interfaces directly with an NGINX server process installed on the same system. If you don't have it already, follow these steps to install [NGINX Open Source](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/) or [NGINX Plus](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/). Once installed, ensure the NGINX instance is running.
 
 ## Installing NGINX Agent from Package Files
-To install NGINX Agent on your system, go to [Releases](https://github.com/nginx/agent/releases) and download `nginx-agent.tar.gz`. Create a new subdirectory and extract the archive into it. Change into the subdirectory matching the package manager format appropriate for your operating system distribution.
+To install NGINX Agent on your system, go to [Releases](https://github.com/nginx/agent/releases) and download a package supported by your OS distribution and CPU architecture.
 
-Depending on OS distribution and CPU architecture type, use your system's package manager to install the package. Some examples:
+Use your system's package manager to install the package. Some examples:
 
 Debian, Ubuntu, and other distributions using the `dpkg` package manager. 
 
@@ -104,7 +104,7 @@ sudo apk add nginx-agent-<agent-version>.apk
 ```
 FreeBSD
 ```
-sudo pkg add nginx-agent-<agent-version>
+sudo pkg add nginx-agent-<agent-version>.pkg
 ```
 
 ## Starting and Enabling Start on Boot

--- a/hugo/content/installation.md
+++ b/hugo/content/installation.md
@@ -16,9 +16,9 @@ NGINX Agent interfaces directly with an NGINX server process installed on the sa
 
 ## Install Agent from Package Files
 
-To install NGINX Agent on your system, go to [Releases](https://github.com/nginx/agent/releases) and download `nginx-agent.tar.gz`. Create a new subdirectory and extract the archive into it. Change into the subdirectory matching the package manager format appropriate for your operating system distribution.
+To install NGINX Agent on your system, go to [Releases](https://github.com/nginx/agent/releases) and download a package supported by your OS distribution and CPU architecture.
 
-Depending on OS distribution and CPU architecture type, use your system's package manager to install the package. Some examples:
+Use your system's package manager to install the package. Some examples:
 
 - Debian, Ubuntu, and other distributions using the `dpkg` package manager.
 
@@ -47,7 +47,7 @@ Depending on OS distribution and CPU architecture type, use your system's packag
 - FreeBSD
  
   ```
-  sudo pkg add nginx-agent-<agent-version>
+  sudo pkg add nginx-agent-<agent-version>.pkg
   ```
 
 ## Start and Enable Start on Boot

--- a/hugo/content/installation.md
+++ b/hugo/content/installation.md
@@ -16,7 +16,7 @@ NGINX Agent interfaces directly with an NGINX server process installed on the sa
 
 ## Install Agent from Package Files
 
-To install NGINX Agent on your system, go to [Releases](https://github.com/nginx/agent/releases) and download a package supported by your OS distribution and CPU architecture.
+To install NGINX Agent on your system, go to [Releases](https://github.com/nginx/agent/releases) and download the latest package supported by your OS distribution and CPU architecture.
 
 Use your system's package manager to install the package. Some examples:
 


### PR DESCRIPTION
### Background
Since the release of https://github.com/nginx/agent/releases/tag/v2.22.0 and onwards we have offered individual packages rather than `nginx-agent.tar.gz` containing all available packages.

### Proposed changes

* Update readme and installation doc to reference individual packages rather than tar file.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
