### PR TITLE
Add timeout to integration tests setup

### DIFF
--- a/test/integration/utils/test_container_utils.go
+++ b/test/integration/utils/test_container_utils.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,6 +13,8 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/compose"
 	wait "github.com/testcontainers/testcontainers-go/wait"
 )
+
+const agentServiceTimeout = 20 * time.Second
 
 // SetupTestContainerWithAgent sets up a container with nginx and nginx-agent installed
 func SetupTestContainerWithAgent(t *testing.T) *testcontainers.DockerContainer {
@@ -27,7 +30,7 @@ func SetupTestContainerWithAgent(t *testing.T) *testcontainers.DockerContainer {
 	t.Cleanup(cancel)
 
 	require.NoError(t,
-		comp.WaitForService("agent", wait.ForLog("OneTimeRegistration completed")).WithEnv(
+		comp.WaitForService("agent", wait.ForLog("OneTimeRegistration completed").WithStartupTimeout(agentServiceTimeout)).WithEnv(
 			map[string]string{
 				"PACKAGE_NAME":  os.Getenv("PACKAGE_NAME"),
 				"PACKAGES_REPO": os.Getenv("PACKAGES_REPO"),
@@ -56,7 +59,7 @@ func SetupTestContainerWithoutAgent(t *testing.T) *testcontainers.DockerContaine
 	ctxCancel, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 
-	require.NoError(t, comp.WaitForService("agent", wait.ForHTTP("/")).WithEnv(
+	require.NoError(t, comp.WaitForService("agent", wait.ForHTTP("/").WithStartupTimeout(agentServiceTimeout)).WithEnv(
 		map[string]string{
 			"PACKAGE_NAME":      os.Getenv("PACKAGE_NAME"),
 			"PACKAGES_REPO":     os.Getenv("PACKAGES_REPO"),


### PR DESCRIPTION
### Proposed changes

* Add timeout to integration test setup. Test will now fail after 20 seconds if it cannot start agent service rather than default of 10 minutes.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
