### PR TITLE
Fix access log parsing for custom log format

### DIFF
--- a/src/core/metrics/sources/nginx_access_log.go
+++ b/src/core/metrics/sources/nginx_access_log.go
@@ -199,6 +199,19 @@ func (c *NginxAccessLog) logStats(ctx context.Context, logFile, logFormat string
 	for key, value := range logVarMap {
 		logPattern = strings.ReplaceAll(logPattern, key, value)
 	}
+	log.Debugf("LogPattern = %s", logPattern)
+	r, err := regexp.Compile(`[\$]([a-z_]+)`)
+	if err != nil {
+		log.Warnf("unable to compile access log regex: %v", err)
+	}
+
+	variables := r.FindAllString(logPattern, -1)
+
+	log.Debugf("LogPattern = %s Matched variables = %v", logPattern, variables)
+	for _, variable := range variables {
+		replacement := "%" + fmt.Sprintf("{DATA:%s}", strings.Trim(variable, "$"))
+		logPattern = strings.Replace(logPattern, variable, replacement, -1)
+	}
 
 	log.Debugf("Collecting from: %s using format: %s", logFile, logFormat)
 	log.Debugf("Pattern used for tailing logs: %s", logPattern)

--- a/src/core/metrics/sources/nginx_access_log.go
+++ b/src/core/metrics/sources/nginx_access_log.go
@@ -200,15 +200,19 @@ func (c *NginxAccessLog) logStats(ctx context.Context, logFile, logFormat string
 		logPattern = strings.ReplaceAll(logPattern, key, value)
 	}
 	log.Debugf("LogPattern = %s", logPattern)
+
+	// A regex pattern to match all the variables that are mentioned in the access log
+	// but are absent from logVarMap and hence are not replaced with the correct format
 	r, err := regexp.Compile(`[\$]([a-z_]+)`)
 	if err != nil {
 		log.Warnf("unable to compile access log regex: %v", err)
 	}
-
+	// Get an array of all the matched variables
 	variables := r.FindAllString(logPattern, -1)
 
 	log.Debugf("LogPattern = %s Matched variables = %v", logPattern, variables)
 	for _, variable := range variables {
+		// Replace the variables with the format {DATA:variable_name} in the logPattern
 		replacement := "%" + fmt.Sprintf("{DATA:%s}", strings.Trim(variable, "$"))
 		logPattern = strings.Replace(logPattern, variable, replacement, -1)
 	}

--- a/src/core/metrics/sources/nginx_access_log.go
+++ b/src/core/metrics/sources/nginx_access_log.go
@@ -56,6 +56,8 @@ var logVarMap = map[string]string{
 	"]":                         "\\]",
 }
 
+// Pattern to match all the variables that are mentioned in the access log
+// and are absent from logVarMap
 var logVarRegex = regexp.MustCompile(`\$([a-zA-Z]+[_[a-zA-Z]+]*)`)
 
 // This metrics source is used to tail the NGINX access logs to retrieve metrics.
@@ -201,24 +203,8 @@ func (c *NginxAccessLog) logStats(ctx context.Context, logFile, logFormat string
 	for key, value := range logVarMap {
 		logPattern = strings.ReplaceAll(logPattern, key, value)
 	}
-	log.Debugf("LogPattern = %s", logPattern)
 
-	// A regex pattern to match all the variables that are mentioned in the access log
-	// but are absent from logVarMap and hence are not replaced with the correct format
-
-	// Get an array of all the matched variables
-	variables := logVarRegex.FindAllStringSubmatch(logPattern, -1)
-
-	log.Debugf("LogPattern = %s Matched variables = %v", logPattern, variables)
-	for _, match := range variables {
-		// fmt.Printf("matched [%s, %s]\n", match[0], match[1])
-
-		variable := match[0]
-		subMatch := match[1]
-
-		replacement := fmt.Sprintf("%%{DATA:%s}", subMatch)
-		logPattern = strings.Replace(logPattern, string(variable), replacement, 1)
-	}
+	logPattern = replaceCustomLogVars(logPattern)
 
 	log.Debugf("Collecting from: %s using format: %s", logFile, logFormat)
 	log.Debugf("Pattern used for tailing logs: %s", logPattern)
@@ -641,4 +627,19 @@ func getDefaultCounters() (map[string]float64, map[string]float64, map[string]fl
 	}
 
 	return httpCounters, upstreamCounters, upstreamCacheCounters
+}
+
+func replaceCustomLogVars(logPattern string) string {
+	// For all the variables in the log format that are not present in the logVarMap
+	// replace them with the %{DATA:.*} format
+	variables := logVarRegex.FindAllStringSubmatch(logPattern, -1)
+
+	for _, match := range variables {
+		variable := match[0]
+		subMatch := match[1] // Excludes the leading $ in the var name
+
+		replacement := fmt.Sprintf("%%{DATA:%s}", subMatch)
+		logPattern = strings.Replace(logPattern, string(variable), replacement, 1)
+	}
+	return logPattern
 }

--- a/src/core/metrics/sources/nginx_access_log.go
+++ b/src/core/metrics/sources/nginx_access_log.go
@@ -56,7 +56,7 @@ var logVarMap = map[string]string{
 	"]":                         "\\]",
 }
 
-var logVarRegex = regexp.MustCompile(`\$([a-z_]+)`)
+var logVarRegex = regexp.MustCompile(`\$([a-zA-Z]+[_[a-zA-Z]+]*)`)
 
 // This metrics source is used to tail the NGINX access logs to retrieve metrics.
 
@@ -211,20 +211,13 @@ func (c *NginxAccessLog) logStats(ctx context.Context, logFile, logFormat string
 
 	log.Debugf("LogPattern = %s Matched variables = %v", logPattern, variables)
 	for _, match := range variables {
+		// fmt.Printf("matched [%s, %s]\n", match[0], match[1])
+
 		variable := match[0]
-		// Replace the variables with the format {DATA:variable_name} in the logPattern
-		replacement := fmt.Sprintf("%%{DATA:%s}", match[1])
-		log.Debugf("logPattern before replace: %s", logPattern)
-		var longestSubMatch string
-		if len(match) > 1 {
-			for _, subMatch := range match[1:] {
-				if len(subMatch) > len(longestSubMatch) {
-					longestSubMatch = string(subMatch)
-				}
-			}
-		}
-		logPattern = strings.Replace(logPattern, string(variable), replacement, -1)
-		log.Debugf("logPattern after replace: %s", logPattern)
+		subMatch := match[1]
+
+		replacement := fmt.Sprintf("%%{DATA:%s}", subMatch)
+		logPattern = strings.Replace(logPattern, string(variable), replacement, 1)
 	}
 
 	log.Debugf("Collecting from: %s using format: %s", logFile, logFormat)

--- a/src/core/metrics/sources/nginx_access_log.go
+++ b/src/core/metrics/sources/nginx_access_log.go
@@ -56,8 +56,7 @@ var logVarMap = map[string]string{
 	"]":                         "\\]",
 }
 
-// Pattern to match all the variables that are mentioned in the access log
-// and are absent from logVarMap
+// Pattern to match all the variables that are mentioned in the access log format
 var logVarRegex = regexp.MustCompile(`\$([a-zA-Z]+[_[a-zA-Z]+]*)`)
 
 // This metrics source is used to tail the NGINX access logs to retrieve metrics.
@@ -629,9 +628,9 @@ func getDefaultCounters() (map[string]float64, map[string]float64, map[string]fl
 	return httpCounters, upstreamCounters, upstreamCacheCounters
 }
 
+// For all the variables in the log format that are not present in the logVarMap
+// replace them with the %{DATA:.*} format
 func replaceCustomLogVars(logPattern string) string {
-	// For all the variables in the log format that are not present in the logVarMap
-	// replace them with the %{DATA:.*} format
 	variables := logVarRegex.FindAllStringSubmatch(logPattern, -1)
 
 	for _, match := range variables {

--- a/src/core/metrics/sources/nginx_access_log.go
+++ b/src/core/metrics/sources/nginx_access_log.go
@@ -56,6 +56,8 @@ var logVarMap = map[string]string{
 	"]":                         "\\]",
 }
 
+var logVarRegex = regexp.MustCompile(`\$([a-z_]+)`)
+
 // This metrics source is used to tail the NGINX access logs to retrieve metrics.
 
 type NginxAccessLog struct {
@@ -203,18 +205,26 @@ func (c *NginxAccessLog) logStats(ctx context.Context, logFile, logFormat string
 
 	// A regex pattern to match all the variables that are mentioned in the access log
 	// but are absent from logVarMap and hence are not replaced with the correct format
-	r, err := regexp.Compile(`[\$]([a-z_]+)`)
-	if err != nil {
-		log.Warnf("unable to compile access log regex: %v", err)
-	}
+
 	// Get an array of all the matched variables
-	variables := r.FindAllString(logPattern, -1)
+	variables := logVarRegex.FindAllStringSubmatch(logPattern, -1)
 
 	log.Debugf("LogPattern = %s Matched variables = %v", logPattern, variables)
-	for _, variable := range variables {
+	for _, match := range variables {
+		variable := match[0]
 		// Replace the variables with the format {DATA:variable_name} in the logPattern
-		replacement := "%" + fmt.Sprintf("{DATA:%s}", strings.Trim(variable, "$"))
-		logPattern = strings.Replace(logPattern, variable, replacement, -1)
+		replacement := fmt.Sprintf("%%{DATA:%s}", match[1])
+		log.Debugf("logPattern before replace: %s", logPattern)
+		var longestSubMatch string
+		if len(match) > 1 {
+			for _, subMatch := range match[1:] {
+				if len(subMatch) > len(longestSubMatch) {
+					longestSubMatch = string(subMatch)
+				}
+			}
+		}
+		logPattern = strings.Replace(logPattern, string(variable), replacement, -1)
+		log.Debugf("logPattern after replace: %s", logPattern)
 	}
 
 	log.Debugf("Collecting from: %s using format: %s", logFile, logFormat)

--- a/src/core/metrics/sources/nginx_access_log_test.go
+++ b/src/core/metrics/sources/nginx_access_log_test.go
@@ -1290,22 +1290,22 @@ func TestAccessLogStats(t *testing.T) {
 		},
 		{
 			"full_access_log_test",
-			`$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for" "$bytes_sent" "$request_length" "$request_time" "$gzip_ratio" "$server_protocol" "$upstream_connect_time" "$upstream_header_time" "$upstream_response_length" "$upstream_response_time" "$upstream_status" "$upstream_cache_status" "$upstream_addr"`,
+			`$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for" "$bytes_sent" "$request_length" "$request_time" "$gzip_ratio" "$server_protocol" "$upstream_connect_time" "$upstream_header_time" "$upstream_response_length" "$upstream_response_time" "$upstream_status" "$upstream_cache_status" "$bar"`,
 			[]string{
-				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"GET /nginx_status HTTP/1.1\" 200 98 \"-\" \"Go-http-client/1.1\" \"-\" \"150\" \"105\" \"0.100\" \"10\" \"HTTP/1.1\" \"350, 0.001, 0.02, -\" \"500, 0.02, -, 20\" \"28, 0, 0, 2\" \"0.00, 0.03, 0.04, -\" \"200\" \"HIT\"\n",
-				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"POST /nginx_status HTTP/1.1\" 201 98 \"-\" \"Go-http-client/1.1\" \"-\" \"250\" \"110\" \"0.300\" \"20\" \"HTTP/1.1\" \"350, 0.01\" \"730, 80\" \"28, 28\" \"0.01, 0.02\" \"201\" \"HIT\"\n",
-				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"GET /nginx_status HTTP/1.1\" 200 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/1.1\" \"350\" \"500\" \"28\" \"0.00\" \"200\" \"HIT\"\n",
-				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"DELETE /nginx_status HTTP/1.1\" 400 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/1.1\" \"350\" \"500\" \"28\" \"0.03\" \"400\" \"MISS\"\n",
-				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"DELETE /nginx_status HTTP/1.1\" 403 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/1.1\" \"100\" \"500\" \"28\" \"0.00\" \"403\" \"HIT\"\n",
-				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"HEAD /nginx_status HTTP/1.1\" 404 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/1.1\" \"350\" \"505\" \"28\" \"0.00\" \"404\" \"MISS\"\n",
-				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"PUT /nginx_status HTTP/1.1\" 499 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/1.1\" \"350\" \"2000\" \"28\" \"0.00\" \"-\" \"HIT\"\n",
-				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"PUT /nginx_status HTTP/1.1\" 500 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/1.1\" \"2350\" \"250\" \"28\" \"0.02\" \"500\" \"UPDATING\"\n",
-				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"OPTIONS /nginx_status HTTP/1.0\" 502 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/1.0\" \"350\" \"500\" \"28\" \"0.01\" \"502\" \"HIT\"\n",
-				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"OPTIONS /nginx_status HTTP/2\" 503 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/2\" \"350\" \"500\" \"28\" \"0.00\" \"503\" \"HIT\" \n",
-				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"OPTIONS /nginx_status HTTP/0.9\" 504 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/0.9\" \"350\" \"590\" \"28\" \"0.00\" \"502\" \"HIT\"\n",
-				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"OPTIONS /nginx_status HTTP/1.1\" 502 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/1.1\" \"900\" \"500\" \"28\" \"0.00\" \"200\" \"HIT\"\n",
-				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"TRACE /nginx_status HTTP/1.1\" 200 98 \"-\" \"Go-http-client/1.1\" \"-\" \"150\" \"105\" \"0.100\" \"-\" \"HTTP/1.1\" \"350\" \"170\" \"28\" \"0.00\" \"200\" \"HIT\"\n",
-				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"TRACE /nginx_status HTTP/1.1\" 200 98 \"-\" \"Go-http-client/1.1\" \"-\" \"150\" \"105\" \"0.100\" \"-\" \"HTTP/1.1\" \"350\" \"500\" \"28\" \"0.00\" \"200\" \"HIT\"\n",
+				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"GET /nginx_status HTTP/1.1\" 200 98 \"-\" \"Go-http-client/1.1\" \"-\" \"150\" \"105\" \"0.100\" \"10\" \"HTTP/1.1\" \"350, 0.001, 0.02, -\" \"500, 0.02, -, 20\" \"28, 0, 0, 2\" \"0.00, 0.03, 0.04, -\" \"200\" \"HIT\" \"bar\"\n",
+				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"POST /nginx_status HTTP/1.1\" 201 98 \"-\" \"Go-http-client/1.1\" \"-\" \"250\" \"110\" \"0.300\" \"20\" \"HTTP/1.1\" \"350, 0.01\" \"730, 80\" \"28, 28\" \"0.01, 0.02\" \"201\" \"HIT\" \"bar\"\n",
+				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"GET /nginx_status HTTP/1.1\" 200 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/1.1\" \"350\" \"500\" \"28\" \"0.00\" \"200\" \"HIT\" \"bar\"\n",
+				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"DELETE /nginx_status HTTP/1.1\" 400 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/1.1\" \"350\" \"500\" \"28\" \"0.03\" \"400\" \"MISS\" \"bar\"\n",
+				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"DELETE /nginx_status HTTP/1.1\" 403 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/1.1\" \"100\" \"500\" \"28\" \"0.00\" \"403\" \"HIT\" \"bar\"\n",
+				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"HEAD /nginx_status HTTP/1.1\" 404 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/1.1\" \"350\" \"505\" \"28\" \"0.00\" \"404\" \"MISS\" \"bar\"\n",
+				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"PUT /nginx_status HTTP/1.1\" 499 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/1.1\" \"350\" \"2000\" \"28\" \"0.00\" \"-\" \"HIT\" \"bar\"\n",
+				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"PUT /nginx_status HTTP/1.1\" 500 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/1.1\" \"2350\" \"250\" \"28\" \"0.02\" \"500\" \"UPDATING\" \"bar\"\n",
+				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"OPTIONS /nginx_status HTTP/1.0\" 502 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/1.0\" \"350\" \"500\" \"28\" \"0.01\" \"502\" \"HIT\" \"bar\"\n",
+				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"OPTIONS /nginx_status HTTP/2\" 503 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/2\" \"350\" \"500\" \"28\" \"0.00\" \"503\" \"HIT\" \"bar\"\n",
+				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"OPTIONS /nginx_status HTTP/0.9\" 504 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/0.9\" \"350\" \"590\" \"28\" \"0.00\" \"502\" \"HIT\" \"bar\"\n",
+				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"OPTIONS /nginx_status HTTP/1.1\" 502 98 \"-\" \"Go-http-client/1.1\" \"-\" \"200\" \"100\" \"0.200\" \"-\" \"HTTP/1.1\" \"900\" \"500\" \"28\" \"0.00\" \"200\" \"HIT\" \"bar\"\n",
+				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"TRACE /nginx_status HTTP/1.1\" 200 98 \"-\" \"Go-http-client/1.1\" \"-\" \"150\" \"105\" \"0.100\" \"-\" \"HTTP/1.1\" \"350\" \"170\" \"28\" \"0.00\" \"200\" \"HIT\" \"bar\"\n",
+				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"TRACE /nginx_status HTTP/1.1\" 200 98 \"-\" \"Go-http-client/1.1\" \"-\" \"150\" \"105\" \"0.100\" \"-\" \"HTTP/1.1\" \"350\" \"500\" \"28\" \"0.00\" \"200\" \"HIT\" \"bar\"\n",
 			},
 			&proto.StatsEntity{
 				Simplemetrics: []*proto.SimpleMetric{
@@ -1560,6 +1560,270 @@ func TestAccessLogStats(t *testing.T) {
 					{
 						Name:  "nginx.cache.updating",
 						Value: 1,
+					},
+				},
+			},
+		},
+		{
+			"custom_access_log_test",
+			`$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$upstream_addr" "$upstream_addr_id" "$http_user_agent" "$http_x_forwarded_for" "$http_x_amplify_id"`,
+			[]string{
+				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"GET /nginx_status HTTP/1.1\" 200 98 \"-\" \"address\" \"address-id\" \"Go-http-client/1.1\" \"-\" \"xyz\"\n",
+				`127.0.0.1 - - [19/May/2022:09:30:39 +0000] "GET /user/register?ahref<Script>p' or 's' = 's</Script> HTTP/1.1" 200 98 "-" "address" "address-id" "-" "-" "xyz"`,
+			},
+			&proto.StatsEntity{
+				Simplemetrics: []*proto.SimpleMetric{
+					{
+						Name:  "nginx.http.gzip.ratio",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.request.time",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.request.time.count",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.request.time.median",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.request.time.max",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.request.time.pctl95",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.request.body_bytes_sent",
+						Value: 196,
+					},
+					{
+						Name:  "nginx.http.request.bytes_sent",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.request.length",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.request.malformed",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.method.post",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.method.get",
+						Value: 2,
+					},
+					{
+						Name:  "nginx.http.method.delete",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.method.put",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.method.head",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.method.options",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.method.others",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.status.1xx",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.status.2xx",
+						Value: 2,
+					},
+					{
+						Name:  "nginx.http.status.3xx",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.status.4xx",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.status.5xx",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.status.403",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.status.404",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.status.500",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.status.502",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.status.503",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.status.504",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.status.discarded",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.v0_9",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.v1_0",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.http.v1_1",
+						Value: 2,
+					},
+					{
+						Name:  "nginx.http.v2",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.connect.time",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.connect.time.count",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.connect.time.max",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.connect.time.median",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.connect.time.pctl95",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.header.time",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.header.time.count",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.header.time.max",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.header.time.median",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.header.time.pctl95",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.request.count",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.next.count",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.response.length",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.response.time",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.response.time.count",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.response.time.max",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.response.time.median",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.response.time.pctl95",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.status.1xx",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.status.2xx",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.status.3xx",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.status.4xx",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.upstream.status.5xx",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.cache.bypass",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.cache.expired",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.cache.hit",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.cache.miss",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.cache.revalidated",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.cache.stale",
+						Value: 0,
+					},
+					{
+						Name:  "nginx.cache.updating",
+						Value: 0,
 					},
 				},
 			},

--- a/src/core/metrics/sources/nginx_access_log_test.go
+++ b/src/core/metrics/sources/nginx_access_log_test.go
@@ -1290,7 +1290,7 @@ func TestAccessLogStats(t *testing.T) {
 		},
 		{
 			"full_access_log_test",
-			`$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for" "$bytes_sent" "$request_length" "$request_time" "$gzip_ratio" "$server_protocol" "$upstream_connect_time" "$upstream_header_time" "$upstream_response_length" "$upstream_response_time" "$upstream_status" "$upstream_cache_status"`,
+			`$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for" "$bytes_sent" "$request_length" "$request_time" "$gzip_ratio" "$server_protocol" "$upstream_connect_time" "$upstream_header_time" "$upstream_response_length" "$upstream_response_time" "$upstream_status" "$upstream_cache_status" "$upstream_addr"`,
 			[]string{
 				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"GET /nginx_status HTTP/1.1\" 200 98 \"-\" \"Go-http-client/1.1\" \"-\" \"150\" \"105\" \"0.100\" \"10\" \"HTTP/1.1\" \"350, 0.001, 0.02, -\" \"500, 0.02, -, 20\" \"28, 0, 0, 2\" \"0.00, 0.03, 0.04, -\" \"200\" \"HIT\"\n",
 				"127.0.0.1 - - [19/May/2022:09:30:39 +0000] \"POST /nginx_status HTTP/1.1\" 201 98 \"-\" \"Go-http-client/1.1\" \"-\" \"250\" \"110\" \"0.300\" \"20\" \"HTTP/1.1\" \"350, 0.01\" \"730, 80\" \"28, 28\" \"0.01, 0.02\" \"201\" \"HIT\"\n",

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/nginx_access_log.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/nginx_access_log.go
@@ -199,6 +199,19 @@ func (c *NginxAccessLog) logStats(ctx context.Context, logFile, logFormat string
 	for key, value := range logVarMap {
 		logPattern = strings.ReplaceAll(logPattern, key, value)
 	}
+	log.Debugf("LogPattern = %s", logPattern)
+	r, err := regexp.Compile(`[\$]([a-z_]+)`)
+	if err != nil {
+		log.Warnf("unable to compile access log regex: %v", err)
+	}
+
+	variables := r.FindAllString(logPattern, -1)
+
+	log.Debugf("LogPattern = %s Matched variables = %v", logPattern, variables)
+	for _, variable := range variables {
+		replacement := "%" + fmt.Sprintf("{DATA:%s}", strings.Trim(variable, "$"))
+		logPattern = strings.Replace(logPattern, variable, replacement, -1)
+	}
 
 	log.Debugf("Collecting from: %s using format: %s", logFile, logFormat)
 	log.Debugf("Pattern used for tailing logs: %s", logPattern)

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/nginx_access_log.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/nginx_access_log.go
@@ -200,15 +200,19 @@ func (c *NginxAccessLog) logStats(ctx context.Context, logFile, logFormat string
 		logPattern = strings.ReplaceAll(logPattern, key, value)
 	}
 	log.Debugf("LogPattern = %s", logPattern)
+
+	// A regex pattern to match all the variables that are mentioned in the access log
+	// but are absent from logVarMap and hence are not replaced with the correct format
 	r, err := regexp.Compile(`[\$]([a-z_]+)`)
 	if err != nil {
 		log.Warnf("unable to compile access log regex: %v", err)
 	}
-
+	// Get an array of all the matched variables
 	variables := r.FindAllString(logPattern, -1)
 
 	log.Debugf("LogPattern = %s Matched variables = %v", logPattern, variables)
 	for _, variable := range variables {
+		// Replace the variables with the format {DATA:variable_name} in the logPattern
 		replacement := "%" + fmt.Sprintf("{DATA:%s}", strings.Trim(variable, "$"))
 		logPattern = strings.Replace(logPattern, variable, replacement, -1)
 	}

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/nginx_access_log.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/nginx_access_log.go
@@ -56,6 +56,8 @@ var logVarMap = map[string]string{
 	"]":                         "\\]",
 }
 
+// Pattern to match all the variables that are mentioned in the access log
+// and are absent from logVarMap
 var logVarRegex = regexp.MustCompile(`\$([a-zA-Z]+[_[a-zA-Z]+]*)`)
 
 // This metrics source is used to tail the NGINX access logs to retrieve metrics.
@@ -201,24 +203,8 @@ func (c *NginxAccessLog) logStats(ctx context.Context, logFile, logFormat string
 	for key, value := range logVarMap {
 		logPattern = strings.ReplaceAll(logPattern, key, value)
 	}
-	log.Debugf("LogPattern = %s", logPattern)
 
-	// A regex pattern to match all the variables that are mentioned in the access log
-	// but are absent from logVarMap and hence are not replaced with the correct format
-
-	// Get an array of all the matched variables
-	variables := logVarRegex.FindAllStringSubmatch(logPattern, -1)
-
-	log.Debugf("LogPattern = %s Matched variables = %v", logPattern, variables)
-	for _, match := range variables {
-		// fmt.Printf("matched [%s, %s]\n", match[0], match[1])
-
-		variable := match[0]
-		subMatch := match[1]
-
-		replacement := fmt.Sprintf("%%{DATA:%s}", subMatch)
-		logPattern = strings.Replace(logPattern, string(variable), replacement, 1)
-	}
+	logPattern = replaceCustomLogVars(logPattern)
 
 	log.Debugf("Collecting from: %s using format: %s", logFile, logFormat)
 	log.Debugf("Pattern used for tailing logs: %s", logPattern)
@@ -641,4 +627,19 @@ func getDefaultCounters() (map[string]float64, map[string]float64, map[string]fl
 	}
 
 	return httpCounters, upstreamCounters, upstreamCacheCounters
+}
+
+func replaceCustomLogVars(logPattern string) string {
+	// For all the variables in the log format that are not present in the logVarMap
+	// replace them with the %{DATA:.*} format
+	variables := logVarRegex.FindAllStringSubmatch(logPattern, -1)
+
+	for _, match := range variables {
+		variable := match[0]
+		subMatch := match[1] // Excludes the leading $ in the var name
+
+		replacement := fmt.Sprintf("%%{DATA:%s}", subMatch)
+		logPattern = strings.Replace(logPattern, string(variable), replacement, 1)
+	}
+	return logPattern
 }

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/nginx_access_log.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/nginx_access_log.go
@@ -56,8 +56,7 @@ var logVarMap = map[string]string{
 	"]":                         "\\]",
 }
 
-// Pattern to match all the variables that are mentioned in the access log
-// and are absent from logVarMap
+// Pattern to match all the variables that are mentioned in the access log format
 var logVarRegex = regexp.MustCompile(`\$([a-zA-Z]+[_[a-zA-Z]+]*)`)
 
 // This metrics source is used to tail the NGINX access logs to retrieve metrics.
@@ -629,9 +628,9 @@ func getDefaultCounters() (map[string]float64, map[string]float64, map[string]fl
 	return httpCounters, upstreamCounters, upstreamCacheCounters
 }
 
+// For all the variables in the log format that are not present in the logVarMap
+// replace them with the %{DATA:.*} format
 func replaceCustomLogVars(logPattern string) string {
-	// For all the variables in the log format that are not present in the logVarMap
-	// replace them with the %{DATA:.*} format
 	variables := logVarRegex.FindAllStringSubmatch(logPattern, -1)
 
 	for _, match := range variables {


### PR DESCRIPTION
### Proposed changes

This PR aims to fix the bug where if a user has an access log format with a variable that is not present in the `logVarMap` https://github.com/nkashiv/agent/blob/main/src/core/metrics/sources/nginx_access_log.go#L33 then the access log parsing fails and no access log metric is collected. 

For example, the following log format will cause an error because it contains `$upstream_addr` which is not present in the map. A user can also have a custom variable defined which will break the parsing. 
```
log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                      '$status $body_bytes_sent "$http_referer" '
                      '"$http_user_agent" "$http_x_forwarded_for" '
                      '"$upstream_addr" "$upstream_response_time" "$upstream_status" '
                      '$http_x_amplify_id';
```
Added a unit test in `nginx_access_log_test.go` to demonstrate this fix.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
