### PR TITLE
Send agent version in grpc metadata

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -265,7 +266,7 @@ func initializeMessagePipe(ctx context.Context, corePlugins []core.Plugin, exten
 }
 
 func setDialOptions(loadedConfig *config.Config) []grpc.DialOption {
-	var grpcDialOptions []grpc.DialOption
+	grpcDialOptions := []grpc.DialOption{grpc.WithUserAgent("nginx-agent/" + strings.TrimPrefix(version, "v"))}
 	grpcDialOptions = append(grpcDialOptions, sdkGRPC.DefaultClientDialOptions...)
 	grpcDialOptions = append(grpcDialOptions, sdkGRPC.DataplaneConnectionDialOptions(loadedConfig.Server.Token, sdkGRPC.NewMessageMeta(uuid.NewString()))...)
 	return grpcDialOptions


### PR DESCRIPTION
### Proposed changes

Include the current version in GRPC metadata, trimming the leading "v" to match common [RFC9110 `User-Agent`][1] conventions.

Before this change, the metadata `user-agent` contained `["go-grpc/1.52.0"]`. After this patch, it contains `["nginx-agent/2.23.1", "go-grpc/1.52.0"]`

[1]: https://httpwg.org/specs/rfc9110.html#field.user-agent

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
