### PR TITLE
Improve error logging for gRPC EOF errors

### DIFF
--- a/sdk/client/commander.go
+++ b/sdk/client/commander.go
@@ -401,7 +401,12 @@ func (c *commander) handleGrpcError(messagePrefix string, err error) error {
 	if st, ok := status.FromError(err); ok {
 		log.Errorf("%s: error communicating with %s, code=%s, message=%v", messagePrefix, c.grpc.Target(), st.Code().String(), st.Message())
 	} else if err == io.EOF {
-		log.Errorf("%s: server %s is not processing requests, code=%s, message=%v", messagePrefix, c.grpc.Target(), st.Code().String(), st.Message())
+		_, err = c.channel.Recv()
+		if st, ok = status.FromError(err); ok {
+			log.Errorf("%s: server %s is not processing requests, code=%s, message=%v", messagePrefix, c.grpc.Target(), st.Code().String(), st.Message())
+		} else {
+			log.Errorf("%s: unable to receive error message for EOF from %s, %v", messagePrefix, c.grpc.Target(), err)
+		}
 	} else {
 		log.Errorf("%s: unknown grpc error while communicating with %s, %v", messagePrefix, c.grpc.Target(), err)
 	}

--- a/test/integration/vendor/github.com/nginx/agent/sdk/v2/client/commander.go
+++ b/test/integration/vendor/github.com/nginx/agent/sdk/v2/client/commander.go
@@ -401,7 +401,12 @@ func (c *commander) handleGrpcError(messagePrefix string, err error) error {
 	if st, ok := status.FromError(err); ok {
 		log.Errorf("%s: error communicating with %s, code=%s, message=%v", messagePrefix, c.grpc.Target(), st.Code().String(), st.Message())
 	} else if err == io.EOF {
-		log.Errorf("%s: server %s is not processing requests, code=%s, message=%v", messagePrefix, c.grpc.Target(), st.Code().String(), st.Message())
+		_, err = c.channel.Recv()
+		if st, ok = status.FromError(err); ok {
+			log.Errorf("%s: server %s is not processing requests, code=%s, message=%v", messagePrefix, c.grpc.Target(), st.Code().String(), st.Message())
+		} else {
+			log.Errorf("%s: unable to receive error message for EOF from %s, %v", messagePrefix, c.grpc.Target(), err)
+		}
 	} else {
 		log.Errorf("%s: unknown grpc error while communicating with %s, %v", messagePrefix, c.grpc.Target(), err)
 	}

--- a/test/performance/vendor/github.com/nginx/agent/sdk/v2/client/commander.go
+++ b/test/performance/vendor/github.com/nginx/agent/sdk/v2/client/commander.go
@@ -401,7 +401,12 @@ func (c *commander) handleGrpcError(messagePrefix string, err error) error {
 	if st, ok := status.FromError(err); ok {
 		log.Errorf("%s: error communicating with %s, code=%s, message=%v", messagePrefix, c.grpc.Target(), st.Code().String(), st.Message())
 	} else if err == io.EOF {
-		log.Errorf("%s: server %s is not processing requests, code=%s, message=%v", messagePrefix, c.grpc.Target(), st.Code().String(), st.Message())
+		_, err = c.channel.Recv()
+		if st, ok = status.FromError(err); ok {
+			log.Errorf("%s: server %s is not processing requests, code=%s, message=%v", messagePrefix, c.grpc.Target(), st.Code().String(), st.Message())
+		} else {
+			log.Errorf("%s: unable to receive error message for EOF from %s, %v", messagePrefix, c.grpc.Target(), err)
+		}
 	} else {
 		log.Errorf("%s: unknown grpc error while communicating with %s, %v", messagePrefix, c.grpc.Target(), err)
 	}

--- a/vendor/github.com/nginx/agent/sdk/v2/client/commander.go
+++ b/vendor/github.com/nginx/agent/sdk/v2/client/commander.go
@@ -401,7 +401,12 @@ func (c *commander) handleGrpcError(messagePrefix string, err error) error {
 	if st, ok := status.FromError(err); ok {
 		log.Errorf("%s: error communicating with %s, code=%s, message=%v", messagePrefix, c.grpc.Target(), st.Code().String(), st.Message())
 	} else if err == io.EOF {
-		log.Errorf("%s: server %s is not processing requests, code=%s, message=%v", messagePrefix, c.grpc.Target(), st.Code().String(), st.Message())
+		_, err = c.channel.Recv()
+		if st, ok = status.FromError(err); ok {
+			log.Errorf("%s: server %s is not processing requests, code=%s, message=%v", messagePrefix, c.grpc.Target(), st.Code().String(), st.Message())
+		} else {
+			log.Errorf("%s: unable to receive error message for EOF from %s, %v", messagePrefix, c.grpc.Target(), err)
+		}
 	} else {
 		log.Errorf("%s: unknown grpc error while communicating with %s, %v", messagePrefix, c.grpc.Target(), err)
 	}


### PR DESCRIPTION
### Proposed changes

Improve error logging for gRPC EOF errors.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
