### PR TITLE
fix: include proxy_ssl_certificate in the nginx config update

### DIFF
--- a/sdk/config_helpers.go
+++ b/sdk/config_helpers.go
@@ -243,7 +243,7 @@ func updateNginxConfigFileConfig(
 				if err := updateNginxConfigFileWithRoot(aux, directive.Args[0], seen, allowedDirectories, directoryMap); err != nil {
 					return true, err
 				}
-			case "ssl_certificate", "ssl_trusted_certificate":
+			case "ssl_certificate", "proxy_ssl_certificate", "ssl_trusted_certificate":
 				if err := updateNginxConfigWithCert(directive.Directive, directive.Args[0], nginxConfig, aux, hostDir, directoryMap, allowedDirectories); err != nil {
 					return true, err
 				}
@@ -296,7 +296,7 @@ func updateNginxConfigWithCert(
 		}
 	}
 
-	if directive == "ssl_certificate" {
+	if directive == "ssl_certificate" || directive == "proxy_ssl_certificate" {
 		cert, err := LoadCertificate(file)
 		if err != nil {
 			return fmt.Errorf("configs: could not load cert(%s): %s", file, err)


### PR DESCRIPTION
### Proposed changes

When processing the nginx config update changes, the `proxy_ssl_certificate` directive should be treated the same as a `ssl_certificate`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
