### PR TITLE
Bump agent version to 2.27.0 for official docker images

### DIFF
--- a/scripts/docker/nginx-oss/apk/Dockerfile
+++ b/scripts/docker/nginx-oss/apk/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as install-nginx
-LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG ENTRY_POINT
 ARG PACKAGES_REPO

--- a/scripts/docker/nginx-oss/deb/Dockerfile
+++ b/scripts/docker/nginx-oss/deb/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as install-nginx
-LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG ENTRY_POINT

--- a/scripts/docker/nginx-oss/rpm/Dockerfile
+++ b/scripts/docker/nginx-oss/rpm/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as install-nginx
-LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG PACKAGES_REPO
 ARG ENTRY_POINT

--- a/scripts/docker/nginx-plus/almalinux/Dockerfile
+++ b/scripts/docker/nginx-plus/almalinux/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as install
-LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG BASE_IMAGE
 ARG PACKAGES_REPO

--- a/scripts/docker/nginx-plus/alpine/Dockerfile
+++ b/scripts/docker/nginx-plus/alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as install
-LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG PACKAGES_REPO
 

--- a/scripts/docker/nginx-plus/amazonlinux/Dockerfile
+++ b/scripts/docker/nginx-plus/amazonlinux/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as install
-LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG BASE_IMAGE
 ARG PACKAGES_REPO

--- a/scripts/docker/nginx-plus/centos/Dockerfile
+++ b/scripts/docker/nginx-plus/centos/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as install
-LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG BASE_IMAGE
 ARG PACKAGES_REPO

--- a/scripts/docker/nginx-plus/debian/Dockerfile
+++ b/scripts/docker/nginx-plus/debian/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as install
-LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG PACKAGES_REPO
 

--- a/scripts/docker/nginx-plus/oraclelinux/Dockerfile
+++ b/scripts/docker/nginx-plus/oraclelinux/Dockerfile
@@ -1,7 +1,7 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as install
-LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG BASE_IMAGE
 ARG PACKAGES_REPO

--- a/scripts/docker/nginx-plus/redhatenterprise/Dockerfile
+++ b/scripts/docker/nginx-plus/redhatenterprise/Dockerfile
@@ -3,7 +3,7 @@ ARG CONTAINER_REGISTRY
 
 FROM ${CONTAINER_REGISTRY}/ubi${OS_VERSION}/ubi:latest as install
 
-LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG PACKAGES_REPO
 ARG OS_VERSION

--- a/scripts/docker/nginx-plus/rockylinux/Dockerfile
+++ b/scripts/docker/nginx-plus/rockylinux/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as install
-LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG BASE_IMAGE
 ARG PACKAGES_REPO

--- a/scripts/docker/nginx-plus/suse/Dockerfile
+++ b/scripts/docker/nginx-plus/suse/Dockerfile
@@ -3,7 +3,7 @@ ARG OS_VERSION
 ARG CONTAINER_REGISTRY
 
 FROM ${CONTAINER_REGISTRY}/${OS_RELEASE}/${OS_VERSION} as install
-LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG OS_VERSION
 ARG PACKAGES_REPO

--- a/scripts/docker/nginx-plus/ubuntu/Dockerfile
+++ b/scripts/docker/nginx-plus/ubuntu/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as install
-LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG PACKAGES_REPO
 

--- a/scripts/docker/official/nginx-oss-with-nginx-agent/alpine/Dockerfile.mainline
+++ b/scripts/docker/official/nginx-oss-with-nginx-agent/alpine/Dockerfile.mainline
@@ -1,7 +1,7 @@
 ARG NGINX_VERSION=1.25.1-alpine
 
 FROM nginx:${NGINX_VERSION}
-LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG NGINX_AGENT_VERSION=2.27.0
 

--- a/scripts/docker/official/nginx-oss-with-nginx-agent/alpine/Dockerfile.stable
+++ b/scripts/docker/official/nginx-oss-with-nginx-agent/alpine/Dockerfile.stable
@@ -1,7 +1,7 @@
 ARG NGINX_VERSION=1.24.0-alpine
 
 FROM nginx:${NGINX_VERSION}
-LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG NGINX_AGENT_VERSION=2.27.0
 

--- a/scripts/docker/official/nginx-plus-with-nginx-agent/alpine/Dockerfile
+++ b/scripts/docker/official/nginx-plus-with-nginx-agent/alpine/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.17
-LABEL maintainer="NGINX Agent Maintainers <agent@nginx.com>"
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 # Define NGINX versions for NGINX Plus and NGINX Plus modules
 # Uncomment this block and the versioned nginxPackages in the main RUN


### PR DESCRIPTION
### Proposed changes

- Add NGINX OSS stable Dockerfile. 
- Bump agent version to 2.27.0 for official docker images.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
