### PR TITLE
fix: made build target to work predictably

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,10 @@ run: ## Run code
 run-debug: ## Run code
 	./build/nginx-agent
 
-build: ## Build agent executable
+build/nginx-agent:
 	GOWORK=off CGO_ENABLED=0 go build -ldflags=${LDFLAGS} -o ./build/nginx-agent
+
+build: build/nginx-agent ## Build agent executable
 
 deps: ## Update dependencies in vendor folders
 	git diff --quiet || { echo "Local changes found. Please commit or stash your changes." >&2; exit 1; }


### PR DESCRIPTION
### Proposed changes

Previously `make build` did not do anything if a binary was deleted from the `build` directory, or the directory was created before running the target, as the target was not marked as PHONY:
```
% make clean
rm -rf ./build
% make build
GOWORK=off CGO_ENABLED=0 go build -ldflags="-w -X main.version=v2.23.1 -X main.commit=7a08fe56 -X main.date=2023-03-10_18-46-36" -o ./build/nginx-agent
% make build
make: `build' is up to date.
% rm build/nginx-agent 
% make build
make: `build' is up to date.
% ls -l build 
total 0
```

After the change:
```
% make clean
rm -rf ./build
% make build
GOWORK=off CGO_ENABLED=0 go build -ldflags="-w -X main.version=v2.23.1 -X main.commit=efc82b89 -X main.date=2023-03-10_19-53-49" -o ./build/nginx-agent
% make build
make: Nothing to be done for `build'.
% rm build/nginx-agent 
% make build
GOWORK=off CGO_ENABLED=0 go build -ldflags="-w -X main.version=v2.23.1 -X main.commit=efc82b89 -X main.date=2023-03-10_19-54-14" -o ./build/nginx-agent
```

(simply marking it as PHONY makes no sense as in usual workflows one would never need to rebuild the same binary in subsequent calls)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
