### PR TITLE
Close controller before exiting

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func main() {
 			plugins.NewAgentEventMeta(version, strconv.Itoa(os.Getpid()))),
 		)
 
-		handleSignals(ctx, commander, loadedConfig, env, pipe, cancel)
+		handleSignals(ctx, commander, loadedConfig, env, pipe, cancel, controller)
 
 		pipe.Run()
 	})
@@ -119,6 +119,7 @@ func handleSignals(
 	env core.Environment,
 	pipe core.MessagePipeInterface,
 	cancel context.CancelFunc,
+	controller client.Controller,
 ) {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
@@ -134,6 +135,10 @@ func handleSignals(
 				log.Warn("Command channel not configured. Skipping sending AgentStopped event")
 			} else if err := cmder.Send(ctx, client.MessageFromCommand(stopCmd)); err != nil {
 				log.Errorf("Error sending AgentStopped event to command channel: %v", err)
+			}
+
+			if err := controller.Close(); err != nil {
+				log.Errorf("Unable to close controller: %v", err)
 			}
 
 			log.Warn("NGINX Agent exiting")

--- a/sdk/proto/events/event.proto
+++ b/sdk/proto/events/event.proto
@@ -72,7 +72,7 @@ message SecurityViolationEvent {
   reserved 33;
   reserved "ViolationContexts";
 
-  // The name of the NGINX App Protect policy that triggered the security violation 
+  // The name of the NGINX App Protect policy that triggered the security violation
   string PolicyName = 1 [(gogoproto.jsontag) = "policy_name"];
   // The unique NGINX App Protect support ID of the violation, used for tracking purposes
   string SupportID = 2 [(gogoproto.jsontag) = "support_id"];
@@ -102,7 +102,7 @@ message SecurityViolationEvent {
   // The HTTP response status to the request that triggered the security violation
   string ResponseCode = 13 [(gogoproto.jsontag) = "response_code"];
 
-  // The server address of the instance that caught the security violation 
+  // The server address of the instance that caught the security violation
   string ServerAddr = 14 [(gogoproto.jsontag) = "server_addr"];
   // The Virtual Server Name of the instance that caught the security violation
   string VSName = 15 [(gogoproto.jsontag) = "vs_name"];
@@ -110,7 +110,7 @@ message SecurityViolationEvent {
   string RemoteAddr = 16 [(gogoproto.jsontag) = "remote_addr"];
   // The targeted port number by the request that triggered the security violation
   string RemotePort = 17 [(gogoproto.jsontag) = "destination_port"];
-  // The server port of the instance that caught the security violation 
+  // The server port of the instance that caught the security violation
   string ServerPort = 18 [(gogoproto.jsontag) = "server_port"];
 
   // A comma-separated list of all the violations triggered by the request
@@ -125,9 +125,9 @@ message SecurityViolationEvent {
   // A comma-separated list of all the signature CVEs
   string SigCVEs = 23 [(gogoproto.jsontag) = "sig_cves"];
 
-  // The class of the client used to send the request that triggered the security violation 
+  // The class of the client used to send the request that triggered the security violation
   string ClientClass = 24 [(gogoproto.jsontag) = "client_class"];
-  // The application used to send the request that triggered the security violation 
+  // The application used to send the request that triggered the security violation
   string ClientApplication = 25 [(gogoproto.jsontag) = "client_application"];
   // The version of the application used to send the request that triggered the security violation
   string ClientApplicationVersion = 26 [(gogoproto.jsontag) = "client_application_version"];
@@ -146,7 +146,7 @@ message SecurityViolationEvent {
   // Signature name of the bot that sent the request that triggered the security violation
   string BotSignatureName = 32 [(gogoproto.jsontag) = "bot_signature_name"];
 
-  // A list of objects containing descriptive data about all the security violations 
+  // A list of objects containing descriptive data about all the security violations
   repeated ViolationData ViolationsData = 34 [(gogoproto.jsontag) = "violations_data"];
 
   // SystemID of the instance where NGINX is running
@@ -177,7 +177,7 @@ message SignatureData {
 
 // Represents the context data of each violation
 message ContextData {
-  // The name within the context data 
+  // The name within the context data
   string Name = 1 [(gogoproto.jsontag) = "parameter_data_name"];
   // The value within the context data
   string Value = 2 [(gogoproto.jsontag) = "parameter_data_value"];

--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -811,15 +811,15 @@ func runtimeFromConfigure(configure []string) []string {
 func AccessLogs(p *proto.NginxConfig) map[string]string {
 	var found = make(map[string]string)
 	name := ""
-	
+
 	for _, accessLog := range p.GetAccessLogs().GetAccessLog() {
 		name = strings.Split(accessLog.GetName(), " ")[0]
-		
+
 		// check if the access log is readable or not
 		if accessLog.GetReadable() && accessLog.GetName() != "off" {
 			format := accessLog.GetFormat()
 			found[name] = format
-		} else if(!strings.Contains(name, "syslog:")){
+		} else if !strings.Contains(name, "syslog:") {
 			log.Warnf("NGINX Access log %s is not readable or is disabled. Please make it readable and enabled in order for NGINX metrics to be collected.", accessLog.GetName())
 		}
 	}
@@ -831,15 +831,15 @@ func AccessLogs(p *proto.NginxConfig) map[string]string {
 func ErrorLogs(p *proto.NginxConfig) map[string]string {
 	var found = make(map[string]string)
 	name := ""
-	
+
 	for _, errorLog := range p.GetErrorLogs().GetErrorLog() {
 		name = strings.Split(errorLog.GetName(), " ")[0]
-		
+
 		// check if the error log is readable or not
 		if errorLog.GetReadable() {
 			// In the future, different error log formats will be supported
 			found[name] = ""
-		} else if(!strings.Contains(name, "syslog:")){
+		} else if !strings.Contains(name, "syslog:") {
 			log.Warnf("NGINX Error log %s is not readable or is disabled. Please make it readable and enabled in order for NGINX metrics to be collected.", errorLog.GetName())
 		}
 	}

--- a/test/integration/vendor/github.com/nginx/agent/sdk/v2/proto/events/event.proto
+++ b/test/integration/vendor/github.com/nginx/agent/sdk/v2/proto/events/event.proto
@@ -72,7 +72,7 @@ message SecurityViolationEvent {
   reserved 33;
   reserved "ViolationContexts";
 
-  // The name of the NGINX App Protect policy that triggered the security violation 
+  // The name of the NGINX App Protect policy that triggered the security violation
   string PolicyName = 1 [(gogoproto.jsontag) = "policy_name"];
   // The unique NGINX App Protect support ID of the violation, used for tracking purposes
   string SupportID = 2 [(gogoproto.jsontag) = "support_id"];
@@ -102,7 +102,7 @@ message SecurityViolationEvent {
   // The HTTP response status to the request that triggered the security violation
   string ResponseCode = 13 [(gogoproto.jsontag) = "response_code"];
 
-  // The server address of the instance that caught the security violation 
+  // The server address of the instance that caught the security violation
   string ServerAddr = 14 [(gogoproto.jsontag) = "server_addr"];
   // The Virtual Server Name of the instance that caught the security violation
   string VSName = 15 [(gogoproto.jsontag) = "vs_name"];
@@ -110,7 +110,7 @@ message SecurityViolationEvent {
   string RemoteAddr = 16 [(gogoproto.jsontag) = "remote_addr"];
   // The targeted port number by the request that triggered the security violation
   string RemotePort = 17 [(gogoproto.jsontag) = "destination_port"];
-  // The server port of the instance that caught the security violation 
+  // The server port of the instance that caught the security violation
   string ServerPort = 18 [(gogoproto.jsontag) = "server_port"];
 
   // A comma-separated list of all the violations triggered by the request
@@ -125,9 +125,9 @@ message SecurityViolationEvent {
   // A comma-separated list of all the signature CVEs
   string SigCVEs = 23 [(gogoproto.jsontag) = "sig_cves"];
 
-  // The class of the client used to send the request that triggered the security violation 
+  // The class of the client used to send the request that triggered the security violation
   string ClientClass = 24 [(gogoproto.jsontag) = "client_class"];
-  // The application used to send the request that triggered the security violation 
+  // The application used to send the request that triggered the security violation
   string ClientApplication = 25 [(gogoproto.jsontag) = "client_application"];
   // The version of the application used to send the request that triggered the security violation
   string ClientApplicationVersion = 26 [(gogoproto.jsontag) = "client_application_version"];
@@ -146,7 +146,7 @@ message SecurityViolationEvent {
   // Signature name of the bot that sent the request that triggered the security violation
   string BotSignatureName = 32 [(gogoproto.jsontag) = "bot_signature_name"];
 
-  // A list of objects containing descriptive data about all the security violations 
+  // A list of objects containing descriptive data about all the security violations
   repeated ViolationData ViolationsData = 34 [(gogoproto.jsontag) = "violations_data"];
 
   // SystemID of the instance where NGINX is running
@@ -177,7 +177,7 @@ message SignatureData {
 
 // Represents the context data of each violation
 message ContextData {
-  // The name within the context data 
+  // The name within the context data
   string Name = 1 [(gogoproto.jsontag) = "parameter_data_name"];
   // The value within the context data
   string Value = 2 [(gogoproto.jsontag) = "parameter_data_value"];

--- a/test/performance/vendor/github.com/nginx/agent/sdk/v2/proto/events/event.proto
+++ b/test/performance/vendor/github.com/nginx/agent/sdk/v2/proto/events/event.proto
@@ -72,7 +72,7 @@ message SecurityViolationEvent {
   reserved 33;
   reserved "ViolationContexts";
 
-  // The name of the NGINX App Protect policy that triggered the security violation 
+  // The name of the NGINX App Protect policy that triggered the security violation
   string PolicyName = 1 [(gogoproto.jsontag) = "policy_name"];
   // The unique NGINX App Protect support ID of the violation, used for tracking purposes
   string SupportID = 2 [(gogoproto.jsontag) = "support_id"];
@@ -102,7 +102,7 @@ message SecurityViolationEvent {
   // The HTTP response status to the request that triggered the security violation
   string ResponseCode = 13 [(gogoproto.jsontag) = "response_code"];
 
-  // The server address of the instance that caught the security violation 
+  // The server address of the instance that caught the security violation
   string ServerAddr = 14 [(gogoproto.jsontag) = "server_addr"];
   // The Virtual Server Name of the instance that caught the security violation
   string VSName = 15 [(gogoproto.jsontag) = "vs_name"];
@@ -110,7 +110,7 @@ message SecurityViolationEvent {
   string RemoteAddr = 16 [(gogoproto.jsontag) = "remote_addr"];
   // The targeted port number by the request that triggered the security violation
   string RemotePort = 17 [(gogoproto.jsontag) = "destination_port"];
-  // The server port of the instance that caught the security violation 
+  // The server port of the instance that caught the security violation
   string ServerPort = 18 [(gogoproto.jsontag) = "server_port"];
 
   // A comma-separated list of all the violations triggered by the request
@@ -125,9 +125,9 @@ message SecurityViolationEvent {
   // A comma-separated list of all the signature CVEs
   string SigCVEs = 23 [(gogoproto.jsontag) = "sig_cves"];
 
-  // The class of the client used to send the request that triggered the security violation 
+  // The class of the client used to send the request that triggered the security violation
   string ClientClass = 24 [(gogoproto.jsontag) = "client_class"];
-  // The application used to send the request that triggered the security violation 
+  // The application used to send the request that triggered the security violation
   string ClientApplication = 25 [(gogoproto.jsontag) = "client_application"];
   // The version of the application used to send the request that triggered the security violation
   string ClientApplicationVersion = 26 [(gogoproto.jsontag) = "client_application_version"];
@@ -146,7 +146,7 @@ message SecurityViolationEvent {
   // Signature name of the bot that sent the request that triggered the security violation
   string BotSignatureName = 32 [(gogoproto.jsontag) = "bot_signature_name"];
 
-  // A list of objects containing descriptive data about all the security violations 
+  // A list of objects containing descriptive data about all the security violations
   repeated ViolationData ViolationsData = 34 [(gogoproto.jsontag) = "violations_data"];
 
   // SystemID of the instance where NGINX is running
@@ -177,7 +177,7 @@ message SignatureData {
 
 // Represents the context data of each violation
 message ContextData {
-  // The name within the context data 
+  // The name within the context data
   string Name = 1 [(gogoproto.jsontag) = "parameter_data_name"];
   // The value within the context data
   string Value = 2 [(gogoproto.jsontag) = "parameter_data_value"];

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
@@ -811,15 +811,15 @@ func runtimeFromConfigure(configure []string) []string {
 func AccessLogs(p *proto.NginxConfig) map[string]string {
 	var found = make(map[string]string)
 	name := ""
-	
+
 	for _, accessLog := range p.GetAccessLogs().GetAccessLog() {
 		name = strings.Split(accessLog.GetName(), " ")[0]
-		
+
 		// check if the access log is readable or not
 		if accessLog.GetReadable() && accessLog.GetName() != "off" {
 			format := accessLog.GetFormat()
 			found[name] = format
-		} else if(!strings.Contains(name, "syslog:")){
+		} else if !strings.Contains(name, "syslog:") {
 			log.Warnf("NGINX Access log %s is not readable or is disabled. Please make it readable and enabled in order for NGINX metrics to be collected.", accessLog.GetName())
 		}
 	}
@@ -831,15 +831,15 @@ func AccessLogs(p *proto.NginxConfig) map[string]string {
 func ErrorLogs(p *proto.NginxConfig) map[string]string {
 	var found = make(map[string]string)
 	name := ""
-	
+
 	for _, errorLog := range p.GetErrorLogs().GetErrorLog() {
 		name = strings.Split(errorLog.GetName(), " ")[0]
-		
+
 		// check if the error log is readable or not
 		if errorLog.GetReadable() {
 			// In the future, different error log formats will be supported
 			found[name] = ""
-		} else if(!strings.Contains(name, "syslog:")){
+		} else if !strings.Contains(name, "syslog:") {
 			log.Warnf("NGINX Error log %s is not readable or is disabled. Please make it readable and enabled in order for NGINX metrics to be collected.", errorLog.GetName())
 		}
 	}

--- a/vendor/github.com/nginx/agent/sdk/v2/proto/events/event.proto
+++ b/vendor/github.com/nginx/agent/sdk/v2/proto/events/event.proto
@@ -72,7 +72,7 @@ message SecurityViolationEvent {
   reserved 33;
   reserved "ViolationContexts";
 
-  // The name of the NGINX App Protect policy that triggered the security violation 
+  // The name of the NGINX App Protect policy that triggered the security violation
   string PolicyName = 1 [(gogoproto.jsontag) = "policy_name"];
   // The unique NGINX App Protect support ID of the violation, used for tracking purposes
   string SupportID = 2 [(gogoproto.jsontag) = "support_id"];
@@ -102,7 +102,7 @@ message SecurityViolationEvent {
   // The HTTP response status to the request that triggered the security violation
   string ResponseCode = 13 [(gogoproto.jsontag) = "response_code"];
 
-  // The server address of the instance that caught the security violation 
+  // The server address of the instance that caught the security violation
   string ServerAddr = 14 [(gogoproto.jsontag) = "server_addr"];
   // The Virtual Server Name of the instance that caught the security violation
   string VSName = 15 [(gogoproto.jsontag) = "vs_name"];
@@ -110,7 +110,7 @@ message SecurityViolationEvent {
   string RemoteAddr = 16 [(gogoproto.jsontag) = "remote_addr"];
   // The targeted port number by the request that triggered the security violation
   string RemotePort = 17 [(gogoproto.jsontag) = "destination_port"];
-  // The server port of the instance that caught the security violation 
+  // The server port of the instance that caught the security violation
   string ServerPort = 18 [(gogoproto.jsontag) = "server_port"];
 
   // A comma-separated list of all the violations triggered by the request
@@ -125,9 +125,9 @@ message SecurityViolationEvent {
   // A comma-separated list of all the signature CVEs
   string SigCVEs = 23 [(gogoproto.jsontag) = "sig_cves"];
 
-  // The class of the client used to send the request that triggered the security violation 
+  // The class of the client used to send the request that triggered the security violation
   string ClientClass = 24 [(gogoproto.jsontag) = "client_class"];
-  // The application used to send the request that triggered the security violation 
+  // The application used to send the request that triggered the security violation
   string ClientApplication = 25 [(gogoproto.jsontag) = "client_application"];
   // The version of the application used to send the request that triggered the security violation
   string ClientApplicationVersion = 26 [(gogoproto.jsontag) = "client_application_version"];
@@ -146,7 +146,7 @@ message SecurityViolationEvent {
   // Signature name of the bot that sent the request that triggered the security violation
   string BotSignatureName = 32 [(gogoproto.jsontag) = "bot_signature_name"];
 
-  // A list of objects containing descriptive data about all the security violations 
+  // A list of objects containing descriptive data about all the security violations
   repeated ViolationData ViolationsData = 34 [(gogoproto.jsontag) = "violations_data"];
 
   // SystemID of the instance where NGINX is running
@@ -177,7 +177,7 @@ message SignatureData {
 
 // Represents the context data of each violation
 message ContextData {
-  // The name within the context data 
+  // The name within the context data
   string Name = 1 [(gogoproto.jsontag) = "parameter_data_name"];
   // The value within the context data
   string Value = 2 [(gogoproto.jsontag) = "parameter_data_value"];


### PR DESCRIPTION
### Description
nginx-agent, when being stopped by sending SIGTERM (default way of stopping a service), closes all opened streams with RST_STREAM with error code 0x8 (CANCEL) (https://httpwg.org/specs/rfc7540.html#ErrorCodes ), which leads to extra warnings and inability to track actual response codes in nginx proxy layer.

### Proposed changes

With these changes, when the agent will receive the SIGTERM signal the controller will be closed before exiting.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
