### PR TITLE
chore: update deprecated API calls

### DIFF
--- a/sdk/grpc/grpc.go
+++ b/sdk/grpc/grpc.go
@@ -12,7 +12,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
@@ -152,7 +152,7 @@ func appendRootCAs(tlsConfig *tls.Config, caFile string) error {
 		return nil
 	}
 
-	ca, err := ioutil.ReadFile(caFile)
+	ca, err := os.ReadFile(caFile)
 	if err != nil {
 		return fmt.Errorf("could not read CA file (%s): %w", caFile, err)
 	}

--- a/src/core/config/commands.go
+++ b/src/core/config/commands.go
@@ -55,7 +55,7 @@ $ nginx-agent completion fish > ~/.config/fish/completions/nginx-agent.fish
 `,
 	DisableFlagsInUseLine: true,
 	ValidArgs:             []string{"bash", "zsh", "fish"},
-	Args:                  cobra.ExactValidArgs(1),
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
 

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -9,7 +9,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -251,7 +250,7 @@ func UpdateAgentConfig(systemId string, updateTags []string, updateFeatures []st
 
 	updatedConfBytes = append([]byte(dynamicConfigUsageComment), updatedConfBytes...)
 
-	err = ioutil.WriteFile(dynamicCfgPath, updatedConfBytes, 0)
+	err = os.WriteFile(dynamicCfgPath, updatedConfBytes, 0)
 	if err != nil {
 		return false, err
 	}

--- a/src/core/environment_test.go
+++ b/src/core/environment_test.go
@@ -10,7 +10,6 @@ package core
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -926,7 +925,7 @@ func TestGetContainerID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mountInfoFile, err := ioutil.TempFile(os.TempDir(), "mountInfo-")
+			mountInfoFile, err := os.CreateTemp(os.TempDir(), "mountInfo-")
 			if err != nil {
 				t.Fatalf("Cannot create temporary file: %v", err)
 			}
@@ -1012,7 +1011,7 @@ func TestCGroupV1Check(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mountInfoFile, err := ioutil.TempFile(os.TempDir(), "cGroupV1Check-")
+			mountInfoFile, err := os.CreateTemp(os.TempDir(), "cGroupV1Check-")
 			if err != nil {
 				t.Fatalf("Cannot create temporary file: %v", err)
 			}

--- a/src/core/network/network.go
+++ b/src/core/network/network.go
@@ -12,7 +12,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -191,7 +191,7 @@ func getDefaultNetworkInterfaceCrossPlatform() (string, error) {
 		}
 		defer f.Close()
 
-		output, err := ioutil.ReadAll(f)
+		output, err := io.ReadAll(f)
 		if err != nil {
 			return "", fmt.Errorf("Can't read contents of %s", linuxFile)
 		}

--- a/src/extensions/nginx-app-protect/nap/attack_signatures.go
+++ b/src/extensions/nginx-app-protect/nap/attack_signatures.go
@@ -9,7 +9,7 @@ package nap
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/nginx/agent/v2/src/core"
@@ -30,7 +30,7 @@ func getAttackSignaturesVersion(versionFile string) (string, error) {
 	}
 
 	// Get the version bytes
-	versionBytes, err := ioutil.ReadFile(versionFile)
+	versionBytes, err := os.ReadFile(versionFile)
 	if err != nil {
 		return "", err
 	}

--- a/src/extensions/nginx-app-protect/nap/nap_metadata_test.go
+++ b/src/extensions/nginx-app-protect/nap/nap_metadata_test.go
@@ -8,7 +8,6 @@
 package nap
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -187,7 +186,7 @@ func setUpFile(file string, content []byte) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(file, content, 0644)
+	err = os.WriteFile(file, content, 0644)
 	if err != nil {
 		return err
 	}

--- a/src/extensions/nginx-app-protect/nap/threat_campaigns.go
+++ b/src/extensions/nginx-app-protect/nap/threat_campaigns.go
@@ -9,7 +9,7 @@ package nap
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/nginx/agent/v2/src/core"
@@ -30,7 +30,7 @@ func getThreatCampaignsVersion(versionFile string) (string, error) {
 	}
 
 	// Get the version bytes
-	versionBytes, err := ioutil.ReadFile(versionFile)
+	versionBytes, err := os.ReadFile(versionFile)
 	if err != nil {
 		return "", err
 	}

--- a/src/plugins/agent_api_test.go
+++ b/src/plugins/agent_api_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/nginx/agent/v2/src/core/metrics"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -490,7 +489,7 @@ func TestMtls_forApi(t *testing.T) {
 					Multiplier:      backoff.BACKOFF_MULTIPLIER,
 				}
 				err = backoff.WaitUntil(ctx, backoffSetting, func() error {
-					_, err := ioutil.ReadFile("../../build/certs/server.crt")
+					_, err := os.ReadFile("../../build/certs/server.crt")
 					return err
 				})
 
@@ -532,11 +531,11 @@ func TestMtls_forApi(t *testing.T) {
 }
 
 func getConfig(t *testing.T) *tls.Config {
-	crt, err := ioutil.ReadFile("../../build/certs/client.crt")
+	crt, err := os.ReadFile("../../build/certs/client.crt")
 	assert.NoError(t, err)
-	key, err := ioutil.ReadFile("../../build/certs/client.key")
+	key, err := os.ReadFile("../../build/certs/client.key")
 	assert.NoError(t, err)
-	ca, err := ioutil.ReadFile("../../build/certs/ca.pem")
+	ca, err := os.ReadFile("../../build/certs/ca.pem")
 	assert.NoError(t, err)
 
 	cert, err := tls.X509KeyPair(crt, key)

--- a/src/plugins/file_watcher_test.go
+++ b/src/plugins/file_watcher_test.go
@@ -9,7 +9,6 @@ package plugins
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -488,7 +487,7 @@ func TestWatcherProcess(t *testing.T) {
 }
 
 func writeFile(t *testing.T, file string) {
-	err := ioutil.WriteFile(file, []byte{}, 0644)
+	err := os.WriteFile(file, []byte{}, 0644)
 	if err != nil {
 		t.Fatalf("failed to write file: %v", err)
 	}
@@ -508,7 +507,7 @@ func writeFiles(t *testing.T, dirs []string) (ret []string) {
 }
 
 func updateFile(t *testing.T, file, content string) {
-	err := ioutil.WriteFile(file, []byte(content), 0644)
+	err := os.WriteFile(file, []byte(content), 0644)
 	if err != nil {
 		t.Fatalf("failed to update file: %v", err)
 	}

--- a/test/integration/reader_test.go
+++ b/test/integration/reader_test.go
@@ -21,8 +21,8 @@ const frameSeparator = ';'
 
 func TestReaderIsAbleToHandleMultipleClients(t *testing.T) {
 	mu := &sync.Mutex{}
-	rand.Seed(time.Now().Unix())
-	addr := fmt.Sprintf("/tmp/advanced_metrics_reader_test_%d.sr", rand.Int63())
+	source := rand.NewSource(time.Now().Unix())
+	addr := fmt.Sprintf("/tmp/advanced_metrics_reader_test_%d.sr", source.Int63())
 
 	r := reader.NewReader(addr)
 	outChannel := r.OutChannel()
@@ -82,8 +82,8 @@ func TestReaderIsAbleToHandleMultipleClients(t *testing.T) {
 
 func TestReaderIsAbleToHandlePartiallySendFrame(t *testing.T) {
 	mu := &sync.Mutex{}
-	rand.Seed(time.Now().Unix())
-	addr := fmt.Sprintf("/tmp/advanced_metrics_reader_test_%d.sr", rand.Int63())
+	source := rand.NewSource(time.Now().Unix())
+	addr := fmt.Sprintf("/tmp/advanced_metrics_reader_test_%d.sr", source.Int63())
 
 	r := reader.NewReader(addr)
 	outChannel := r.OutChannel()
@@ -130,8 +130,8 @@ func TestReaderIsAbleToHandlePartiallySendFrame(t *testing.T) {
 
 func TestReaderIsAbleToCloseOngoingConnections(t *testing.T) {
 	mu := &sync.Mutex{}
-	rand.Seed(time.Now().Unix())
-	addr := fmt.Sprintf("/tmp/advanced_metrics_reader_test_%d.sr", rand.Int63())
+	source := rand.NewSource(time.Now().Unix())
+	addr := fmt.Sprintf("/tmp/advanced_metrics_reader_test_%d.sr", source.Int63())
 
 	r := reader.NewReader(addr)
 	outChannel := r.OutChannel()
@@ -179,8 +179,8 @@ func TestReaderIsAbleToCloseOngoingConnections(t *testing.T) {
 
 func TestReaderWithGeneratedData(t *testing.T) {
 	mu := &sync.Mutex{}
-	rand.Seed(time.Now().Unix())
-	addr := fmt.Sprintf("/tmp/advanced_metrics_reader_test_%d.sr", rand.Int63())
+	source := rand.NewSource(time.Now().Unix())
+	addr := fmt.Sprintf("/tmp/advanced_metrics_reader_test_%d.sr", source.Int63())
 
 	r := reader.NewReader(addr)
 	outChannel := r.OutChannel()

--- a/test/integration/vendor/github.com/nginx/agent/sdk/v2/grpc/grpc.go
+++ b/test/integration/vendor/github.com/nginx/agent/sdk/v2/grpc/grpc.go
@@ -12,7 +12,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
@@ -152,7 +152,7 @@ func appendRootCAs(tlsConfig *tls.Config, caFile string) error {
 		return nil
 	}
 
-	ca, err := ioutil.ReadFile(caFile)
+	ca, err := os.ReadFile(caFile)
 	if err != nil {
 		return fmt.Errorf("could not read CA file (%s): %w", caFile, err)
 	}

--- a/test/performance/vendor/github.com/nginx/agent/sdk/v2/grpc/grpc.go
+++ b/test/performance/vendor/github.com/nginx/agent/sdk/v2/grpc/grpc.go
@@ -12,7 +12,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
@@ -152,7 +152,7 @@ func appendRootCAs(tlsConfig *tls.Config, caFile string) error {
 		return nil
 	}
 
-	ca, err := ioutil.ReadFile(caFile)
+	ca, err := os.ReadFile(caFile)
 	if err != nil {
 		return fmt.Errorf("could not read CA file (%s): %w", caFile, err)
 	}

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/commands.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/commands.go
@@ -55,7 +55,7 @@ $ nginx-agent completion fish > ~/.config/fish/completions/nginx-agent.fish
 `,
 	DisableFlagsInUseLine: true,
 	ValidArgs:             []string{"bash", "zsh", "fish"},
