### PR TITLE
Change default REST api config

### DIFF
--- a/nginx-agent.conf
+++ b/nginx-agent.conf
@@ -38,4 +38,8 @@ config_dirs: "/etc/nginx:/usr/local/etc/nginx:/usr/share/nginx/modules:/etc/nms"
 
 api:
   # default port for NGINX Agent API, this is for the server configuration of the REST API
-  port: 8081
+  # port: 8081
+  
+  # ~~~ WARNING ~~~ If the computer running NGINX Agent is directly exposed to the
+  # internet, within your environment ensure to check the exposure of this port.
+  # Not checking could result in exposing NGINX Agent to everybody on the internet.


### PR DESCRIPTION
### Proposed changes

Updating the default NGINX Agent config file to provide a warning of REST api port exposure and to comment out port by default 


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
