### PR TITLE
Reload NGINX after rolling back NGINX configuration changes

### DIFF
--- a/src/plugins/nginx_test.go
+++ b/src/plugins/nginx_test.go
@@ -38,94 +38,94 @@ var (
 	first  = []byte("nginx conf contents")
 	second = []byte("")
 	third  = []byte(`user       www www;  ## Default: nobody
-	worker_processes  5;  ## Default: 1
-	error_log  logs/error.log;
-	pid        logs/nginx.pid;
-	worker_rlimit_nofile 8192;
-
-	events {
-	worker_connections  4096;  ## Default: 1024
-	}
-	
-	http {
-	include    conf/mime.types;
-	include    /etc/nginx/proxy.conf;
-	include    /etc/nginx/fastcgi.conf;
-	index    index.html index.htm index.php;
-
-	default_type application/octet-stream;
-	log_format   main '$remote_addr - $remote_user [$time_local]  $status '
-		'\"$request\" $body_bytes_sent \"$http_referer\" '
-		'\"$http_user_agent\" \"$http_x_forwarded_for\"';
-	access_log   logs/access.log  main;
-	sendfile     on;
-	tcp_nopush   on;
-	server_names_hash_bucket_size 128; # this seems to be required for some vhosts
-	
-	server { # php/fastcgi
-		listen       80;
-		server_name  domain1.com www.domain1.com;
-		access_log   logs/domain1.access.log  main;
-		root         html;
-
-		location ~ \.php$ {
-		fastcgi_pass   127.0.0.1:1025;
-		}
-	}`)
+	 worker_processes  5;  ## Default: 1
+	 error_log  logs/error.log;
+	 pid        logs/nginx.pid;
+	 worker_rlimit_nofile 8192;
+ 
+	 events {
+	 worker_connections  4096;  ## Default: 1024
+	 }
+	 
+	 http {
+	 include    conf/mime.types;
+	 include    /etc/nginx/proxy.conf;
+	 include    /etc/nginx/fastcgi.conf;
+	 index    index.html index.htm index.php;
+ 
+	 default_type application/octet-stream;
+	 log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+		 '\"$request\" $body_bytes_sent \"$http_referer\" '
+		 '\"$http_user_agent\" \"$http_x_forwarded_for\"';
+	 access_log   logs/access.log  main;
+	 sendfile     on;
+	 tcp_nopush   on;
+	 server_names_hash_bucket_size 128; # this seems to be required for some vhosts
+	 
+	 server { # php/fastcgi
+		 listen       80;
+		 server_name  domain1.com www.domain1.com;
+		 access_log   logs/domain1.access.log  main;
+		 root         html;
+ 
+		 location ~ \.php$ {
+		 fastcgi_pass   127.0.0.1:1025;
+		 }
+	 }`)
 	fourth = []byte(`daemon            off;
-	worker_processes  2;
-	user              www-data;
-	
-	events {
-		use           epoll;
-		worker_connections  128;
-	}
-	
-	error_log         logs/error.log info;
-	
-	http {
-		server_tokens off;
-		charset       utf-8;
-	
-		access_log    logs/access.log  combined;
-	
-		server {
-			server_name   localhost;
-			listen        127.0.0.1:80;
-	
-			error_page    500 502 503 504;
-	
-			location      / {
-				root      html;
-			}
-		}
-	}`)
+	 worker_processes  2;
+	 user              www-data;
+	 
+	 events {
+		 use           epoll;
+		 worker_connections  128;
+	 }
+	 
+	 error_log         logs/error.log info;
+	 
+	 http {
+		 server_tokens off;
+		 charset       utf-8;
+	 
+		 access_log    logs/access.log  combined;
+	 
+		 server {
+			 server_name   localhost;
+			 listen        127.0.0.1:80;
+	 
+			 error_page    500 502 503 504;
+	 
+			 location      / {
+				 root      html;
+			 }
+		 }
+	 }`)
 	wafMetaData1 = []byte(`{
-		"napVersion": "3.1088.2",
-		"globalStateFileName": "",
-		"globalStateFileUID": "",
-		"attackSignatureRevisionTimestamp ": "2021.04.04",
-		"threatCampaignRevisionTimestamp": "2021.04.16",
-		"policyMetadata": [
-		  {
-			"name": "default-enforcemen t3",
-			"uid": "d102e132-12a0-483d-8329-d365d29801e0",
-			"revisionTimestamp": 1669071164488
-		  },
-		  {
-			"name": "ignore-xss3",
-			" uid": "de178e35-dc3b-40da-a53e-2bcede19e072",
-			"revisionTimestamp": 1668723801915
-		  }
-		],
-		"logProfileMetadata": [
-		  {
-			"nam e": "log_all",
-			"uid": "ee07fd58-fbd2-4db9-a2c2-0d06dc4d4321",
-			"revisionTimestamp": 1668723322517
-		  }
-		]
-	  }`)
+		 "napVersion": "3.1088.2",
+		 "globalStateFileName": "",
+		 "globalStateFileUID": "",
+		 "attackSignatureRevisionTimestamp ": "2021.04.04",
+		 "threatCampaignRevisionTimestamp": "2021.04.16",
+		 "policyMetadata": [
+		   {
+			 "name": "default-enforcemen t3",
+			 "uid": "d102e132-12a0-483d-8329-d365d29801e0",
+			 "revisionTimestamp": 1669071164488
+		   },
+		   {
+			 "name": "ignore-xss3",
+			 " uid": "de178e35-dc3b-40da-a53e-2bcede19e072",
+			 "revisionTimestamp": 1668723801915
+		   }
+		 ],
+		 "logProfileMetadata": [
+		   {
+			 "nam e": "log_all",
+			 "uid": "ee07fd58-fbd2-4db9-a2c2-0d06dc4d4321",
+			 "revisionTimestamp": 1668723322517
+		   }
+		 ]
+	   }`)
 )
 
 func TestNginxConfigApply(t *testing.T) {
@@ -1074,6 +1074,7 @@ func TestNginx_monitor(t *testing.T) {
 
 	env := tutils.GetMockEnvWithProcess()
 	binary := tutils.NewMockNginxBinary()
+	binary.On("Reload", mock.Anything, mock.Anything).Return(nil)
 	binary.On("GetErrorLogs").Return(make(map[string]string)).Once()
 	binary.On("GetErrorLogs").Return(map[string]string{errorLogFileName: errorLogFileName}).Once()
 
@@ -1083,7 +1084,7 @@ func TestNginx_monitor(t *testing.T) {
 
 	// Validate that errors in the logs returned
 	go func() {
-		errorFound := pluginUnderTest.monitor(pluginUnderTest.getNginxProccessInfo())
+		errorFound := pluginUnderTest.reloadNginx(&proto.NginxDetails{})
 		assert.NoError(t, errorFound)
 	}()
 
@@ -1093,7 +1094,7 @@ func TestNginx_monitor(t *testing.T) {
 
 	// Validate that errors in the logs returned
 	go func() {
-		errorFound := pluginUnderTest.monitor(pluginUnderTest.getNginxProccessInfo())
+		errorFound := pluginUnderTest.reloadNginx(&proto.NginxDetails{})
 		errorsChannel <- errorFound
 	}()
 	time.Sleep(1 * time.Second)


### PR DESCRIPTION
### Proposed changes

If an error is detected after a NGINX reload during a config apply, then we need to rollback the config changes and reload NGINX again to revert the changes.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
