### PR TITLE
Fix flaky install/uninstall test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,13 +71,13 @@ jobs:
       matrix:
         container:
         - image: "rockylinux"
-          version: "8-minimal"
+          version: "8"
         - image: "rockylinux"
-          version: "9-minimal"
+          version: "9"
         - image: "almalinux"
-          version: "8-minimal"
+          version: "8"
         - image: "almalinux"
-          version: "9-minimal"
+          version: "9"
         - image: "ubuntu"
           version: "22.04"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,13 +71,13 @@ jobs:
       matrix:
         container:
         - image: "rockylinux"
-          version: "8"
+          version: "8-minimal"
         - image: "rockylinux"
-          version: "9"
+          version: "9-minimal"
         - image: "almalinux"
-          version: "8"
+          version: "8-minimal"
         - image: "almalinux"
-          version: "9"
+          version: "9-minimal"
         - image: "ubuntu"
           version: "22.04"
     steps:

--- a/test/integration/install/install_uninstall_test.go
+++ b/test/integration/install/install_uninstall_test.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path"
@@ -11,7 +12,7 @@ import (
 	"time"
 
 	"github.com/nginx/agent/test/integration/utils"
-	"github.com/shirou/gopsutil/process"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -33,21 +34,8 @@ var (
 // Verifies that agent installs with correct output and files.
 // Verifies that agent uninstalls and removes all the files.
 func TestAgentManualInstallUninstall(t *testing.T) {
-	// Check the environment variable $PACKAGE_NAME is set
-	require.NotEmpty(t, AGENT_PACKAGE_FILENAME, "Environment variable $PACKAGE_NAME not set")
-
-	testContainer := utils.SetupTestContainerWithoutAgent(t)
-
-	exitCode, osReleaseFileContent, err := testContainer.Exec(context.Background(), []string{"cat", osReleasePath})
-	assert.NoError(t, err)
-	osReleaseContent, err := io.ReadAll(osReleaseFileContent)
-	assert.NoError(t, err)
-	assert.Equal(t, 0, exitCode)
-	assert.NotEmpty(t, osReleaseContent, "os release file empty")
-
 	expectedInstallLogMsgs := map[string]string{
 		"InstallFoundNginxAgent": "Found nginx-agent /usr/bin/nginx-agent",
-		"InstallAgentToRunAs":    "nginx-agent will be configured to run as same user",
 		"InstallAgentSuccess":    "NGINX Agent package has been successfully installed.",
 		"InstallAgentStartCmd":   "sudo systemctl start nginx-agent",
 	}
@@ -62,6 +50,19 @@ func TestAgentManualInstallUninstall(t *testing.T) {
 		"AgentDynamicConfigFile": "/etc/nginx-agent/agent-dynamic.conf",
 	}
 
+	// Check the environment variable $PACKAGE_NAME is set
+	require.NotEmpty(t, AGENT_PACKAGE_FILENAME, "Environment variable $PACKAGE_NAME not set")
+
+	testContainer := utils.SetupTestContainerWithoutAgent(t)
+
+	ctx := context.Background()
+	exitCode, osReleaseFileContent, err := testContainer.Exec(ctx, []string{"cat", osReleasePath})
+	assert.NoError(t, err)
+	osReleaseContent, err := io.ReadAll(osReleaseFileContent)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+	assert.NotEmpty(t, osReleaseContent, "os release file empty")
+
 	// Check the file size is less than or equal 20MB
 	absLocalAgentPkgDirPath, err := filepath.Abs("../../../build/")
 	assert.NoError(t, err, "Error finding local agent package build dir")
@@ -72,27 +73,30 @@ func TestAgentManualInstallUninstall(t *testing.T) {
 
 	// Install Agent inside container and record installation time/install output
 	containerAgentPackagePath := getPackagePath(absContainerAgentPackageDir, string(osReleaseContent))
-	installTime, installLog := installAgent(t, testContainer, containerAgentPackagePath, string(osReleaseContent))
+	installTime, installLog, err := installAgent(ctx, testContainer, containerAgentPackagePath, string(osReleaseContent))
+	require.NoError(t, err)
 
 	// Check the install time under 30s
 	assert.LessOrEqual(t, installTime, maxInstallTime)
 
 	// Check install output
-	for log, logMsg := range expectedInstallLogMsgs {
-		if log == "InstallAgentToRunAs" && !nginxIsRunning() {
-			continue // only expected if nginx is installed and running
-		}
+	if nginxIsRunning(ctx, testContainer) {
+		expectedInstallLogMsgs["InstallAgentToRunAs"] = "nginx-agent will be configured to run as same user"
+	}
+
+	for _, logMsg := range expectedInstallLogMsgs {
 		assert.Contains(t, installLog, logMsg)
 	}
 
 	// Check nginx-agent config files were created.
 	for _, path := range expectedAgentPaths {
-		_, err = testContainer.CopyFileFromContainer(context.Background(), path)
+		_, err = testContainer.CopyFileFromContainer(ctx, path)
 		assert.NoError(t, err)
 	}
 
 	// Uninstall the agent package
-	uninstallLog := uninstallAgent(t, testContainer, string(osReleaseContent))
+	uninstallLog, err := uninstallAgent(ctx, testContainer, string(osReleaseContent))
+	require.NoError(t, err)
 
 	// Check uninstall output
 	if strings.HasSuffix(containerAgentPackagePath, "rpm") {
@@ -105,13 +109,13 @@ func TestAgentManualInstallUninstall(t *testing.T) {
 
 	// Check nginx-agent config files were removed.
 	for path := range expectedAgentPaths {
-		_, err = testContainer.CopyFileFromContainer(context.Background(), path)
+		_, err = testContainer.CopyFileFromContainer(ctx, path)
 		assert.Error(t, err)
 	}
 }
 
 // installAgent installs the agent returning total install time and install output
-func installAgent(t *testing.T, container *testcontainers.DockerContainer, agentPackageFilePath, osReleaseContent string) (time.Duration, string) {
+func installAgent(ctx context.Context, container *testcontainers.DockerContainer, agentPackageFilePath, osReleaseContent string) (time.Duration, string, error) {
 	// Get OS to create install cmd
 	installCmd := createInstallCommand(agentPackageFilePath, osReleaseContent)
 
@@ -119,31 +123,34 @@ func installAgent(t *testing.T, container *testcontainers.DockerContainer, agent
 	start := time.Now()
 
 	// Start agent installation and capture install output
-	exitCode, cmdOut, err := container.Exec(context.Background(), installCmd)
-	assert.NoError(t, err)
-	assert.Equal(t, 0, exitCode, "expected exit code of 0")
+	exitCode, cmdOut, err := container.Exec(ctx, installCmd)
+	if err != nil {
+		return time.Since(start), "", err
+	}
+	if exitCode != 0 {
+		return time.Since(start), "", errors.New("expected exit code of 0")
+	}
 
 	stdoutStderr, err := io.ReadAll(cmdOut)
-	assert.NoError(t, err)
-
-	elapsed := time.Since(start)
-
-	return elapsed, string(stdoutStderr)
+	return time.Since(start), string(stdoutStderr), err
 }
 
 // uninstallAgent uninstall the agent returning output
-func uninstallAgent(t *testing.T, container *testcontainers.DockerContainer, osReleaseContent string) string {
+func uninstallAgent(ctx context.Context, container *testcontainers.DockerContainer, osReleaseContent string) (string, error) {
 	// Get OS to create uninstall cmd
 	uninstallCmd := createUninstallCommand(osReleaseContent)
 
 	// Start agent uninstall and capture uninstall output
-	exitCode, cmdOut, err := container.Exec(context.Background(), uninstallCmd)
-	assert.NoError(t, err)
-	assert.Equal(t, 0, exitCode)
+	exitCode, cmdOut, err := container.Exec(ctx, uninstallCmd)
+	if err != nil {
+		return "", err
+	}
+	if exitCode != 0 {
+		return "", errors.New("expected exit code of 0")
+	}
 
 	stdoutStderr, err := io.ReadAll(cmdOut)
-	assert.NoError(t, err)
-	return string(stdoutStderr)
+	return string(stdoutStderr), err
 }
 
 func createInstallCommand(agentPackageFilePath, osReleaseContent string) []string {
@@ -162,17 +169,12 @@ func createUninstallCommand(osReleaseContent string) []string {
 	}
 }
 
-func nginxIsRunning() bool {
-	processes, _ := process.Processes()
-
-	for _, process := range processes {
-		name, _ := process.Name()
-		if name == "nginx" {
-			return true
-		}
+func nginxIsRunning(ctx context.Context, container *testcontainers.DockerContainer) bool {
+	exitCode, _, err := container.Exec(ctx, []string{"pgrep", "nginx"})
+	if err != nil || exitCode != 0 {
+		return false
 	}
-
-	return false
+	return true
 }
 
 func getPackagePath(pkgDir, osReleaseContent string) string {


### PR DESCRIPTION
### Proposed changes

* Install/uninstall test now uses a single context
* Fix: Check for nginx install now checks inside container rather than host

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13

### Testing
Passed 45 runs in a row on my VM 15 * matrix of `rockylinux`, `almalinux`, `ubuntu`(respectively):
```
Run 1 times
ok  	github.com/nginx/agent/test/integration/install	101.312s
ok  	github.com/nginx/agent/test/integration/install	94.418s
ok  	github.com/nginx/agent/test/integration/install	22.826s
Run 2 times
ok  	github.com/nginx/agent/test/integration/install	52.023s
ok  	github.com/nginx/agent/test/integration/install	33.253s
ok  	github.com/nginx/agent/test/integration/install	22.226s
Run 3 times
ok  	github.com/nginx/agent/test/integration/install	48.382s
ok  	github.com/nginx/agent/test/integration/install	31.949s
ok  	github.com/nginx/agent/test/integration/install	22.246s
Run 4 times
ok  	github.com/nginx/agent/test/integration/install	52.999s
ok  	github.com/nginx/agent/test/integration/install	36.730s
ok  	github.com/nginx/agent/test/integration/install	22.432s
Run 5 times
ok  	github.com/nginx/agent/test/integration/install	51.788s
ok  	github.com/nginx/agent/test/integration/install	34.334s
ok  	github.com/nginx/agent/test/integration/install	22.083s
Run 6 times
ok  	github.com/nginx/agent/test/integration/install	100.555s
ok  	github.com/nginx/agent/test/integration/install	92.552s
ok  	github.com/nginx/agent/test/integration/install	22.608s
Run 7 times
ok  	github.com/nginx/agent/test/integration/install	57.978s
ok  	github.com/nginx/agent/test/integration/install	35.227s
ok  	github.com/nginx/agent/test/integration/install	22.208s
Run 8 times
ok  	github.com/nginx/agent/test/integration/install	52.876s
ok  	github.com/nginx/agent/test/integration/install	34.402s
ok  	github.com/nginx/agent/test/integration/install	24.797s
Run 9 times
ok  	github.com/nginx/agent/test/integration/install	57.189s
ok  	github.com/nginx/agent/test/integration/install	32.628s
ok  	github.com/nginx/agent/test/integration/install	21.654s
Run 10 times
ok  	github.com/nginx/agent/test/integration/install	49.162s
ok  	github.com/nginx/agent/test/integration/install	36.552s
ok  	github.com/nginx/agent/test/integration/install	21.823s
Run 11 times
ok  	github.com/nginx/agent/test/integration/install	50.825s
ok  	github.com/nginx/agent/test/integration/install	31.728s
ok  	github.com/nginx/agent/test/integration/install	20.233s
Run 12 times
ok  	github.com/nginx/agent/test/integration/install	51.977s
ok  	github.com/nginx/agent/test/integration/install	29.588s
ok  	github.com/nginx/agent/test/integration/install	20.949s
Run 13 times
ok  	github.com/nginx/agent/test/integration/install	43.217s
ok  	github.com/nginx/agent/test/integration/install	29.618s
ok  	github.com/nginx/agent/test/integration/install	21.690s
Run 14 times
ok  	github.com/nginx/agent/test/integration/install	95.431s
ok  	github.com/nginx/agent/test/integration/install	90.997s
ok  	github.com/nginx/agent/test/integration/install	24.131s
Run 15 times
ok  	github.com/nginx/agent/test/integration/install	102.997s
ok  	github.com/nginx/agent/test/integration/install	93.495s
ok  	github.com/nginx/agent/test/integration/install	23.632s
```
