### PR TITLE
added fix for listen directives in stub status and plus API configs

### DIFF
--- a/sdk/config_helpers.go
+++ b/sdk/config_helpers.go
@@ -661,7 +661,7 @@ func parseServerHost(parent *crossplane.Directive) string {
 		case "listen":
 			host, port, err := net.SplitHostPort(dir.Args[0])
 			if err == nil {
-				if host != "*" && host != "::" {
+				if host != "*" && host != "::" && host != "" {
 					serverName = host
 				}
 				listenPort = port
@@ -691,7 +691,11 @@ func isPort(value string) bool {
 func parseLocationPath(location *crossplane.Directive) string {
 	path := "/"
 	if len(location.Args) > 0 {
-		path = location.Args[0]
+		if location.Args[0] != "=" {
+			path = location.Args[0]
+		} else {
+			path = location.Args[1]
+		}
 	}
 	return path
 }

--- a/sdk/config_helpers_test.go
+++ b/sdk/config_helpers_test.go
@@ -871,6 +871,54 @@ server {
 		},
 		{
 			plus: []string{
+				"http://127.0.0.1:80/api/",
+			},
+			conf: `
+server {
+    listen 127.0.0.1;
+	server_name _;
+    location = /api/ {
+        api write=on;
+        allow 127.0.0.1;
+        deny all;
+    }
+}
+`,
+		},
+		{
+			plus: []string{
+				"http://localhost:80/api/",
+			},
+			conf: `
+server {
+    listen 80;
+	server_name _;
+    location = /api/ {
+        api write=on;
+        allow 127.0.0.1;
+        deny all;
+    }
+}
+`,
+		},
+		{
+			plus: []string{
+				"http://localhost:80/api/",
+			},
+			conf: `
+server {
+    listen :80;
+	server_name _;
+    location = /api/ {
+        api write=on;
+        allow 127.0.0.1;
+        deny all;
+    }
+}
+`,
+		},
+		{
+			plus: []string{
 				"http://localhost:80/api/",
 			},
 			conf: `
@@ -934,6 +982,72 @@ server {
 			}
 		
 			location /stub_status {
+				stub_status;
+			}
+		}
+		`,
+		},
+		{
+			oss: []string{
+				"http://localhost:80/stub_status",
+			},
+			conf: `
+		server {
+			server_name   localhost;
+			listen        :80;
+		
+			error_page    500 502 503 504  /50x.html;
+			# ssl_certificate /usr/local/nginx/conf/cert.pem;
+		
+			location      / {
+				root      /tmp/testdata/foo;
+			}
+		
+			location /stub_status {
+				stub_status;
+			}
+		}
+		`,
+		},
+		{
+			oss: []string{
+				"http://localhost:80/stub_status",
+			},
+			conf: `
+		server {
+			server_name   localhost;
+			listen        80;
+		
+			error_page    500 502 503 504  /50x.html;
+			# ssl_certificate /usr/local/nginx/conf/cert.pem;
+		
+			location      / {
+				root      /tmp/testdata/foo;
+			}
+		
+			location /stub_status {
+				stub_status;
+			}
+		}
+		`,
+		},
+		{
+			oss: []string{
+				"http://localhost:80/stub_status",
+			},
+			conf: `
+		server {
+			server_name   localhost;
+			listen        80;
+		
+			error_page    500 502 503 504  /50x.html;
+			# ssl_certificate /usr/local/nginx/conf/cert.pem;
+		
+			location      / {
+				root      /tmp/testdata/foo;
+			}
+		
+			location = /stub_status {
 				stub_status;
 			}
 		}

--- a/test/integration/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/test/integration/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -661,7 +661,7 @@ func parseServerHost(parent *crossplane.Directive) string {
 		case "listen":
 			host, port, err := net.SplitHostPort(dir.Args[0])
 			if err == nil {
-				if host != "*" && host != "::" {
+				if host != "*" && host != "::" && host != "" {
 					serverName = host
 				}
 				listenPort = port
@@ -691,7 +691,11 @@ func isPort(value string) bool {
 func parseLocationPath(location *crossplane.Directive) string {
 	path := "/"
 	if len(location.Args) > 0 {
-		path = location.Args[0]
+		if location.Args[0] != "=" {
+			path = location.Args[0]
+		} else {
+			path = location.Args[1]
+		}
 	}
 	return path
 }

--- a/test/performance/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/test/performance/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -661,7 +661,7 @@ func parseServerHost(parent *crossplane.Directive) string {
 		case "listen":
 			host, port, err := net.SplitHostPort(dir.Args[0])
 			if err == nil {
-				if host != "*" && host != "::" {
+				if host != "*" && host != "::" && host != "" {
 					serverName = host
 				}
 				listenPort = port
@@ -691,7 +691,11 @@ func isPort(value string) bool {
 func parseLocationPath(location *crossplane.Directive) string {
 	path := "/"
 	if len(location.Args) > 0 {
-		path = location.Args[0]
+		if location.Args[0] != "=" {
+			path = location.Args[0]
+		} else {
+			path = location.Args[1]
+		}
 	}
 	return path
 }

--- a/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -661,7 +661,7 @@ func parseServerHost(parent *crossplane.Directive) string {
 		case "listen":
 			host, port, err := net.SplitHostPort(dir.Args[0])
 			if err == nil {
-				if host != "*" && host != "::" {
+				if host != "*" && host != "::" && host != "" {
 					serverName = host
 				}
 				listenPort = port
@@ -691,7 +691,11 @@ func isPort(value string) bool {
 func parseLocationPath(location *crossplane.Directive) string {
 	path := "/"
 	if len(location.Args) > 0 {
-		path = location.Args[0]
+		if location.Args[0] != "=" {
+			path = location.Args[0]
+		} else {
+			path = location.Args[1]
+		}
 	}
 	return path
 }


### PR DESCRIPTION
### Proposed changes

Changed the way we parse plus and stub status from configs so it works with :port and port only formats. Also parse = in location block. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
