### PR TITLE
Fix cache level size info for systems data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Variable Definitions                                                                                            #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-VERSION = $(shell git describe --match "v[0-9]*" --abbrev=0 --tags)
+VERSION = 2.8.2 # $(shell git describe --match "v[0-9]*" --abbrev=0 --tags)
 COMMIT = $(shell git rev-parse --short HEAD)
 DATE = $(shell date +%F_%H-%M-%S)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Variable Definitions                                                                                            #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-VERSION = 2.8.2 # $(shell git describe --match "v[0-9]*" --abbrev=0 --tags)
+VERSION = $(shell git describe --match "v[0-9]*" --abbrev=0 --tags)
 COMMIT = $(shell git rev-parse --short HEAD)
 DATE = $(shell date +%F_%H-%M-%S)
 

--- a/src/core/environment.go
+++ b/src/core/environment.go
@@ -526,7 +526,11 @@ func getProcessorCacheInfo(cpuInfo cpuid.CPUInfo) map[string]string {
 		return cache
 	}
 
-	cpuInfos := strings.TrimSpace(string(out))
+	return parselscpuInfo(string(out),cache)
+}
+
+func parselscpuInfo(lscpuInfo string, cache map[string]string) map[string]string {
+	cpuInfos := strings.TrimSpace(lscpuInfo)
 	lines := strings.Split(cpuInfos, "\n")
 	cpuInfoMap := map[string]string{}
 	for _, line := range lines {

--- a/src/core/environment.go
+++ b/src/core/environment.go
@@ -526,7 +526,7 @@ func getProcessorCacheInfo(cpuInfo cpuid.CPUInfo) map[string]string {
 		return cache
 	}
 
-	return parselscpuInfo(string(out),cache)
+	return parselscpuInfo(string(out), cache)
 }
 
 func parselscpuInfo(lscpuInfo string, cache map[string]string) map[string]string {
@@ -556,7 +556,7 @@ func parselscpuInfo(lscpuInfo string, cache map[string]string) map[string]string
 		cache["L3"] = l3Cache
 	}
 
-    return cache
+	return cache
 }
 
 func getDefaultProcessorCacheInfo(cpuInfo cpuid.CPUInfo) map[string]string {
@@ -576,15 +576,15 @@ func formatBytes(bytes int) string {
 	if bytes <= -1 {
 		return "-1"
 	}
-	mib := 1024 * 1024;
+	mib := 1024 * 1024
 	kib := 1024
 
 	if bytes >= mib {
-		return fmt.Sprint(bytes/mib) +  " MiB"
+		return fmt.Sprint(bytes/mib) + " MiB"
 	} else if bytes >= kib {
-		return fmt.Sprint(bytes/kib) +  " KiB"
+		return fmt.Sprint(bytes/kib) + " KiB"
 	} else {
-		return fmt.Sprint(bytes) +  " B"
+		return fmt.Sprint(bytes) + " B"
 	}
 }
 

--- a/src/core/environment.go
+++ b/src/core/environment.go
@@ -522,7 +522,7 @@ func getProcessorCacheInfo(cpuInfo cpuid.CPUInfo) map[string]string {
 
 	out, err := exec.Command("lscpu").Output()
 	if err != nil {
-		// return default values of cache
+		log.Warnf("Error executing lscpu on host: %v", err)
 		return cache
 	}
 
@@ -530,9 +530,9 @@ func getProcessorCacheInfo(cpuInfo cpuid.CPUInfo) map[string]string {
 }
 
 func parselscpuInfo(lscpuInfo string, cache map[string]string) map[string]string {
-	cpuInfos := strings.TrimSpace(lscpuInfo)
-	lines := strings.Split(cpuInfos, "\n")
-	cpuInfoMap := map[string]string{}
+	lscpuInfos := strings.TrimSpace(lscpuInfo)
+	lines := strings.Split(lscpuInfos, "\n")
+	lscpuInfoMap := map[string]string{}
 	for _, line := range lines {
 		fields := strings.Split(line, ":")
 		if len(fields) < 2 {
@@ -540,19 +540,19 @@ func parselscpuInfo(lscpuInfo string, cache map[string]string) map[string]string
 		}
 		key := strings.TrimSpace(fields[0])
 		value := strings.TrimSpace(fields[1])
-		cpuInfoMap[key] = strings.Trim(value, "\"")
+		lscpuInfoMap[key] = strings.Trim(value, "\"")
 	}
 
-	if l1dCache, ok := cpuInfoMap["L1d cache"]; ok {
+	if l1dCache, ok := lscpuInfoMap["L1d cache"]; ok {
 		cache["L1d"] = l1dCache
 	}
-	if l1iCache, ok := cpuInfoMap["L1i cache"]; ok {
+	if l1iCache, ok := lscpuInfoMap["L1i cache"]; ok {
 		cache["L1i"] = l1iCache
 	}
-	if l2Cache, ok := cpuInfoMap["L2 cache"]; ok {
+	if l2Cache, ok := lscpuInfoMap["L2 cache"]; ok {
 		cache["L2"] = l2Cache
 	}
-	if l3Cache, ok := cpuInfoMap["L3 cache"]; ok {
+	if l3Cache, ok := lscpuInfoMap["L3 cache"]; ok {
 		cache["L3"] = l3Cache
 	}
 

--- a/src/core/environment.go
+++ b/src/core/environment.go
@@ -510,22 +510,78 @@ func processors() (res []*proto.CpuInfo) {
 }
 
 func processorCache(item cpu.InfoStat) map[string]string {
-	// Find a library that supports multiple CPUs
-	cache := map[string]string{
-		// values are in bytes
-		"L1d":       fmt.Sprintf("%v", cpuid.CPU.Cache.L1D),
-		"L1i":       fmt.Sprintf("%v", cpuid.CPU.Cache.L1D),
-		"L2":        fmt.Sprintf("%v", cpuid.CPU.Cache.L2),
-		"L3":        fmt.Sprintf("%v", cpuid.CPU.Cache.L3),
-		"Features:": strings.Join(cpuid.CPU.FeatureSet(), ","),
-		// "Flags:": strings.Join(item.Flags, ","),
-		"Cacheline bytes:": fmt.Sprintf("%v", cpuid.CPU.CacheLine),
-	}
-
+	cache := getProcessorCacheInfo(cpuid.CPU)
 	if cpuid.CPU.Supports(cpuid.SSE, cpuid.SSE2) {
 		cache["SIMD 2:"] = "Streaming SIMD 2 Extensions"
 	}
 	return cache
+}
+
+func getProcessorCacheInfo(cpuInfo cpuid.CPUInfo) map[string]string {
+	cache := getDefaultProcessorCacheInfo(cpuInfo)
+
+	out, err := exec.Command("lscpu").Output()
+	if err != nil {
+		// return default values of cache
+		return cache
+	}
+
+	cpuInfos := strings.TrimSpace(string(out))
+	lines := strings.Split(cpuInfos, "\n")
+	cpuInfoMap := map[string]string{}
+	for _, line := range lines {
+		fields := strings.Split(line, ":")
+		if len(fields) < 2 {
+			continue
+		}
+		key := strings.TrimSpace(fields[0])
+		value := strings.TrimSpace(fields[1])
+		cpuInfoMap[key] = strings.Trim(value, "\"")
+	}
+
+	if l1dCache, ok := cpuInfoMap["L1d cache"]; ok {
+		cache["L1d"] = l1dCache
+	}
+	if l1iCache, ok := cpuInfoMap["L1i cache"]; ok {
+		cache["L1i"] = l1iCache
+	}
+	if l2Cache, ok := cpuInfoMap["L2 cache"]; ok {
+		cache["L2"] = l2Cache
+	}
+	if l3Cache, ok := cpuInfoMap["L3 cache"]; ok {
+		cache["L3"] = l3Cache
+	}
+
+    return cache
+}
+
+func getDefaultProcessorCacheInfo(cpuInfo cpuid.CPUInfo) map[string]string {
+	// Find a library that supports multiple CPUs
+	return map[string]string{
+		"L1d":       formatBytes(cpuInfo.Cache.L1D),
+		"L1i":       formatBytes(cpuInfo.Cache.L1D),
+		"L2":        formatBytes(cpuInfo.Cache.L2),
+		"L3":        formatBytes(cpuInfo.Cache.L3),
+		"Features:": strings.Join(cpuInfo.FeatureSet(), ","),
+		// "Flags:": strings.Join(item.Flags, ","),
+		"Cacheline bytes:": fmt.Sprintf("%v", cpuInfo.CacheLine),
+	}
+}
+
+func formatBytes(bytes int) string {
+	if bytes <= -1 {
+		return "-1"
+	}
+	mib := 1024 * 1024;
+	kib := 1024
+
+	if bytes >= mib {
+		return fmt.Sprint(bytes/mib) +  " MiB"
+	} else if bytes >= kib {
+		return fmt.Sprint(bytes/kib) +  " KiB"
+	} else {
+		return fmt.Sprint(bytes) +  " B"
+	}
 }
 
 func virtualization() (string, string) {

--- a/vendor/github.com/nginx/agent/sdk/v2/proto/host.proto
+++ b/vendor/github.com/nginx/agent/sdk/v2/proto/host.proto
@@ -91,7 +91,7 @@ message CpuInfo {
   int32 cpus = 6 [(gogoproto.jsontag) = "cpus"];
   // Type of hypervisor (e.g guest or host)
   string virtualization = 7 [(gogoproto.jsontag) = "virtualization"];
-  // Map of caches with names as the keys and size in bytes as the values
+  // Map of caches with names as the keys and size in formatted bytes as the values
   map<string, string> cache = 8 [(gogoproto.jsontag) = "cache"];
 }
 


### PR DESCRIPTION
### Proposed changes

- To get cpuInfo,  execute  lscpu command on host and read its output.  (as nginx-amplify-agent currently [does](https://github.com/nginxinc/nginx-amplify-agent/blob/fa4fb352ee6db134899364f5c8a3e0f1bd536ed3/amplify/agent/collectors/system/meta.py#L92))
- If read fails, then fall back to current nginx-agent implementation.
- In addition to it, cache will have formatted bytes string instead of just bytes.  (as nginx-amplify-agent currently [does](https://github.com/nginxinc/nginx-amplify-agent/blob/fa4fb352ee6db134899364f5c8a3e0f1bd536ed3/amplify/agent/collectors/system/meta.py#L109))
   **Formatted bytes.** -> E.g. instead of "L1" : "1024", cache map will be represented by  "L1" : "1 KiB"

#### Test  -
- Added Units tests.
- Deployed agent changes in sandbox. Validated change by intercepting message that converter sends to receiver (aka AMP backend).

#### Callout -
Testing changes on different archs.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))