### PR TITLE
quick change to use OSARCH variable to build amd64 binaries on arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,8 @@ run-debug: ## Run code
 build/nginx-agent:
 	GOWORK=off CGO_ENABLED=0 go build -ldflags=${LDFLAGS} -o ./build/nginx-agent
 
-build: build/nginx-agent ## Build agent executable
+build: ## Build agent executable
+	GOARCH=${OSARCH} go build -o build/nginx-agent 
 
 deps: ## Update dependencies in vendor folders
 	cd sdk && make generate

--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,9 @@ run: ## Run code
 run-debug: ## Run code
 	./build/nginx-agent
 
-build/nginx-agent:
-	GOWORK=off CGO_ENABLED=0 go build -ldflags=${LDFLAGS} -o ./build/nginx-agent
 
 build: ## Build agent executable
-	GOARCH=${OSARCH} go build -o build/nginx-agent 
+	GOWORK=off CGO_ENABLED=0 GOARCH=${OSARCH} go build -ldflags=${LDFLAGS} -o ./build/nginx-agent 
 
 deps: ## Update dependencies in vendor folders
 	cd sdk && make generate


### PR DESCRIPTION
### Proposed changes

Use OSARCH variable build amd64 binaries on arm64

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
