### PR TITLE
Update NGINX monitor function to handle monitoring multiple NGINX error logs

### DIFF
--- a/src/plugins/nginx.go
+++ b/src/plugins/nginx.go
@@ -575,7 +575,10 @@ func (n *Nginx) monitor(processInfo []core.Process) error {
 	go n.monitorLogs(errorLogs, logErrorChannel)
 	go n.monitorPids(processInfo, pidsChannel)
 
-	for i := 0; i < (1 + len(errorLogs)); i++ {
+	// Expect to receive one message from the pidsChannel and a message for each NGINX error log file in the logErrorChannel
+	numberOfExpectedMessages := 1 + len(errorLogs)
+
+	for i := 0; i < numberOfExpectedMessages; i++ {
 		select {
 		case err := <-pidsChannel:
 			log.Tracef("message received in pidsChannel: %s", err)

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/nginx.go
@@ -575,7 +575,10 @@ func (n *Nginx) monitor(processInfo []core.Process) error {
 	go n.monitorLogs(errorLogs, logErrorChannel)
 	go n.monitorPids(processInfo, pidsChannel)
 
-	for i := 0; i < (1 + len(errorLogs)); i++ {
+	// Expect to receive one message from the pidsChannel and a message for each NGINX error log file in the logErrorChannel
+	numberOfExpectedMessages := 1 + len(errorLogs)
+
+	for i := 0; i < numberOfExpectedMessages; i++ {
 		select {
 		case err := <-pidsChannel:
 			log.Tracef("message received in pidsChannel: %s", err)


### PR DESCRIPTION
### Proposed changes

If multiple error logs are configured, the NGINX Agent wasn't waiting to get a message in the logErrorChannel for all the error log files. This caused an error in the agent when when it was trying to put a message onto a closed channel. Noe the agent will wait until it received a message for each error log before closing the channel. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
