### PR TITLE
Remove aux files from trace logging

### DIFF
--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -318,9 +318,11 @@ func hasConfPath(files []*proto.File, confPath string) bool {
 
 func (n *NginxBinaryType) WriteConfig(config *proto.NginxConfig) (*sdk.ConfigApply, error) {
 	if log.IsLevelEnabled(log.TraceLevel) {
-		jsonConfig, err := json.Marshal(config)
+		loggedConfig := config
+		loggedConfig.Zaux.Contents = nil
+		jsonConfig, err := json.Marshal(loggedConfig)
 		if err != nil {
-			log.Tracef("Writing raw config: %+v", config)
+			log.Tracef("Writing raw config: %+v", loggedConfig)
 		} else {
 			log.Tracef("Writing JSON config: %+v", string(jsonConfig))
 		}

--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -318,7 +318,7 @@ func hasConfPath(files []*proto.File, confPath string) bool {
 
 func (n *NginxBinaryType) WriteConfig(config *proto.NginxConfig) (*sdk.ConfigApply, error) {
 	if log.IsLevelEnabled(log.TraceLevel) {
-		loggedConfig := proto.NginxConfig{}
+		var loggedConfig proto.NginxConfig
 		loggedConfig = *config
 		loggedConfig.Zaux = &proto.ZippedFile{}
 		jsonConfig, err := json.Marshal(loggedConfig)

--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -318,8 +318,9 @@ func hasConfPath(files []*proto.File, confPath string) bool {
 
 func (n *NginxBinaryType) WriteConfig(config *proto.NginxConfig) (*sdk.ConfigApply, error) {
 	if log.IsLevelEnabled(log.TraceLevel) {
-		loggedConfig := config
-		loggedConfig.Zaux.Contents = nil
+		loggedConfig := proto.NginxConfig{}
+		loggedConfig = *config
+		loggedConfig.Zaux = &proto.ZippedFile{}
 		jsonConfig, err := json.Marshal(loggedConfig)
 		if err != nil {
 			log.Tracef("Writing raw config: %+v", loggedConfig)


### PR DESCRIPTION
### Proposed changes

This change logs a modified `nginxConfig` object when the agent runs in `trace` mode. This modified object does not contain the aux zipped files that are part of the sent configuration.

### Checklist

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
