### PR TITLE
Skip CI for docs only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches:
     - 'main'
     - 'release-*'
+    paths-ignore:
+    - "**.md"
+    - "docs/**"
+    - "hugo/**"
   pull_request:
     types:
     - opened


### PR DESCRIPTION
### Proposed changes

* Skips CI for changes to:
  * Hugo docs
  * Markdown/Github docs

### References:
* https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths
* https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-file-paths

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
