### PR TITLE
Output mount point in error message

### DIFF
--- a/src/core/metrics/sources/disk.go
+++ b/src/core/metrics/sources/disk.go
@@ -39,7 +39,7 @@ func (c *Disk) Collect(ctx context.Context, wg *sync.WaitGroup, m chan<- *metric
 		usage, err := disk.Usage(part.Mountpoint)
 
 		if err != nil {
-			c.logger.Log(fmt.Sprintf("Failed to get disk metrics, %v", err))
+			c.logger.Log(fmt.Sprintf("Failed to get disk metrics for mount point %s, %v", part.Mountpoint, err))
 			continue
 		}
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/disk.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/disk.go
@@ -39,7 +39,7 @@ func (c *Disk) Collect(ctx context.Context, wg *sync.WaitGroup, m chan<- *metric
 		usage, err := disk.Usage(part.Mountpoint)
 
 		if err != nil {
-			c.logger.Log(fmt.Sprintf("Failed to get disk metrics, %v", err))
+			c.logger.Log(fmt.Sprintf("Failed to get disk metrics for mount point %s, %v", part.Mountpoint, err))
 			continue
 		}
 


### PR DESCRIPTION
Fixes #328

### Proposed changes

This change adds the mount point that failed to the disk usage error message.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [X] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [X] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
