### PR TITLE
Fix worker io metrics permission issue when running in a container

### DIFF
--- a/src/core/metrics/collectors/nginx_test.go
+++ b/src/core/metrics/collectors/nginx_test.go
@@ -235,7 +235,7 @@ func TestNginxCollector_UpdateCollectorConfig(t *testing.T) {
 		dimensions: metrics.NewCommonDim(host, &config.Config{}, "123"),
 	}
 
-	nginxCollector.UpdateCollectorConfig(&metrics.NginxCollectorConfig{StubStatus: "http://localhost:80/api"}, configuration)
+	nginxCollector.UpdateCollectorConfig(&metrics.NginxCollectorConfig{StubStatus: "http://localhost:80/api"}, configuration, env)
 
 	// Verify that sources are stopped
 	mockNginxSource1.AssertExpectations(t)

--- a/src/core/metrics/sources/swap.go
+++ b/src/core/metrics/sources/swap.go
@@ -41,8 +41,9 @@ func NewSwapSource(namespace string, env core.Environment) *Swap {
 	if err != nil {
 		if e, ok := err.(*os.PathError); ok {
 			log.Warnf("Unable to collect Swap metrics because the file %v was not found", e.Path)
+		} else {
+			log.Warnf("Unable to collect Swap metrics, %v", err)
 		}
-		log.Warnf("Unable to collect Swap metrics, %v", err)
 	}
 
 	return &Swap{NewMetricSourceLogger(), &namedMetric{namespace, "swap"}, statFunc}

--- a/src/plugins/metrics.go
+++ b/src/plugins/metrics.go
@@ -325,7 +325,7 @@ func (m *Metrics) updateCollectorsConfig() {
 		if nginxCollector, ok := collector.(*collectors.NginxCollector); ok {
 			if collectorConfig, ok := m.collectorConfigsMap[nginxCollector.GetNginxId()]; ok {
 				log.Tracef("Updating nginx collector config for nginxId %s", collectorConfig.NginxId)
-				nginxCollector.UpdateCollectorConfig(collectorConfig, m.conf)
+				nginxCollector.UpdateCollectorConfig(collectorConfig, m.conf, m.env)
 			}
 		}
 		collector.UpdateConfig(m.conf)

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/swap.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/swap.go
@@ -41,8 +41,9 @@ func NewSwapSource(namespace string, env core.Environment) *Swap {
 	if err != nil {
 		if e, ok := err.(*os.PathError); ok {
 			log.Warnf("Unable to collect Swap metrics because the file %v was not found", e.Path)
+		} else {
+			log.Warnf("Unable to collect Swap metrics, %v", err)
 		}
-		log.Warnf("Unable to collect Swap metrics, %v", err)
 	}
 
 	return &Swap{NewMetricSourceLogger(), &namedMetric{namespace, "swap"}, statFunc}

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/metrics.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/metrics.go
@@ -325,7 +325,7 @@ func (m *Metrics) updateCollectorsConfig() {
 		if nginxCollector, ok := collector.(*collectors.NginxCollector); ok {
 			if collectorConfig, ok := m.collectorConfigsMap[nginxCollector.GetNginxId()]; ok {
 				log.Tracef("Updating nginx collector config for nginxId %s", collectorConfig.NginxId)
-				nginxCollector.UpdateCollectorConfig(collectorConfig, m.conf)
+				nginxCollector.UpdateCollectorConfig(collectorConfig, m.conf, m.env)
 			}
 		}
 		collector.UpdateConfig(m.conf)


### PR DESCRIPTION
### Proposed changes

When running in a container the agent doesn't have permission to read the io proc file for the NGINX worker processes so adding a check to exclude these metrics when running in a container.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
