### PR TITLE
Fix: specified predefined access log format (#340)

### DIFF
--- a/sdk/config_helpers.go
+++ b/sdk/config_helpers.go
@@ -391,8 +391,10 @@ func updateNginxConfigWithAccessLog(file string, format string, nginxConfig *pro
 
 	if formatMap[format] != "" {
 		al.Format = formatMap[format]
+	} else if format == "" || format == "combined" {
+		al.Format = predefinedAccessLogFormat
 	} else {
-		al.Format = format
+		al.Format = ""
 	}
 
 	nginxConfig.AccessLogs.AccessLog = append(nginxConfig.AccessLogs.AccessLog, al)
@@ -624,9 +626,10 @@ func AddAuxfileToNginxConfig(
 }
 
 const (
-	plusAPIDirective = "api"
-	ossAPIDirective  = "stub_status"
-	apiFormat        = "http://%s%s"
+	plusAPIDirective          = "api"
+	ossAPIDirective           = "stub_status"
+	apiFormat                 = "http://%s%s"
+	predefinedAccessLogFormat = "$remote_addr - $remote_user [$time_local] \"$reques\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\""
 )
 
 func parseStatusAPIEndpoints(parent *crossplane.Directive, current *crossplane.Directive) ([]string, []string) {

--- a/sdk/config_helpers.go
+++ b/sdk/config_helpers.go
@@ -629,7 +629,7 @@ const (
 	plusAPIDirective          = "api"
 	ossAPIDirective           = "stub_status"
 	apiFormat                 = "http://%s%s"
-	predefinedAccessLogFormat = "$remote_addr - $remote_user [$time_local] \"$reques\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\""
+	predefinedAccessLogFormat = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\""
 )
 
 func parseStatusAPIEndpoints(parent *crossplane.Directive, current *crossplane.Directive) ([]string, []string) {

--- a/sdk/config_helpers_test.go
+++ b/sdk/config_helpers_test.go
@@ -85,7 +85,7 @@ var accessLogs = &proto.AccessLogs{
 		},
 		{
 			Name:        "/tmp/testdata/logs/access2.log",
-			Format:      "combined",
+			Format:      predefinedAccessLogFormat,
 			Permissions: "0644",
 			Readable:    true,
 		},
@@ -540,7 +540,7 @@ var tests = []struct {
 				AccessLog: []*proto.AccessLog{
 					{
 						Name:        "/tmp/testdata/logs/access2.log",
-						Format:      "",
+						Format:      predefinedAccessLogFormat,
 						Permissions: "0644",
 						Readable:    true,
 					},

--- a/test/integration/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/test/integration/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -391,8 +391,10 @@ func updateNginxConfigWithAccessLog(file string, format string, nginxConfig *pro
 
 	if formatMap[format] != "" {
 		al.Format = formatMap[format]
+	} else if format == "" || format == "combined" {
+		al.Format = predefinedAccessLogFormat
 	} else {
-		al.Format = format
+		al.Format = ""
 	}
 
 	nginxConfig.AccessLogs.AccessLog = append(nginxConfig.AccessLogs.AccessLog, al)
@@ -624,9 +626,10 @@ func AddAuxfileToNginxConfig(
 }
 
 const (
-	plusAPIDirective = "api"
-	ossAPIDirective  = "stub_status"
-	apiFormat        = "http://%s%s"
+	plusAPIDirective          = "api"
+	ossAPIDirective           = "stub_status"
+	apiFormat                 = "http://%s%s"
+	predefinedAccessLogFormat = "$remote_addr - $remote_user [$time_local] \"$reques\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\""
 )
 
 func parseStatusAPIEndpoints(parent *crossplane.Directive, current *crossplane.Directive) ([]string, []string) {

--- a/test/integration/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/test/integration/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -629,7 +629,7 @@ const (
 	plusAPIDirective          = "api"
 	ossAPIDirective           = "stub_status"
 	apiFormat                 = "http://%s%s"
-	predefinedAccessLogFormat = "$remote_addr - $remote_user [$time_local] \"$reques\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\""
+	predefinedAccessLogFormat = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\""
 )
 
 func parseStatusAPIEndpoints(parent *crossplane.Directive, current *crossplane.Directive) ([]string, []string) {

--- a/test/performance/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/test/performance/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -391,8 +391,10 @@ func updateNginxConfigWithAccessLog(file string, format string, nginxConfig *pro
 
 	if formatMap[format] != "" {
 		al.Format = formatMap[format]
+	} else if format == "" || format == "combined" {
+		al.Format = predefinedAccessLogFormat
 	} else {
-		al.Format = format
+		al.Format = ""
 	}
 
 	nginxConfig.AccessLogs.AccessLog = append(nginxConfig.AccessLogs.AccessLog, al)
@@ -624,9 +626,10 @@ func AddAuxfileToNginxConfig(
 }
 
 const (
-	plusAPIDirective = "api"
-	ossAPIDirective  = "stub_status"
-	apiFormat        = "http://%s%s"
+	plusAPIDirective          = "api"
+	ossAPIDirective           = "stub_status"
+	apiFormat                 = "http://%s%s"
+	predefinedAccessLogFormat = "$remote_addr - $remote_user [$time_local] \"$reques\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\""
 )
 
 func parseStatusAPIEndpoints(parent *crossplane.Directive, current *crossplane.Directive) ([]string, []string) {

--- a/test/performance/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/test/performance/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -629,7 +629,7 @@ const (
 	plusAPIDirective          = "api"
 	ossAPIDirective           = "stub_status"
 	apiFormat                 = "http://%s%s"
-	predefinedAccessLogFormat = "$remote_addr - $remote_user [$time_local] \"$reques\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\""
+	predefinedAccessLogFormat = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\""
 )
 
 func parseStatusAPIEndpoints(parent *crossplane.Directive, current *crossplane.Directive) ([]string, []string) {

--- a/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -391,8 +391,10 @@ func updateNginxConfigWithAccessLog(file string, format string, nginxConfig *pro
 
 	if formatMap[format] != "" {
 		al.Format = formatMap[format]
+	} else if format == "" || format == "combined" {
+		al.Format = predefinedAccessLogFormat
 	} else {
-		al.Format = format
+		al.Format = ""
 	}
 
 	nginxConfig.AccessLogs.AccessLog = append(nginxConfig.AccessLogs.AccessLog, al)
@@ -624,9 +626,10 @@ func AddAuxfileToNginxConfig(
 }
 
 const (
-	plusAPIDirective = "api"
-	ossAPIDirective  = "stub_status"
-	apiFormat        = "http://%s%s"
+	plusAPIDirective          = "api"
+	ossAPIDirective           = "stub_status"
+	apiFormat                 = "http://%s%s"
+	predefinedAccessLogFormat = "$remote_addr - $remote_user [$time_local] \"$reques\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\""
 )
 
 func parseStatusAPIEndpoints(parent *crossplane.Directive, current *crossplane.Directive) ([]string, []string) {

--- a/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -629,7 +629,7 @@ const (
 	plusAPIDirective          = "api"
 	ossAPIDirective           = "stub_status"
 	apiFormat                 = "http://%s%s"
-	predefinedAccessLogFormat = "$remote_addr - $remote_user [$time_local] \"$reques\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\""
+	predefinedAccessLogFormat = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\""
 )
 
 func parseStatusAPIEndpoints(parent *crossplane.Directive, current *crossplane.Directive) ([]string, []string) {


### PR DESCRIPTION
Fixed: #340 
* nginx has the predefined access log format below.
* https://nginx.org/en/docs/http/ngx_http_log_module.html
* if the log_format isn't specified or combined, it should be predefined one.

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
