### PR TITLE
fix: bump hugo theme to 0.33.0

### DIFF
--- a/hugo/go.mod
+++ b/hugo/go.mod
@@ -3,5 +3,5 @@ module github.com/nginx/agent/hugo
 go 1.18
 
 require (
-	github.com/nginxinc/nginx-hugo-theme v0.28.0 // indirect
+	github.com/nginxinc/nginx-hugo-theme v0.33.0 // indirect
 )


### PR DESCRIPTION
### Proposed changes

Update documentation go.mod to use latest hugo theme 0.33.0
- Fixes Coveo search

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
