### PR TITLE
Fix handing of setting access_log off;

### DIFF
--- a/sdk/backoff_test.go
+++ b/sdk/backoff_test.go
@@ -10,7 +10,6 @@ package sdk
 import (
 	"context"
 	"errors"
-
 	"testing"
 	"time"
 

--- a/sdk/certificates.go
+++ b/sdk/certificates.go
@@ -12,7 +12,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 func LoadCertificates(certPath, keyPath string) (*tls.Certificate, *x509.CertPool, error) {
@@ -33,7 +33,7 @@ func LoadCertificates(certPath, keyPath string) (*tls.Certificate, *x509.CertPoo
 }
 
 func LoadCertificate(certPath string) (*x509.Certificate, error) {
-	fileContents, err := ioutil.ReadFile(certPath)
+	fileContents, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/config_apply.go
+++ b/sdk/config_apply.go
@@ -16,10 +16,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nginx/agent/sdk/v2/zip"
+
 	crossplane "github.com/nginxinc/nginx-go-crossplane"
 	log "github.com/sirupsen/logrus"
-
-	"github.com/nginx/agent/sdk/v2/zip"
 )
 
 // ConfigApply facilitates synchronizing the current config against incoming config_apply request. By keeping track

--- a/sdk/config_apply_test.go
+++ b/sdk/config_apply_test.go
@@ -10,7 +10,6 @@ package sdk
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -76,24 +75,24 @@ func TestNewConfigApply(t *testing.T) {
 	require.NoError(t, os.Mkdir(rootDirectory, os.ModePerm))
 
 	rootFile1 := path.Join(rootDirectory, "root1.html")
-	require.NoError(t, ioutil.WriteFile(rootFile1, []byte{}, 0644))
+	require.NoError(t, os.WriteFile(rootFile1, []byte{}, 0644))
 
 	rootFile2 := path.Join(rootDirectory, "root2.html")
-	require.NoError(t, ioutil.WriteFile(rootFile2, []byte{}, 0644))
+	require.NoError(t, os.WriteFile(rootFile2, []byte{}, 0644))
 
 	rootFile3 := path.Join(rootDirectory, "root3.html")
-	require.NoError(t, ioutil.WriteFile(rootFile3, []byte{}, 0644))
+	require.NoError(t, os.WriteFile(rootFile3, []byte{}, 0644))
 
 	emptyConfFile := path.Join(tmpDir, "empty_nginx.conf")
-	require.NoError(t, ioutil.WriteFile(emptyConfFile, []byte{}, 0644))
+	require.NoError(t, os.WriteFile(emptyConfFile, []byte{}, 0644))
 
 	defaultConfFile := path.Join(tmpDir, "default_nginx.conf")
 	defaultConfFileContent := fmt.Sprintf(defaultConfFileContentsString, rootDirectory, rootDirectory)
-	require.NoError(t, ioutil.WriteFile(defaultConfFile, []byte(defaultConfFileContent), 0644))
+	require.NoError(t, os.WriteFile(defaultConfFile, []byte(defaultConfFileContent), 0644))
 
 	confFile := path.Join(tmpDir, "nginx.conf")
 	confFileContent := fmt.Sprintf(confFileContentsString, defaultConfFile)
-	require.NoError(t, ioutil.WriteFile(confFile, []byte(confFileContent), 0644))
+	require.NoError(t, os.WriteFile(confFile, []byte(confFileContent), 0644))
 
 	testCases := []struct {
 		name                string
@@ -178,7 +177,7 @@ func TestConfigApplyMarkAndSave(t *testing.T) {
 	unknownFileUnknownDir := path.Join(tmpDir, "/unknown/unknown.conf")
 	unknownFileUnknownNestedDirs := path.Join(tmpDir, "/unknown/nested/unknown.conf")
 
-	require.NoError(t, ioutil.WriteFile(knownFile, []byte{}, 0644))
+	require.NoError(t, os.WriteFile(knownFile, []byte{}, 0644))
 
 	writer, err := zip.NewWriter("/")
 	require.NoError(t, err)
@@ -250,21 +249,21 @@ func TestConfigApplyCompleteAndRollback(t *testing.T) {
 	require.NoError(t, os.Mkdir(rootDirectory, os.ModePerm))
 
 	rootFile1 := path.Join(rootDirectory, "root1.html")
-	require.NoError(t, ioutil.WriteFile(rootFile1, []byte{}, 0644))
+	require.NoError(t, os.WriteFile(rootFile1, []byte{}, 0644))
 
 	rootFile2 := path.Join(rootDirectory, "root2.html")
-	require.NoError(t, ioutil.WriteFile(rootFile2, []byte{}, 0644))
+	require.NoError(t, os.WriteFile(rootFile2, []byte{}, 0644))
 
 	rootFile3 := path.Join(rootDirectory, "root3.html")
-	require.NoError(t, ioutil.WriteFile(rootFile3, []byte{}, 0644))
+	require.NoError(t, os.WriteFile(rootFile3, []byte{}, 0644))
 
 	defaultConfFile := path.Join(tmpDir, "default_nginx.conf")
 	defaultConfFileContent := fmt.Sprintf(defaultConfFileContentsString, rootDirectory, rootDirectory)
-	require.NoError(t, ioutil.WriteFile(defaultConfFile, []byte(defaultConfFileContent), 0644))
+	require.NoError(t, os.WriteFile(defaultConfFile, []byte(defaultConfFileContent), 0644))
 
 	confFile := path.Join(tmpDir, "nginx.conf")
 	confFileContent := fmt.Sprintf(confFileContentsString, defaultConfFile)
-	require.NoError(t, ioutil.WriteFile(confFile, []byte(confFileContent), 0644))
+	require.NoError(t, os.WriteFile(confFile, []byte(confFileContent), 0644))
 
 	allowedDirectories := map[string]struct{}{tmpDir: {}}
 
@@ -279,7 +278,7 @@ func TestConfigApplyCompleteAndRollback(t *testing.T) {
 	// MarkAndSave an unknown file that does not exist, then create the file afterwards
 	unknownConfFile := path.Join(tmpDir, "unknown.conf")
 	assert.NoError(t, configApply.MarkAndSave(unknownConfFile))
-	assert.NoError(t, ioutil.WriteFile(unknownConfFile, []byte{}, 0644))
+	assert.NoError(t, os.WriteFile(unknownConfFile, []byte{}, 0644))
 
 	// Verify that only root files are deleted
 	assert.NoError(t, configApply.Complete())

--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -810,14 +810,18 @@ func runtimeFromConfigure(configure []string) []string {
 // AccessLogs returns a list of access logs in the config
 func AccessLogs(p *proto.NginxConfig) map[string]string {
 	var found = make(map[string]string)
+
 	for _, accessLog := range p.GetAccessLogs().GetAccessLog() {
-		// check if the access log is readable or not
-		if accessLog.GetReadable() && accessLog.GetName() != "off" {
+		if accessLog.GetName() == "off" {
+			continue
+		}
+
+		if accessLog.GetReadable() {
 			name := strings.Split(accessLog.GetName(), " ")[0]
 			format := accessLog.GetFormat()
 			found[name] = format
 		} else {
-			log.Warnf("NGINX Access log %s is not readable or is disabled. Please make it readable and enabled in order for NGINX metrics to be collected.", accessLog.GetName())
+			log.Warnf("NGINX Access log %s is not readable. Please make it readable in order for NGINX metrics to be collected.", accessLog.GetName())
 		}
 	}
 
@@ -827,14 +831,14 @@ func AccessLogs(p *proto.NginxConfig) map[string]string {
 // ErrorLogs returns a list of error logs in the config
 func ErrorLogs(p *proto.NginxConfig) map[string]string {
 	var found = make(map[string]string)
+
 	for _, errorLog := range p.GetErrorLogs().GetErrorLog() {
-		// check if the error log is readable or not
 		if errorLog.GetReadable() {
 			name := strings.Split(errorLog.GetName(), " ")[0]
 			// In the future, different error log formats will be supported
 			found[name] = ""
 		} else {
-			log.Warnf("NGINX Error log %s is not readable or is disabled. Please make it readable and enabled in order for NGINX metrics to be collected.", errorLog.GetName())
+			log.Warnf("NGINX Error log %s is not readable. Please make it readable in order for NGINX metrics to be collected.", errorLog.GetName())
 		}
 	}
 

--- a/src/core/nginx_test.go
+++ b/src/core/nginx_test.go
@@ -18,12 +18,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/nginx/agent/sdk/v2/proto"
 	"github.com/nginx/agent/sdk/v2/zip"
 	"github.com/nginx/agent/v2/src/core/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const CONF_TEMPLATE = `

--- a/test/integration/vendor/github.com/nginx/agent/sdk/v2/certificates.go
+++ b/test/integration/vendor/github.com/nginx/agent/sdk/v2/certificates.go
@@ -12,7 +12,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 func LoadCertificates(certPath, keyPath string) (*tls.Certificate, *x509.CertPool, error) {
@@ -33,7 +33,7 @@ func LoadCertificates(certPath, keyPath string) (*tls.Certificate, *x509.CertPoo
 }
 
 func LoadCertificate(certPath string) (*x509.Certificate, error) {
-	fileContents, err := ioutil.ReadFile(certPath)
+	fileContents, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/vendor/github.com/nginx/agent/sdk/v2/config_apply.go
+++ b/test/integration/vendor/github.com/nginx/agent/sdk/v2/config_apply.go
@@ -16,10 +16,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nginx/agent/sdk/v2/zip"
+
 	crossplane "github.com/nginxinc/nginx-go-crossplane"
 	log "github.com/sirupsen/logrus"
-
-	"github.com/nginx/agent/sdk/v2/zip"
 )
 
 // ConfigApply facilitates synchronizing the current config against incoming config_apply request. By keeping track

--- a/test/performance/vendor/github.com/nginx/agent/sdk/v2/certificates.go
+++ b/test/performance/vendor/github.com/nginx/agent/sdk/v2/certificates.go
@@ -12,7 +12,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 func LoadCertificates(certPath, keyPath string) (*tls.Certificate, *x509.CertPool, error) {
@@ -33,7 +33,7 @@ func LoadCertificates(certPath, keyPath string) (*tls.Certificate, *x509.CertPoo
 }
 
 func LoadCertificate(certPath string) (*x509.Certificate, error) {
-	fileContents, err := ioutil.ReadFile(certPath)
+	fileContents, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/performance/vendor/github.com/nginx/agent/sdk/v2/config_apply.go
+++ b/test/performance/vendor/github.com/nginx/agent/sdk/v2/config_apply.go
@@ -16,10 +16,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nginx/agent/sdk/v2/zip"
+
 	crossplane "github.com/nginxinc/nginx-go-crossplane"
 	log "github.com/sirupsen/logrus"
-
-	"github.com/nginx/agent/sdk/v2/zip"
 )
 
 // ConfigApply facilitates synchronizing the current config against incoming config_apply request. By keeping track

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
@@ -810,14 +810,18 @@ func runtimeFromConfigure(configure []string) []string {
 // AccessLogs returns a list of access logs in the config
 func AccessLogs(p *proto.NginxConfig) map[string]string {
 	var found = make(map[string]string)
+
 	for _, accessLog := range p.GetAccessLogs().GetAccessLog() {
-		// check if the access log is readable or not
-		if accessLog.GetReadable() && accessLog.GetName() != "off" {
+		if accessLog.GetName() == "off" {
+			continue
+		}
+
+		if accessLog.GetReadable() {
 			name := strings.Split(accessLog.GetName(), " ")[0]
 			format := accessLog.GetFormat()
 			found[name] = format
 		} else {
-			log.Warnf("NGINX Access log %s is not readable or is disabled. Please make it readable and enabled in order for NGINX metrics to be collected.", accessLog.GetName())
+			log.Warnf("NGINX Access log %s is not readable. Please make it readable in order for NGINX metrics to be collected.", accessLog.GetName())
 		}
 	}
 
@@ -827,14 +831,14 @@ func AccessLogs(p *proto.NginxConfig) map[string]string {
 // ErrorLogs returns a list of error logs in the config
 func ErrorLogs(p *proto.NginxConfig) map[string]string {
 	var found = make(map[string]string)
+
 	for _, errorLog := range p.GetErrorLogs().GetErrorLog() {
-		// check if the error log is readable or not
 		if errorLog.GetReadable() {
 			name := strings.Split(errorLog.GetName(), " ")[0]
 			// In the future, different error log formats will be supported
 			found[name] = ""
 		} else {
-			log.Warnf("NGINX Error log %s is not readable or is disabled. Please make it readable and enabled in order for NGINX metrics to be collected.", errorLog.GetName())
+			log.Warnf("NGINX Error log %s is not readable. Please make it readable in order for NGINX metrics to be collected.", errorLog.GetName())
 		}
 	}
 

--- a/vendor/github.com/nginx/agent/sdk/v2/certificates.go
+++ b/vendor/github.com/nginx/agent/sdk/v2/certificates.go
@@ -12,7 +12,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 func LoadCertificates(certPath, keyPath string) (*tls.Certificate, *x509.CertPool, error) {
@@ -33,7 +33,7 @@ func LoadCertificates(certPath, keyPath string) (*tls.Certificate, *x509.CertPoo
 }
 
 func LoadCertificate(certPath string) (*x509.Certificate, error) {
-	fileContents, err := ioutil.ReadFile(certPath)
+	fileContents, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/nginx/agent/sdk/v2/config_apply.go
+++ b/vendor/github.com/nginx/agent/sdk/v2/config_apply.go
@@ -16,10 +16,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nginx/agent/sdk/v2/zip"
+
 	crossplane "github.com/nginxinc/nginx-go-crossplane"
 	log "github.com/sirupsen/logrus"
-
-	"github.com/nginx/agent/sdk/v2/zip"
 )
 
 // ConfigApply facilitates synchronizing the current config against incoming config_apply request. By keeping track


### PR DESCRIPTION
### Proposed changes

Fixes: https://github.com/nginx/agent/issues/184

* Handle special value `"off"` for disabling access logging for a given context. No longer erroneously produces a warning.
* Remove note in logs about disabled [`error_log`](https://nginx.org/en/docs/ngx_core_module.html#error_log). `error_log off;` does not disable error logging, this config produces an `error_log` in a file named `off`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
