### PR TITLE
Monitor NGINX logs for critical & error messages after NGINX reload 

### DIFF
--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -280,7 +280,7 @@ func (n *NginxBinaryType) ValidateConfig(processId, bin, configLocation string, 
 }
 
 func (n *NginxBinaryType) validateConfigCheckResponse(response *bytes.Buffer, configLocation string) error {
-	if bytes.Contains(response.Bytes(), []byte("[emerg]")) || bytes.Contains(response.Bytes(), []byte("[alert]")) {
+	if bytes.Contains(response.Bytes(), []byte("[emerg]")) || bytes.Contains(response.Bytes(), []byte("[alert]")) || bytes.Contains(response.Bytes(), []byte("[crit]")) {
 		return fmt.Errorf("error running nginx -t -c %v:\n%s", configLocation, response)
 	}
 

--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -280,7 +280,7 @@ func (n *NginxBinaryType) ValidateConfig(processId, bin, configLocation string, 
 }
 
 func (n *NginxBinaryType) validateConfigCheckResponse(response *bytes.Buffer, configLocation string) error {
-	if bytes.Contains(response.Bytes(), []byte("[emerg]")) || bytes.Contains(response.Bytes(), []byte("[alert]")) || bytes.Contains(response.Bytes(), []byte("[crit]")) {
+	if bytes.Contains(response.Bytes(), []byte("[emerg]")) || bytes.Contains(response.Bytes(), []byte("[alert]")) || bytes.Contains(response.Bytes(), []byte("[crit]")) || bytes.Contains(response.Bytes(), []byte("[error]"))  {
 		return fmt.Errorf("error running nginx -t -c %v:\n%s", configLocation, response)
 	}
 

--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -280,7 +280,7 @@ func (n *NginxBinaryType) ValidateConfig(processId, bin, configLocation string, 
 }
 
 func (n *NginxBinaryType) validateConfigCheckResponse(response *bytes.Buffer, configLocation string) error {
-	if bytes.Contains(response.Bytes(), []byte("[emerg]")) || bytes.Contains(response.Bytes(), []byte("[alert]")) || bytes.Contains(response.Bytes(), []byte("[crit]")) || bytes.Contains(response.Bytes(), []byte("[error]"))  {
+	if bytes.Contains(response.Bytes(), []byte("[emerg]")) || bytes.Contains(response.Bytes(), []byte("[alert]")) || bytes.Contains(response.Bytes(), []byte("[crit]")) || bytes.Contains(response.Bytes(), []byte("[error]")) {
 		return fmt.Errorf("error running nginx -t -c %v:\n%s", configLocation, response)
 	}
 

--- a/src/core/nginx_test.go
+++ b/src/core/nginx_test.go
@@ -959,6 +959,8 @@ func TestNginxBinaryType_validateConfigCheckResponse(t *testing.T) {
 		{name: "validation fails, emerg respected, config irrelevant", response: "nginx [emerg]", treatWarningsAsErrors: true, expected: errors.New("error running nginx -t -c :\nnginx [emerg]")},
 		{name: "validation fails, alert respected", response: "nginx [alert]", treatWarningsAsErrors: false, expected: errors.New("error running nginx -t -c :\nnginx [alert]")},
 		{name: "validation fails, alert respected, config irrelevant", response: "nginx [alert]", treatWarningsAsErrors: true, expected: errors.New("error running nginx -t -c :\nnginx [alert]")},
+		{name: "validation fails, crit respected", response: "nginx [crit]", treatWarningsAsErrors: false, expected: errors.New("error running nginx -t -c :\nnginx [crit]")},
+		{name: "validation fails, crit respected, config irrelevant", response: "nginx [crit]", treatWarningsAsErrors: true, expected: errors.New("error running nginx -t -c :\nnginx [crit]")},
 		{name: "validation passes, warn ignored", response: "nginx [warn]", treatWarningsAsErrors: false, expected: nil},
 		{name: "validation fails, warn respected", response: "nginx [warn]", treatWarningsAsErrors: true, expected: errors.New("error running nginx -t -c :\nnginx [warn]")},
 		{name: "validation passes, info irrelevant", response: "nginx [info]", treatWarningsAsErrors: false, expected: nil},

--- a/src/core/nginx_test.go
+++ b/src/core/nginx_test.go
@@ -961,6 +961,8 @@ func TestNginxBinaryType_validateConfigCheckResponse(t *testing.T) {
 		{name: "validation fails, alert respected, config irrelevant", response: "nginx [alert]", treatWarningsAsErrors: true, expected: errors.New("error running nginx -t -c :\nnginx [alert]")},
 		{name: "validation fails, crit respected", response: "nginx [crit]", treatWarningsAsErrors: false, expected: errors.New("error running nginx -t -c :\nnginx [crit]")},
 		{name: "validation fails, crit respected, config irrelevant", response: "nginx [crit]", treatWarningsAsErrors: true, expected: errors.New("error running nginx -t -c :\nnginx [crit]")},
+		{name: "validation fails, error respected", response: "nginx [error]", treatWarningsAsErrors: false, expected: errors.New("error running nginx -t -c :\nnginx [error]")},
+		{name: "validation fails, error respected, config irrelevant", response: "nginx [error]", treatWarningsAsErrors: true, expected: errors.New("error running nginx -t -c :\nnginx [error]")},
 		{name: "validation passes, warn ignored", response: "nginx [warn]", treatWarningsAsErrors: false, expected: nil},
 		{name: "validation fails, warn respected", response: "nginx [warn]", treatWarningsAsErrors: true, expected: errors.New("error running nginx -t -c :\nnginx [warn]")},
 		{name: "validation passes, info irrelevant", response: "nginx [info]", treatWarningsAsErrors: false, expected: nil},

--- a/src/plugins/nginx.go
+++ b/src/plugins/nginx.go
@@ -48,6 +48,7 @@ var (
 		re.MustCompile(`.*\[emerg\].*`),
 		re.MustCompile(`.*\[alert\].*`),
 		re.MustCompile(`.*\[crit\].*`),
+		re.MustCompile(`.*\[error\].*`),
 	}
 	warningRegex = re.MustCompile(`.*\[warn\].*`)
 )

--- a/src/plugins/nginx.go
+++ b/src/plugins/nginx.go
@@ -47,6 +47,7 @@ var (
 	reloadErrorList   = []*re.Regexp{
 		re.MustCompile(`.*\[emerg\].*`),
 		re.MustCompile(`.*\[alert\].*`),
+		re.MustCompile(`.*\[crit\].*`),
 	}
 	warningRegex = re.MustCompile(`.*\[warn\].*`)
 )

--- a/src/plugins/nginx_test.go
+++ b/src/plugins/nginx_test.go
@@ -1133,6 +1133,12 @@ func TestNginx_monitorLog(t *testing.T) {
 			treatWarningsAsErrors: false,
 		},
 		{
+			name:                  "crit level test permission",
+			errorLog:              "2023/07/07 11:30:00 [crit] 123456#123456: *1 connect() to unix:/test/test/test/test.sock failed (2: No such file or directory) while connecting to upstream, client: 0.0.0.0, server: _, request: \"POST /test HTTP/2.0\", upstream: \"grpc://unix:/test/test/test/test.sock:\", host: \"0.0.0.0:0\"",
+			expected:              "2023/07/07 11:30:00 [crit] 123456#123456: *1 connect() to unix:/test/test/test/test.sock failed (2: No such file or directory) while connecting to upstream, client: 0.0.0.0, server: _, request: \"POST /test HTTP/2.0\", upstream: \"grpc://unix:/test/test/test/test.sock:\", host: \"0.0.0.0:0\"",
+			treatWarningsAsErrors: false,
+		},
+		{
 			name:                  "validation passes, warn ignored",
 			errorLog:              "nginx: [warn] 2048 worker_connections exceed open file resource limit: 1024",
 			expected:              "",

--- a/src/plugins/nginx_test.go
+++ b/src/plugins/nginx_test.go
@@ -1133,6 +1133,12 @@ func TestNginx_monitorLog(t *testing.T) {
 			treatWarningsAsErrors: false,
 		},
 		{
+			name:                  "error level test permission",
+			errorLog:              "2023/07/11 14:00:00 [error] 123456#123456: *1 connect() failed (111: Connection refused) while connecting to upstream, client: 000.00.0.000, server: _, request: \"GET /test HTTP/2.0\", upstream: \"http://00.0.0.0:8081/test/test/test/test\", host: \"00.0000.0000.0000\", referrer: \"https://00.0000.0000.000/test/\"",
+			expected:              "2023/07/11 14:00:00 [error] 123456#123456: *1 connect() failed (111: Connection refused) while connecting to upstream, client: 000.00.0.000, server: _, request: \"GET /test HTTP/2.0\", upstream: \"http://00.0.0.0:8081/test/test/test/test\", host: \"00.0000.0000.0000\", referrer: \"https://00.0000.0000.000/test/\"",
+			treatWarningsAsErrors: false,
+		},
+		{
 			name:                  "crit level test permission",
 			errorLog:              "2023/07/07 11:30:00 [crit] 123456#123456: *1 connect() to unix:/test/test/test/test.sock failed (2: No such file or directory) while connecting to upstream, client: 0.0.0.0, server: _, request: \"POST /test HTTP/2.0\", upstream: \"grpc://unix:/test/test/test/test.sock:\", host: \"0.0.0.0:0\"",
 			expected:              "2023/07/07 11:30:00 [crit] 123456#123456: *1 connect() to unix:/test/test/test/test.sock failed (2: No such file or directory) while connecting to upstream, client: 0.0.0.0, server: _, request: \"POST /test HTTP/2.0\", upstream: \"grpc://unix:/test/test/test/test.sock:\", host: \"0.0.0.0:0\"",

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
@@ -280,7 +280,7 @@ func (n *NginxBinaryType) ValidateConfig(processId, bin, configLocation string, 
 }
 
 func (n *NginxBinaryType) validateConfigCheckResponse(response *bytes.Buffer, configLocation string) error {
-	if bytes.Contains(response.Bytes(), []byte("[emerg]")) || bytes.Contains(response.Bytes(), []byte("[alert]")) {
+	if bytes.Contains(response.Bytes(), []byte("[emerg]")) || bytes.Contains(response.Bytes(), []byte("[alert]")) || bytes.Contains(response.Bytes(), []byte("[crit]")) {
 		return fmt.Errorf("error running nginx -t -c %v:\n%s", configLocation, response)
 	}
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
@@ -280,7 +280,7 @@ func (n *NginxBinaryType) ValidateConfig(processId, bin, configLocation string, 
 }
 
 func (n *NginxBinaryType) validateConfigCheckResponse(response *bytes.Buffer, configLocation string) error {
-	if bytes.Contains(response.Bytes(), []byte("[emerg]")) || bytes.Contains(response.Bytes(), []byte("[alert]")) || bytes.Contains(response.Bytes(), []byte("[crit]")) {
+	if bytes.Contains(response.Bytes(), []byte("[emerg]")) || bytes.Contains(response.Bytes(), []byte("[alert]")) || bytes.Contains(response.Bytes(), []byte("[crit]")) || bytes.Contains(response.Bytes(), []byte("[error]")) {
 		return fmt.Errorf("error running nginx -t -c %v:\n%s", configLocation, response)
 	}
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/nginx.go
@@ -48,6 +48,7 @@ var (
 		re.MustCompile(`.*\[emerg\].*`),
 		re.MustCompile(`.*\[alert\].*`),
 		re.MustCompile(`.*\[crit\].*`),
+		re.MustCompile(`.*\[error\].*`),
 	}
 	warningRegex = re.MustCompile(`.*\[warn\].*`)
 )

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/nginx.go
@@ -47,6 +47,7 @@ var (
 	reloadErrorList   = []*re.Regexp{
 		re.MustCompile(`.*\[emerg\].*`),
 		re.MustCompile(`.*\[alert\].*`),
+		re.MustCompile(`.*\[crit\].*`),
 	}
 	warningRegex = re.MustCompile(`.*\[warn\].*`)
 )


### PR DESCRIPTION
### Proposed changes

Monitor NGINX logs for critical & error after an NGINX reload

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
