### PR TITLE
fix: fix Linux default network interface parsing

### DIFF
--- a/src/core/network/network.go
+++ b/src/core/network/network.go
@@ -292,20 +292,21 @@ func parseToLinuxRouteStruct(output []byte) (routeStruct, error) {
 	const (
 		destinationField = 1 // field containing hex destination address
 	)
-	lineNumber := 0
 	scanner := bufio.NewScanner(bytes.NewReader(output))
 
 	// Skip header line
 	if !scanner.Scan() {
-		return routeStruct{}, errors.New("Invalid linux route file")
+		if scanner.Err() == nil {
+			return routeStruct{}, errors.New("invalid linux route file: no header line")
+		} else {
+			return routeStruct{}, fmt.Errorf("invalid linux route file: %w", scanner.Err())
+		}
 	}
+
+	lineNumber := 0
 
 	for scanner.Scan() {
 		lineNumber++
-		if lineNumber == 1 {
-			// Skip header line.
-			continue
-		}
 		row := scanner.Text()
 		tokens := strings.Fields(strings.TrimSpace(row))
 		if len(tokens) < 11 {
@@ -325,25 +326,28 @@ func parseToLinuxRouteStruct(output []byte) (routeStruct, error) {
 		}
 
 		// The default interface is the one that's 0
-		if destination != 0 {
-			continue
+		if destination == 0 {
+			return routeStruct{
+				Iface:       tokens[0],
+				Destination: tokens[1],
+				Gateway:     tokens[2],
+				Flags:       tokens[3],
+				RefCnt:      tokens[4],
+				Use:         tokens[5],
+				Metric:      tokens[6],
+				Mask:        tokens[7],
+				MTU:         tokens[8],
+				Window:      tokens[9],
+				IRTT:        tokens[10],
+			}, nil
 		}
-
-		return routeStruct{
-			Iface:       tokens[0],
-			Destination: tokens[1],
-			Gateway:     tokens[2],
-			Flags:       tokens[3],
-			RefCnt:      tokens[4],
-			Use:         tokens[5],
-			Metric:      tokens[6],
-			Mask:        tokens[7],
-			MTU:         tokens[8],
-			Window:      tokens[9],
-			IRTT:        tokens[10],
-		}, nil
 	}
-	return routeStruct{}, errors.New("interface with default destination not found")
+
+	if scanner.Err() == nil {
+		return routeStruct{}, errors.New("interface with default destination not found")
+	} else {
+		return routeStruct{}, fmt.Errorf("invalid linux route file: %w", scanner.Err())
+	}
 }
 
 func ipv6ToStr(ip []byte) string {

--- a/src/core/network/network_test.go
+++ b/src/core/network/network_test.go
@@ -21,8 +21,7 @@ func TestParseToLinuxRouteStruct(t *testing.T) {
 		err      error
 	}{
 		{
-			input: []byte(`
-			Iface   Destination     Gateway         Flags   RefCnt  Use     Metric  Mask            MTU     Window  IRTT                                                       
+			input: []byte(`Iface   Destination     Gateway         Flags   RefCnt  Use     Metric  Mask            MTU     Window  IRTT                                                       
 			enp0s3  0002000A        00000000        0001    0       0       0       00FFFFFF        0       0       0                                                                             
 			enp0s3  0202000A        00000000        0005    0       0       100     FFFFFFFF        0       0       0                                                                           
 			enp0s3  00000000        0202000A        0003    0       0       100     00000000        0       0       0                                                                        
@@ -44,15 +43,14 @@ func TestParseToLinuxRouteStruct(t *testing.T) {
 			err: nil,
 		},
 		{
-			input: []byte(`
-			Iface   Destination     Gateway         Flags   RefCnt  Use     Metric  Mask            MTU     Window  IRTT`),
+			input:    []byte(`Iface   Destination     Gateway         Flags   RefCnt  Use     Metric  Mask            MTU     Window  IRTT`),
 			expected: routeStruct{},
 			err:      errors.New("interface with default destination not found"),
 		},
 		{
 			input:    []byte(``),
 			expected: routeStruct{},
-			err:      errors.New("Invalid linux route file"),
+			err:      errors.New("invalid linux route file: no header line"),
 		},
 	}
 	for _, test := range tests {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/network/network.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/network/network.go
@@ -292,20 +292,21 @@ func parseToLinuxRouteStruct(output []byte) (routeStruct, error) {
 	const (
 		destinationField = 1 // field containing hex destination address
 	)
-	lineNumber := 0
 	scanner := bufio.NewScanner(bytes.NewReader(output))
 
 	// Skip header line
 	if !scanner.Scan() {
-		return routeStruct{}, errors.New("Invalid linux route file")
+		if scanner.Err() == nil {
+			return routeStruct{}, errors.New("invalid linux route file: no header line")
+		} else {
+			return routeStruct{}, fmt.Errorf("invalid linux route file: %w", scanner.Err())
+		}
 	}
+
+	lineNumber := 0
 
 	for scanner.Scan() {
 		lineNumber++
-		if lineNumber == 1 {
-			// Skip header line.
-			continue
-		}
 		row := scanner.Text()
 		tokens := strings.Fields(strings.TrimSpace(row))
 		if len(tokens) < 11 {
@@ -325,25 +326,28 @@ func parseToLinuxRouteStruct(output []byte) (routeStruct, error) {
 		}
 
 		// The default interface is the one that's 0
-		if destination != 0 {
-			continue
+		if destination == 0 {
+			return routeStruct{
+				Iface:       tokens[0],
+				Destination: tokens[1],
+				Gateway:     tokens[2],
+				Flags:       tokens[3],
+				RefCnt:      tokens[4],
+				Use:         tokens[5],
+				Metric:      tokens[6],
+				Mask:        tokens[7],
+				MTU:         tokens[8],
+				Window:      tokens[9],
+				IRTT:        tokens[10],
+			}, nil
 		}
-
-		return routeStruct{
-			Iface:       tokens[0],
-			Destination: tokens[1],
-			Gateway:     tokens[2],
-			Flags:       tokens[3],
-			RefCnt:      tokens[4],
-			Use:         tokens[5],
-			Metric:      tokens[6],
-			Mask:        tokens[7],
-			MTU:         tokens[8],
-			Window:      tokens[9],
-			IRTT:        tokens[10],
-		}, nil
 	}
-	return routeStruct{}, errors.New("interface with default destination not found")
+
+	if scanner.Err() == nil {
+		return routeStruct{}, errors.New("interface with default destination not found")
+	} else {
+		return routeStruct{}, fmt.Errorf("invalid linux route file: %w", scanner.Err())
+	}
 }
 
 func ipv6ToStr(ip []byte) string {


### PR DESCRIPTION
Fixes #317

This fix resolves a problem where the header line of /proc/net/route is skipped twice when running on Linux. This change also adds error checking to the Scanner performing the parsing operation.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [X] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [X] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
