### PR TITLE
Fix packager script post deinstall.

### DIFF
--- a/scripts/packages/packager/local-entrypoint.sh
+++ b/scripts/packages/packager/local-entrypoint.sh
@@ -13,7 +13,7 @@ mkdir -p /staging/usr/local/etc/rc.d
 cp nginx-agent.conf /staging/usr/local/etc/nginx-agent
 cp scripts/packages/nginx-agent /staging/usr/local/etc/rc.d
 cp scripts/packages/preinstall.sh /staging/+PRE_INSTALL
-cp scripts/packages/postremove.sh /staging/+PRE_DEINSTALL
+cp scripts/packages/postremove.sh /staging/+POST_DEINSTALL
 cp scripts/packages/postinstall.sh /staging/+POST_INSTALL
 cp scripts/packages/plist /staging
 cp build/nginx-agent /staging/usr/local/bin

--- a/scripts/packages/packager/signed-entrypoint.sh
+++ b/scripts/packages/packager/signed-entrypoint.sh
@@ -18,7 +18,7 @@ mkdir -p staging/usr/local/etc/rc.d
 cp nginx-agent.conf staging/usr/local/etc/nginx-agent
 cp scripts/packages/nginx-agent staging/usr/local/etc/rc.d
 cp scripts/packages/preinstall.sh staging/+PRE_INSTALL
-cp scripts/packages/postremove.sh staging/+PRE_DEINSTALL
+cp scripts/packages/postremove.sh staging/+POST_DEINSTALL
 cp scripts/packages/postinstall.sh staging/+POST_INSTALL
 cp scripts/packages/plist staging
 cp build/nginx-agent staging/usr/local/bin


### PR DESCRIPTION
* postremove.sh should be assigned +POST_DEINSTALL literally.

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
