### PR TITLE
fix: use host architecture to determine FreeBSD ABI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,6 @@ jobs:
       - name: Build Packages
         run: |
           make clean local-deb-package local-rpm-package local-txz-package local-apk-package
-          cp ./build/packages/txz/FreeBSD:13:*/*.pkg ./build/
           tar -cf ./build/nginx-agent-snapshots.tar.gz ./build/*.deb ./build/*.rpm ./build/*.pkg ./build/*.apk
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,7 @@ jobs:
       - name: Build Packages
         run: |
           make clean local-deb-package local-rpm-package local-txz-package local-apk-package
+          cp ./build/packages/txz/FreeBSD:13:*/*.pkg ./build/
           tar -cf ./build/nginx-agent-snapshots.tar.gz ./build/*.deb ./build/*.rpm ./build/*.pkg ./build/*.apk
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/scripts/packages/packager/local-entrypoint.sh
+++ b/scripts/packages/packager/local-entrypoint.sh
@@ -9,8 +9,6 @@ case "$(uname -m)" in
     arm64|aarch64) ABIARCH=aarch64 ;;
 esac
 
-FREEBSD_DISTROS="FreeBSD:12:${ABIARCH} FreeBSD:13:${ABIARCH}"
-
 cd /nginx-agent/
 
 mkdir -p /staging/usr/local/bin
@@ -31,21 +29,19 @@ chmod +x /staging/usr/local/etc/rc.d/nginx-agent
 git config --global --add safe.directory /nginx-agent
 VERSION="$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')-SNAPSHOT-$(git rev-parse --short HEAD)" envsubst < scripts/packages/manifest > /staging/+MANIFEST
 
-for freebsd_abi in $FREEBSD_DISTROS; do
-    mkdir -p ./build/packages/txz/"$freebsd_abi"
+mkdir -p ./build
 
-    pkg -o ABI="$freebsd_abi" create --format txz \
-        -m /staging \
-        -r /staging \
-        -p /staging/plist \
-        -o ./build/packages/txz/"$freebsd_abi"
+pkg -o ABI="FreeBSD:13:${ABIARCH}" create --format txz \
+    -m /staging \
+    -r /staging \
+    -p /staging/plist \
+    -o ./build
 
-    # Creating symbolic link from txz to pkg. In older versions of pkg the extension would represent the format of the file
-    # but since version 1.17.0 pkg will now always create a file with the extesion pkg no matter what the format is.
-    # See 1.17.0 release notes for more info: https://cgit.freebsd.org/ports/commit/?id=e497a16a286972bfcab908209b11ee6a13d99dc9
-    cd build/packages/txz/"$freebsd_abi"
-    ln -s nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT-"$(git rev-parse --short HEAD)".pkg nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT-"$(git rev-parse --short HEAD)".txz
-    cd ../../../../
-done
+# Creating symbolic link from txz to pkg. In older versions of pkg the extension would represent the format of the file
+# but since version 1.17.0 pkg will now always create a file with the extesion pkg no matter what the format is.
+# See 1.17.0 release notes for more info: https://cgit.freebsd.org/ports/commit/?id=e497a16a286972bfcab908209b11ee6a13d99dc9
+cd build
+ln -s nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT-"$(git rev-parse --short HEAD)".pkg nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT-"$(git rev-parse --short HEAD)".txz
+cd ../
 
 rm -rf /staging

--- a/scripts/packages/packager/local-entrypoint.sh
+++ b/scripts/packages/packager/local-entrypoint.sh
@@ -4,6 +4,13 @@ set -e
 set -x
 set -euxo pipefail
 
+case "$(uname -m)" in
+    amd64|x86_64)  ABIARCH=amd64 ;;
+    arm64|aarch64) ABIARCH=aarch64 ;;
+esac
+
+FREEBSD_DISTROS="FreeBSD:12:${ABIARCH} FreeBSD:13:${ABIARCH}"
+
 cd /nginx-agent/
 
 mkdir -p /staging/usr/local/bin
@@ -24,17 +31,21 @@ chmod +x /staging/usr/local/etc/rc.d/nginx-agent
 git config --global --add safe.directory /nginx-agent
 VERSION="$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')-SNAPSHOT-$(git rev-parse --short HEAD)" envsubst < scripts/packages/manifest > /staging/+MANIFEST
 
-pkg -o ABI="FreeBSD:13:amd64" create --format txz  \
-    -m /staging \
-    -r /staging \
-    -p /staging/plist \
-    -o ./build/; \
+for freebsd_abi in $FREEBSD_DISTROS; do
+    mkdir -p ./build/packages/txz/"$freebsd_abi"
 
-# Creating symbolic link from txz to pkg. In older versions of pkg the extension would represent the format of the file 
-# but since version 1.17.0 pkg will now always create a file with the extesion pkg no matter what the format is. 
-# See 1.17.0 release notes for more info: https://cgit.freebsd.org/ports/commit/?id=e497a16a286972bfcab908209b11ee6a13d99dc9
-cd build/
-ln -s nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT-"$(git rev-parse --short HEAD)".pkg nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT-"$(git rev-parse --short HEAD)".txz 
-cd ..
+    pkg -o ABI="$freebsd_abi" create --format txz \
+        -m /staging \
+        -r /staging \
+        -p /staging/plist \
+        -o ./build/packages/txz/"$freebsd_abi"
+
+    # Creating symbolic link from txz to pkg. In older versions of pkg the extension would represent the format of the file
+    # but since version 1.17.0 pkg will now always create a file with the extesion pkg no matter what the format is.
+    # See 1.17.0 release notes for more info: https://cgit.freebsd.org/ports/commit/?id=e497a16a286972bfcab908209b11ee6a13d99dc9
+    cd build/packages/txz/"$freebsd_abi"
+    ln -s nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT-"$(git rev-parse --short HEAD)".pkg nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT-"$(git rev-parse --short HEAD)".txz
+    cd ../../../../
+done
 
 rm -rf /staging

--- a/scripts/packages/packager/signed-entrypoint.sh
+++ b/scripts/packages/packager/signed-entrypoint.sh
@@ -4,12 +4,7 @@ set -e
 set -x
 set -euxo pipefail
 
-case "$(uname -m)" in
-    amd64|x86_64)  ABIARCH=amd64 ;;
-    arm64|aarch64) ABIARCH=aarch64 ;;
-esac
-
-FREEBSD_DISTROS="FreeBSD:12:${ABIARCH} FreeBSD:13:${ABIARCH}"
+FREEBSD_DISTROS="FreeBSD:12:amd64 FreeBSD:13:amd64"
 
 cd /nginx-agent/
 

--- a/scripts/packages/packager/signed-entrypoint.sh
+++ b/scripts/packages/packager/signed-entrypoint.sh
@@ -4,7 +4,12 @@ set -e
 set -x
 set -euxo pipefail
 
-FREEBSD_DISTROS="FreeBSD:12:amd64 FreeBSD:13:amd64"
+case "$(uname -m)" in
+    amd64|x86_64)  ABIARCH=amd64 ;;
+    arm64|aarch64) ABIARCH=aarch64 ;;
+esac
+
+FREEBSD_DISTROS="FreeBSD:12:${ABIARCH} FreeBSD:13:${ABIARCH}"
 
 cd /nginx-agent/
 
@@ -39,8 +44,8 @@ for freebsd_abi in $FREEBSD_DISTROS; do \
         -o ./build/packages/txz/"$freebsd_abi"; \
     # create freebsd pkg repo layout
     pkg repo ./build/packages/txz/"$freebsd_abi" .key.rsa; \
-    # Creating symbolic link from txz to pkg. In older versions of pkg the extension would represent the format of the file 
-    # but since version 1.17.0 pkg will now always create a file with the extesion pkg no matter what the format is. 
+    # Creating symbolic link from txz to pkg. In older versions of pkg the extension would represent the format of the file
+    # but since version 1.17.0 pkg will now always create a file with the extesion pkg no matter what the format is.
     # See 1.17.0 release notes for more info: https://cgit.freebsd.org/ports/commit/?id=e497a16a286972bfcab908209b11ee6a13d99dc9
     cd build/packages/txz/"$freebsd_abi"; \
     ln -s nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')".pkg nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')".txz; \


### PR DESCRIPTION
### Proposed changes

This change allows to get working FreeBSD agent packages on both x86 and arm64 hosts/runners when running `make local-txz-package` target.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] If applicable, I have tested my cross-platform changes (verified manually on FreeBSD 13.2 amd64/aarch64)