### PR TITLE
fix: fixes segfault when process is TERMed

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,7 +130,9 @@ func handleSignals(
 			)
 			log.Debugf("Sending agent stopped event: %v", stopCmd)
 
-			if err := cmder.Send(ctx, client.MessageFromCommand(stopCmd)); err != nil {
+			if cmder == nil {
+				log.Warn("Command channel not configured. Skipping sending AgentStopped event")
+			} else if err := cmder.Send(ctx, client.MessageFromCommand(stopCmd)); err != nil {
 				log.Errorf("Error sending AgentStopped event to command channel: %v", err)
 			}
 


### PR DESCRIPTION
Fixes #334

This change prevents agent from having a segmentation fault when it receives a TERM or INT signal.

### Proposed changes

In this change, we add an explicit nil check for `cmder` in `main.go` around line 133. This prevents the condition where agent segfaults.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [X] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [X] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
