### PR TITLE
fix: Pass correct variable for lscpu command to work

### DIFF
--- a/src/core/environment.go
+++ b/src/core/environment.go
@@ -662,7 +662,7 @@ type execShellCommand struct {
 }
 
 func (e execShellCommand) Exec(cmd string, arg ...string) ([]byte, error) {
-	execCmd := exec.Command(name, arg...)
+	execCmd := exec.Command(cmd, arg...)
 	return execCmd.Output()
 }
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/environment.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/environment.go
@@ -662,7 +662,7 @@ type execShellCommand struct {
 }
 
 func (e execShellCommand) Exec(cmd string, arg ...string) ([]byte, error) {
-	execCmd := exec.Command(name, arg...)
+	execCmd := exec.Command(cmd, arg...)
 	return execCmd.Output()
 }
 


### PR DESCRIPTION

### Proposed changes

* The `exec.Command()` function was being passed an incorrect argument instead of the actual command to be executed
* Ran `go test` from within `src/core`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