-	Args:                  cobra.ExactValidArgs(1),
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/config.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/config.go
@@ -9,7 +9,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -251,7 +250,7 @@ func UpdateAgentConfig(systemId string, updateTags []string, updateFeatures []st
 
 	updatedConfBytes = append([]byte(dynamicConfigUsageComment), updatedConfBytes...)
 
-	err = ioutil.WriteFile(dynamicCfgPath, updatedConfBytes, 0)
+	err = os.WriteFile(dynamicCfgPath, updatedConfBytes, 0)
 	if err != nil {
 		return false, err
 	}

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/network/network.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/network/network.go
@@ -12,7 +12,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -191,7 +191,7 @@ func getDefaultNetworkInterfaceCrossPlatform() (string, error) {
 		}
 		defer f.Close()
 
-		output, err := ioutil.ReadAll(f)
+		output, err := io.ReadAll(f)
 		if err != nil {
 			return "", fmt.Errorf("Can't read contents of %s", linuxFile)
 		}

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/extensions/nginx-app-protect/nap/attack_signatures.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/extensions/nginx-app-protect/nap/attack_signatures.go
@@ -9,7 +9,7 @@ package nap
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/nginx/agent/v2/src/core"
@@ -30,7 +30,7 @@ func getAttackSignaturesVersion(versionFile string) (string, error) {
 	}
 
 	// Get the version bytes
-	versionBytes, err := ioutil.ReadFile(versionFile)
+	versionBytes, err := os.ReadFile(versionFile)
 	if err != nil {
 		return "", err
 	}

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/extensions/nginx-app-protect/nap/threat_campaigns.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/extensions/nginx-app-protect/nap/threat_campaigns.go
@@ -9,7 +9,7 @@ package nap
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/nginx/agent/v2/src/core"
@@ -30,7 +30,7 @@ func getThreatCampaignsVersion(versionFile string) (string, error) {
 	}
 
 	// Get the version bytes
-	versionBytes, err := ioutil.ReadFile(versionFile)
+	versionBytes, err := os.ReadFile(versionFile)
 	if err != nil {
 		return "", err
 	}

--- a/test/performance/vendor/github.com/nginx/agent/v2/test/utils/symbols.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/test/utils/symbols.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 )
 
