### PR TITLE
Fix plus docker files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ DATE = $(shell date +%F_%H-%M-%S)
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 OS_RELEASE  ?= ubuntu
 OS_VERSION  ?= 22.04
-BASE_IMAGE  = "docker.io/${OS_RELEASE}:${OS_VERSION}"
+BASE_IMAGE  = "${OS_RELEASE}:${OS_VERSION}"
 IMAGE_TAG   = "agent_${OS_RELEASE}_${OS_VERSION}"
 
 

--- a/scripts/docker/nginx-plus/alpine/Dockerfile
+++ b/scripts/docker/nginx-plus/alpine/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE
-FROM ${BASE_IMAGE} as install
+FROM docker.io/${BASE_IMAGE} as install
 LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
 
 ARG PACKAGES_REPO

--- a/scripts/docker/nginx-plus/amazonlinux/Dockerfile
+++ b/scripts/docker/nginx-plus/amazonlinux/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE
-FROM ${BASE_IMAGE} as install
+FROM docker.io/${BASE_IMAGE} as install
 LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
 
 ARG BASE_IMAGE

--- a/scripts/docker/nginx-plus/centos/Dockerfile
+++ b/scripts/docker/nginx-plus/centos/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE
-FROM ${BASE_IMAGE} as install
+FROM docker.io/${BASE_IMAGE} as install
 LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
 
 ARG BASE_IMAGE

--- a/scripts/docker/nginx-plus/debian/Dockerfile
+++ b/scripts/docker/nginx-plus/debian/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE
-FROM ${BASE_IMAGE} as install
+FROM docker.io/${BASE_IMAGE} as install
 LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
 
 ARG PACKAGES_REPO

--- a/scripts/docker/nginx-plus/oraclelinux/Dockerfile
+++ b/scripts/docker/nginx-plus/oraclelinux/Dockerfile
@@ -1,6 +1,6 @@
 
 ARG BASE_IMAGE
-FROM ${BASE_IMAGE} as install
+FROM docker.io/${BASE_IMAGE} as install
 LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
 
 ARG BASE_IMAGE

--- a/scripts/docker/nginx-plus/ubuntu/Dockerfile
+++ b/scripts/docker/nginx-plus/ubuntu/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE
-FROM ${BASE_IMAGE} as install
+FROM docker.io/${BASE_IMAGE} as install
 LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
 
 ARG PACKAGES_REPO


### PR DESCRIPTION
### Proposed changes

Add `docker.io/` to `Dockerfiles` instead of in the `BASE_IMAGE` arg to stop Nginx Plus Dockerfiles from failing to build.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
