### PR TITLE
Use ParseInt instead of Atoi when converting process id string to an int

### DIFF
--- a/src/core/metrics/sources/nginx_worker.go
+++ b/src/core/metrics/sources/nginx_worker.go
@@ -185,7 +185,7 @@ func (client *NginxWorkerClient) GetWorkerStats(childProcs []*proto.NginxDetails
 		}
 		numWorkers++
 
-		pidAsInt, err := strconv.Atoi(nginxDetails.ProcessId)
+		pidAsInt, err := strconv.ParseInt(nginxDetails.ProcessId, 10, 32)
 		if err != nil {
 			client.logger.Log(fmt.Sprintf("Failed to convert %s to int: %v", nginxDetails.ProcessId, err))
 			continue

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/nginx_worker.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/nginx_worker.go
@@ -185,7 +185,7 @@ func (client *NginxWorkerClient) GetWorkerStats(childProcs []*proto.NginxDetails
 		}
 		numWorkers++
 
-		pidAsInt, err := strconv.Atoi(nginxDetails.ProcessId)
+		pidAsInt, err := strconv.ParseInt(nginxDetails.ProcessId, 10, 32)
 		if err != nil {
 			client.logger.Log(fmt.Sprintf("Failed to convert %s to int: %v", nginxDetails.ProcessId, err))
 			continue


### PR DESCRIPTION
### Proposed changes

Use ParseInt instead of Atoi when converting process id string to an int

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