@@ -27,7 +26,7 @@ func LoadSymbolsFile() (*Symbols, error) {
 		symFile = symbolsFileLocal
 	}
 
-	content, err := ioutil.ReadFile(symFile)
+	content, err := os.ReadFile(symFile)
 	if err != nil {
 		return nil, err
 	}

--- a/test/performance/vendor/github.com/nginx/agent/v2/test/utils/tls.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/test/utils/tls.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 
@@ -16,7 +16,7 @@ func LoadKeyPair() credentials.TransportCredentials {
 		log.Fatalf("Load server certification failed: %v", err)
 	}
 
-	data, err := ioutil.ReadFile("certs/client/ca.crt")
+	data, err := os.ReadFile("certs/client/ca.crt")
 	if err != nil {
 		log.Fatalf("can't read ca file: %v", err)
 	}

--- a/test/utils/symbols.go
+++ b/test/utils/symbols.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 )
 
@@ -27,7 +26,7 @@ func LoadSymbolsFile() (*Symbols, error) {
 		symFile = symbolsFileLocal
 	}
 
-	content, err := ioutil.ReadFile(symFile)
+	content, err := os.ReadFile(symFile)
 	if err != nil {
 		return nil, err
 	}

--- a/test/utils/tls.go
+++ b/test/utils/tls.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 
@@ -16,7 +16,7 @@ func LoadKeyPair() credentials.TransportCredentials {
 		log.Fatalf("Load server certification failed: %v", err)
 	}
 
-	data, err := ioutil.ReadFile("certs/client/ca.crt")
+	data, err := os.ReadFile("certs/client/ca.crt")
 	if err != nil {
 		log.Fatalf("can't read ca file: %v", err)
 	}

--- a/vendor/github.com/nginx/agent/sdk/v2/grpc/grpc.go
+++ b/vendor/github.com/nginx/agent/sdk/v2/grpc/grpc.go
@@ -12,7 +12,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
@@ -152,7 +152,7 @@ func appendRootCAs(tlsConfig *tls.Config, caFile string) error {
 		return nil
 	}
 
-	ca, err := ioutil.ReadFile(caFile)
+	ca, err := os.ReadFile(caFile)
 	if err != nil {
 		return fmt.Errorf("could not read CA file (%s): %w", caFile, err)
 	}


### PR DESCRIPTION
This change removes the usage of most of the deprecated APIs by changing them to the current APIs.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [X] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [X] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
