### PR TITLE
Skip warnings on non-file log destinations

### DIFF
--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -813,7 +813,7 @@ func AccessLogs(p *proto.NginxConfig) map[string]string {
 
 	for _, accessLog := range p.GetAccessLogs().GetAccessLog() {
 		if isIgnorableLogType(accessLog.GetName()) {
-      continue
+			continue
 		}
 
 		if accessLog.GetReadable() {
@@ -822,25 +822,28 @@ func AccessLogs(p *proto.NginxConfig) map[string]string {
 			found[name] = format
 		} else {
 			log.Warnf("NGINX Access log file %s is not readable. Please make it readable in order for NGINX metrics to be collected.", accessLog.GetName())
-    }
+		}
 	}
+
+	return found
+}
 
 // ErrorLogs returns a list of error logs in the config
 func ErrorLogs(p *proto.NginxConfig) map[string]string {
 	var found = make(map[string]string)
 
 	for _, errorLog := range p.GetErrorLogs().GetErrorLog() {
-    if isIgnorableLogType(errorLog.GetName()) {
+		if isIgnorableLogType(errorLog.GetName()) {
 			continue
 		}
-    
+
 		if errorLog.GetReadable() {
 			name := strings.Split(errorLog.GetName(), " ")[0]
 			// In the future, different error log formats will be supported
 			found[name] = ""
 		} else {
 			log.Warnf("NGINX Error log file %s is not readable. Please make it readable in order for NGINX metrics to be collected.", errorLog.GetName())
-    }
+		}
 	}
 
 	return found

--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -882,7 +882,7 @@ func getDirectoryMapDiff(currentDirectoryMap []*proto.Directory, incomingDirecto
 // be used for metrics collection
 func isIgnorableLogType(logName string) bool {
 	var name = strings.ToLower(logName)
-	var isIgnorableName = name == "off" || name == "stderr" || name == "stdout"
+	var isIgnorableName = name == "off" || name == "/dev/stderr" || name == "/dev/stdout" || name == "/dev/null"
 	var isSyslog = strings.HasPrefix(name, "syslog:")
 	return isIgnorableName || isSyslog
 }

--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -810,7 +810,6 @@ func runtimeFromConfigure(configure []string) []string {
 // AccessLogs returns a list of access logs in the config
 func AccessLogs(p *proto.NginxConfig) map[string]string {
 	var found = make(map[string]string)
-
 	for _, accessLog := range p.GetAccessLogs().GetAccessLog() {
 		if isIgnorableLogType(accessLog.GetName()) {
 			continue
@@ -821,7 +820,7 @@ func AccessLogs(p *proto.NginxConfig) map[string]string {
 			format := accessLog.GetFormat()
 			found[name] = format
 		} else {
-			log.Warnf("NGINX Access log file %s is not readable. Please make it readable in order for NGINX metrics to be collected.", accessLog.GetName())
+			log.Warnf("NGINX Access log %s is not readable or is disabled. Please make it readable and enabled in order for NGINX metrics to be collected.", accessLog.GetName())
 		}
 	}
 
@@ -842,7 +841,7 @@ func ErrorLogs(p *proto.NginxConfig) map[string]string {
 			// In the future, different error log formats will be supported
 			found[name] = ""
 		} else {
-			log.Warnf("NGINX Error log file %s is not readable. Please make it readable in order for NGINX metrics to be collected.", errorLog.GetName())
+			log.Warnf("NGINX Error log %s is not readable or is disabled. Please make it readable and enabled in order for NGINX metrics to be collected.", errorLog.GetName())
 		}
 	}
 

--- a/src/core/nginx_test.go
+++ b/src/core/nginx_test.go
@@ -979,3 +979,419 @@ func TestNginxBinaryType_validateConfigCheckResponse(t *testing.T) {
 		})
 	}
 }
+
+func TestAccessLog(t *testing.T) {
+	type testDef struct {
+		name     string
+		config   *proto.NginxConfig
+		expected map[string]string
+	}
+
+	// no test case for process lookup, that would require running nginx or proc somewhere
+	for _, test := range []testDef{
+		{ 
+			name: "access logs not set", 
+			config: &proto.NginxConfig{ AccessLogs: &proto.AccessLogs{AccessLog: make([]*proto.AccessLog, 0)} },
+			expected: map[string]string{},
+		},
+		{ 
+			name: "access logs set", 
+			config: &proto.NginxConfig{ 
+				AccessLogs: &proto.AccessLogs{
+					AccessLog: []*proto.AccessLog{
+						{
+							Name:        "/tmp/testdata/logs/access2.log",
+							Format:      "",
+							Permissions: "0644",
+							Readable:    true,
+						},
+					},
+				},
+			},
+			expected: map[string]string{"/tmp/testdata/logs/access2.log": ""},
+		},
+		{ 
+			name: "access logs set not readable", 
+			config: &proto.NginxConfig{ 
+				AccessLogs: &proto.AccessLogs{
+					AccessLog: []*proto.AccessLog{
+						{
+							Name:        "/tmp/testdata/logs/access2.log",
+							Format:      "",
+							Permissions: "0644",
+							Readable:    false,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "access logs syslog", 
+			config: &proto.NginxConfig{ 
+				AccessLogs: &proto.AccessLogs{
+					AccessLog: []*proto.AccessLog{
+						{
+							Name:        "syslog:server=unix:/var/log/nginx.sock,nohostname;",
+							Format:      "",
+							Permissions: "0644",
+							Readable:    true,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "access logs syslog not readable",
+			config: &proto.NginxConfig{ 
+				AccessLogs: &proto.AccessLogs{
+					AccessLog: []*proto.AccessLog{
+						{
+							Name:        "syslog:server=unix:/var/log/nginx.sock,nohostname;",
+							Format:      "",
+							Permissions: "0644",
+							Readable:    false,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "access logs off",
+			config: &proto.NginxConfig{ 
+				AccessLogs: &proto.AccessLogs{
+					AccessLog: []*proto.AccessLog{
+						{
+							Name:        "off",
+							Format:      "",
+							Permissions: "0644",
+							Readable:    true,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "access logs off not readable",
+			config: &proto.NginxConfig{ 
+				AccessLogs: &proto.AccessLogs{
+					AccessLog: []*proto.AccessLog{
+						{
+							Name:        "off",
+							Format:      "",
+							Permissions: "0644",
+							Readable:    false,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "access logs dev null",
+			config: &proto.NginxConfig{ 
+				AccessLogs: &proto.AccessLogs{
+					AccessLog: []*proto.AccessLog{
+						{
+							Name:        "/dev/null",
+							Format:      "",
+							Permissions: "0644",
+							Readable:    true,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "access logs dev null not readable",
+			config: &proto.NginxConfig{ 
+				AccessLogs: &proto.AccessLogs{
+					AccessLog: []*proto.AccessLog{
+						{
+							Name:        "/dev/null",
+							Format:      "",
+							Permissions: "0644",
+							Readable:    false,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "access logs dev stdout",
+			config: &proto.NginxConfig{ 
+				AccessLogs: &proto.AccessLogs{
+					AccessLog: []*proto.AccessLog{
+						{
+							Name:        "/dev/stdout",
+							Format:      "",
+							Permissions: "0644",
+							Readable:    true,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "access logs dev stdout not readable",
+			config: &proto.NginxConfig{ 
+				AccessLogs: &proto.AccessLogs{
+					AccessLog: []*proto.AccessLog{
+						{
+							Name:        "/dev/stdout",
+							Format:      "",
+							Permissions: "0644",
+							Readable:    false,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "access logs dev stderr",
+			config: &proto.NginxConfig{ 
+				AccessLogs: &proto.AccessLogs{
+					AccessLog: []*proto.AccessLog{
+						{
+							Name:        "/dev/stderr",
+							Format:      "",
+							Permissions: "0644",
+							Readable:    true,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "access logs dev stderr not readable",
+			config: &proto.NginxConfig{ 
+				AccessLogs: &proto.AccessLogs{
+					AccessLog: []*proto.AccessLog{
+						{
+							Name:        "/dev/stderr",
+							Format:      "",
+							Permissions: "0644",
+							Readable:    false,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+	} {
+		t.Run(test.name, func(tt *testing.T) {
+			logs := AccessLogs(test.config)
+			assert.Equal(tt, test.expected, logs)
+		})
+	}
+}
+
+func TestErrorLog(t *testing.T) {
+	type testDef struct {
+		name     string
+		config   *proto.NginxConfig
+		expected map[string]string
+	}
+
+	// no test case for process lookup, that would require running nginx or proc somewhere
+	for _, test := range []testDef{
+		{ 
+			name: "error logs not set", 
+			config: &proto.NginxConfig{ ErrorLogs: &proto.ErrorLogs{ErrorLog: make([]*proto.ErrorLog, 0)} },
+			expected: map[string]string{},
+		},
+		{ 
+			name: "error logs set", 
+			config: &proto.NginxConfig{ 
+				ErrorLogs: &proto.ErrorLogs{
+					ErrorLog: []*proto.ErrorLog{
+						{
+							Name:        "/tmp/testdata/logs/access2.log",
+							Permissions: "0644",
+							Readable:    true,
+						},
+					},
+				},
+			},
+			expected: map[string]string{"/tmp/testdata/logs/access2.log": ""},
+		},
+		{ 
+			name: "error logs set not readable", 
+			config: &proto.NginxConfig{ 
+				ErrorLogs: &proto.ErrorLogs{
+					ErrorLog: []*proto.ErrorLog{
+						{
+							Name:        "/tmp/testdata/logs/access2.log",
+							Permissions: "0644",
+							Readable:    false,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "error logs syslog", 
+			config: &proto.NginxConfig{ 
+				ErrorLogs: &proto.ErrorLogs{
+					ErrorLog: []*proto.ErrorLog{
+						{
+							Name:        "syslog:server=unix:/var/log/nginx.sock,nohostname;",
+							Permissions: "0644",
+							Readable:    true,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "error logs syslog not readable",
+			config: &proto.NginxConfig{ 
+				ErrorLogs: &proto.ErrorLogs{
+					ErrorLog: []*proto.ErrorLog{
+						{
+							Name:        "syslog:server=unix:/var/log/nginx.sock,nohostname;",
+							Permissions: "0644",
+							Readable:    false,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "error logs off",
+			config: &proto.NginxConfig{ 
+				ErrorLogs: &proto.ErrorLogs{
+					ErrorLog: []*proto.ErrorLog{
+						{
+							Name:        "off",
+							Permissions: "0644",
+							Readable:    true,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "error logs off not readable",
+			config: &proto.NginxConfig{ 
+				ErrorLogs: &proto.ErrorLogs{
+					ErrorLog: []*proto.ErrorLog{
+						{
+							Name:        "off",
+							Permissions: "0644",
+							Readable:    false,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "error logs dev null",
+			config: &proto.NginxConfig{ 
+				ErrorLogs: &proto.ErrorLogs{
+					ErrorLog: []*proto.ErrorLog{
+						{
+							Name:        "/dev/null",
+							Permissions: "0644",
+							Readable:    true,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "error logs dev null not readable",
+			config: &proto.NginxConfig{ 
+				ErrorLogs: &proto.ErrorLogs{
+					ErrorLog: []*proto.ErrorLog{
+						{
+							Name:        "/dev/null",
+							Permissions: "0644",
+							Readable:    false,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "error logs dev stdout",
+			config: &proto.NginxConfig{ 
+				ErrorLogs: &proto.ErrorLogs{
+					ErrorLog: []*proto.ErrorLog{
+						{
+							Name:        "/dev/stdout",
+							Permissions: "0644",
+							Readable:    true,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "error logs dev stdout not readable",
+			config: &proto.NginxConfig{ 
+				ErrorLogs: &proto.ErrorLogs{
+					ErrorLog: []*proto.ErrorLog{
+						{
+							Name:        "/dev/stdout",
+							Permissions: "0644",
+							Readable:    false,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "error logs dev stderr",
+			config: &proto.NginxConfig{ 
+				ErrorLogs: &proto.ErrorLogs{
+					ErrorLog: []*proto.ErrorLog{
+						{
+							Name:        "/dev/stderr",
+							Permissions: "0644",
+							Readable:    true,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{ 
+			name: "error logs dev stderr not readable",
+			config: &proto.NginxConfig{ 
+				ErrorLogs: &proto.ErrorLogs{
+					ErrorLog: []*proto.ErrorLog{
+						{
+							Name:        "/dev/stderr",
+							Permissions: "0644",
+							Readable:    false,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+	} {
+		t.Run(test.name, func(tt *testing.T) {
+			logs := ErrorLogs(test.config)
+			assert.Equal(tt, test.expected, logs)
+		})
+	}
+}

--- a/src/core/nginx_test.go
+++ b/src/core/nginx_test.go
@@ -989,14 +989,14 @@ func TestAccessLog(t *testing.T) {
 
 	// no test case for process lookup, that would require running nginx or proc somewhere
 	for _, test := range []testDef{
-		{ 
-			name: "access logs not set", 
-			config: &proto.NginxConfig{ AccessLogs: &proto.AccessLogs{AccessLog: make([]*proto.AccessLog, 0)} },
+		{
+			name:     "access logs not set",
+			config:   &proto.NginxConfig{AccessLogs: &proto.AccessLogs{AccessLog: make([]*proto.AccessLog, 0)}},
 			expected: map[string]string{},
 		},
-		{ 
-			name: "access logs set", 
-			config: &proto.NginxConfig{ 
+		{
+			name: "access logs set",
+			config: &proto.NginxConfig{
 				AccessLogs: &proto.AccessLogs{
 					AccessLog: []*proto.AccessLog{
 						{
@@ -1010,9 +1010,9 @@ func TestAccessLog(t *testing.T) {
 			},
 			expected: map[string]string{"/tmp/testdata/logs/access2.log": ""},
 		},
-		{ 
-			name: "access logs set not readable", 
-			config: &proto.NginxConfig{ 
+		{
+			name: "access logs set not readable",
+			config: &proto.NginxConfig{
 				AccessLogs: &proto.AccessLogs{
 					AccessLog: []*proto.AccessLog{
 						{
@@ -1026,9 +1026,9 @@ func TestAccessLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
-			name: "access logs syslog", 
-			config: &proto.NginxConfig{ 
+		{
+			name: "access logs syslog",
+			config: &proto.NginxConfig{
 				AccessLogs: &proto.AccessLogs{
 					AccessLog: []*proto.AccessLog{
 						{
@@ -1042,9 +1042,9 @@ func TestAccessLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "access logs syslog not readable",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				AccessLogs: &proto.AccessLogs{
 					AccessLog: []*proto.AccessLog{
 						{
@@ -1058,9 +1058,9 @@ func TestAccessLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "access logs off",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				AccessLogs: &proto.AccessLogs{
 					AccessLog: []*proto.AccessLog{
 						{
@@ -1074,9 +1074,9 @@ func TestAccessLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "access logs off not readable",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				AccessLogs: &proto.AccessLogs{
 					AccessLog: []*proto.AccessLog{
 						{
@@ -1090,9 +1090,9 @@ func TestAccessLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "access logs dev null",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				AccessLogs: &proto.AccessLogs{
 					AccessLog: []*proto.AccessLog{
 						{
@@ -1106,9 +1106,9 @@ func TestAccessLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "access logs dev null not readable",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				AccessLogs: &proto.AccessLogs{
 					AccessLog: []*proto.AccessLog{
 						{
@@ -1122,9 +1122,9 @@ func TestAccessLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "access logs dev stdout",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				AccessLogs: &proto.AccessLogs{
 					AccessLog: []*proto.AccessLog{
 						{
@@ -1138,9 +1138,9 @@ func TestAccessLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "access logs dev stdout not readable",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				AccessLogs: &proto.AccessLogs{
 					AccessLog: []*proto.AccessLog{
 						{
@@ -1154,9 +1154,9 @@ func TestAccessLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "access logs dev stderr",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				AccessLogs: &proto.AccessLogs{
 					AccessLog: []*proto.AccessLog{
 						{
@@ -1170,9 +1170,9 @@ func TestAccessLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "access logs dev stderr not readable",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				AccessLogs: &proto.AccessLogs{
 					AccessLog: []*proto.AccessLog{
 						{
@@ -1203,14 +1203,14 @@ func TestErrorLog(t *testing.T) {
 
 	// no test case for process lookup, that would require running nginx or proc somewhere
 	for _, test := range []testDef{
-		{ 
-			name: "error logs not set", 
-			config: &proto.NginxConfig{ ErrorLogs: &proto.ErrorLogs{ErrorLog: make([]*proto.ErrorLog, 0)} },
+		{
+			name:     "error logs not set",
+			config:   &proto.NginxConfig{ErrorLogs: &proto.ErrorLogs{ErrorLog: make([]*proto.ErrorLog, 0)}},
 			expected: map[string]string{},
 		},
-		{ 
-			name: "error logs set", 
-			config: &proto.NginxConfig{ 
+		{
+			name: "error logs set",
+			config: &proto.NginxConfig{
 				ErrorLogs: &proto.ErrorLogs{
 					ErrorLog: []*proto.ErrorLog{
 						{
@@ -1223,9 +1223,9 @@ func TestErrorLog(t *testing.T) {
 			},
 			expected: map[string]string{"/tmp/testdata/logs/access2.log": ""},
 		},
-		{ 
-			name: "error logs set not readable", 
-			config: &proto.NginxConfig{ 
+		{
+			name: "error logs set not readable",
+			config: &proto.NginxConfig{
 				ErrorLogs: &proto.ErrorLogs{
 					ErrorLog: []*proto.ErrorLog{
 						{
@@ -1238,9 +1238,9 @@ func TestErrorLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
-			name: "error logs syslog", 
-			config: &proto.NginxConfig{ 
+		{
+			name: "error logs syslog",
+			config: &proto.NginxConfig{
 				ErrorLogs: &proto.ErrorLogs{
 					ErrorLog: []*proto.ErrorLog{
 						{
@@ -1253,9 +1253,9 @@ func TestErrorLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "error logs syslog not readable",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				ErrorLogs: &proto.ErrorLogs{
 					ErrorLog: []*proto.ErrorLog{
 						{
@@ -1268,9 +1268,9 @@ func TestErrorLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "error logs off",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				ErrorLogs: &proto.ErrorLogs{
 					ErrorLog: []*proto.ErrorLog{
 						{
@@ -1283,9 +1283,9 @@ func TestErrorLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "error logs off not readable",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				ErrorLogs: &proto.ErrorLogs{
 					ErrorLog: []*proto.ErrorLog{
 						{
@@ -1298,9 +1298,9 @@ func TestErrorLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "error logs dev null",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				ErrorLogs: &proto.ErrorLogs{
 					ErrorLog: []*proto.ErrorLog{
 						{
@@ -1313,9 +1313,9 @@ func TestErrorLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "error logs dev null not readable",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				ErrorLogs: &proto.ErrorLogs{
 					ErrorLog: []*proto.ErrorLog{
 						{
@@ -1328,9 +1328,9 @@ func TestErrorLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "error logs dev stdout",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				ErrorLogs: &proto.ErrorLogs{
 					ErrorLog: []*proto.ErrorLog{
 						{
@@ -1343,9 +1343,9 @@ func TestErrorLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "error logs dev stdout not readable",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				ErrorLogs: &proto.ErrorLogs{
 					ErrorLog: []*proto.ErrorLog{
 						{
@@ -1358,9 +1358,9 @@ func TestErrorLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "error logs dev stderr",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				ErrorLogs: &proto.ErrorLogs{
 					ErrorLog: []*proto.ErrorLog{
 						{
@@ -1373,9 +1373,9 @@ func TestErrorLog(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
-		{ 
+		{
 			name: "error logs dev stderr not readable",
-			config: &proto.NginxConfig{ 
+			config: &proto.NginxConfig{
 				ErrorLogs: &proto.ErrorLogs{
 					ErrorLog: []*proto.ErrorLog{
 						{

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
@@ -813,7 +813,7 @@ func AccessLogs(p *proto.NginxConfig) map[string]string {
 
 	for _, accessLog := range p.GetAccessLogs().GetAccessLog() {
 		if isIgnorableLogType(accessLog.GetName()) {
-      continue
+			continue
 		}
 
 		if accessLog.GetReadable() {
@@ -822,25 +822,28 @@ func AccessLogs(p *proto.NginxConfig) map[string]string {
 			found[name] = format
 		} else {
 			log.Warnf("NGINX Access log file %s is not readable. Please make it readable in order for NGINX metrics to be collected.", accessLog.GetName())
-    }
+		}
 	}
+
+	return found
+}
 
 // ErrorLogs returns a list of error logs in the config
 func ErrorLogs(p *proto.NginxConfig) map[string]string {
 	var found = make(map[string]string)
 
 	for _, errorLog := range p.GetErrorLogs().GetErrorLog() {
-    if isIgnorableLogType(errorLog.GetName()) {
+		if isIgnorableLogType(errorLog.GetName()) {
 			continue
 		}
-    
+
 		if errorLog.GetReadable() {
 			name := strings.Split(errorLog.GetName(), " ")[0]
 			// In the future, different error log formats will be supported
 			found[name] = ""
 		} else {
 			log.Warnf("NGINX Error log file %s is not readable. Please make it readable in order for NGINX metrics to be collected.", errorLog.GetName())
-    }
+		}
 	}
 
 	return found

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
@@ -882,7 +882,7 @@ func getDirectoryMapDiff(currentDirectoryMap []*proto.Directory, incomingDirecto
 // be used for metrics collection
 func isIgnorableLogType(logName string) bool {
 	var name = strings.ToLower(logName)
-	var isIgnorableName = name == "off" || name == "stderr" || name == "stdout"
+	var isIgnorableName = name == "off" || name == "/dev/stderr" || name == "/dev/stdout" || name == "/dev/null"
 	var isSyslog = strings.HasPrefix(name, "syslog:")
 	return isIgnorableName || isSyslog
 }

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
@@ -810,7 +810,6 @@ func runtimeFromConfigure(configure []string) []string {
 // AccessLogs returns a list of access logs in the config
 func AccessLogs(p *proto.NginxConfig) map[string]string {
 	var found = make(map[string]string)
-
 	for _, accessLog := range p.GetAccessLogs().GetAccessLog() {
 		if isIgnorableLogType(accessLog.GetName()) {
 			continue
@@ -821,7 +820,7 @@ func AccessLogs(p *proto.NginxConfig) map[string]string {
 			format := accessLog.GetFormat()
 			found[name] = format
 		} else {
-			log.Warnf("NGINX Access log file %s is not readable. Please make it readable in order for NGINX metrics to be collected.", accessLog.GetName())
+			log.Warnf("NGINX Access log %s is not readable or is disabled. Please make it readable and enabled in order for NGINX metrics to be collected.", accessLog.GetName())
 		}
 	}
 
@@ -842,7 +841,7 @@ func ErrorLogs(p *proto.NginxConfig) map[string]string {
 			// In the future, different error log formats will be supported
 			found[name] = ""
 		} else {
-			log.Warnf("NGINX Error log file %s is not readable. Please make it readable in order for NGINX metrics to be collected.", errorLog.GetName())
+			log.Warnf("NGINX Error log %s is not readable or is disabled. Please make it readable and enabled in order for NGINX metrics to be collected.", errorLog.GetName())
 		}
 	}
 


### PR DESCRIPTION
Fixes #185

### Proposed changes

This change suppresses the warning messages emitted when nginx is configured to output logs to `STDOUT`, `STDERR`, or syslog.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [X] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [X] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
