### PR TITLE
chore: cert directives for ssl_client_certificate and ssl_trusted_certificate

### DIFF
--- a/sdk/config_helpers.go
+++ b/sdk/config_helpers.go
@@ -192,7 +192,7 @@ func updateNginxConfigFromPayload(
 			return fmt.Errorf("configs: could not read file info(%s): %s", xpConf.File, err)
 		}
 
-		if err := directoryMap.appendFile(base, info); err != nil {
+		if err = directoryMap.appendFile(base, info); err != nil {
 			return err
 		}
 
@@ -259,7 +259,7 @@ func updateNginxConfigFileConfig(
 				if err := updateNginxConfigFileWithRoot(aux, directive.Args[0], seen, allowedDirectories, directoryMap); err != nil {
 					return true, err
 				}
-			case "ssl_certificate", "proxy_ssl_certificate", "ssl_trusted_certificate":
+			case "ssl_certificate", "proxy_ssl_certificate", "ssl_client_certificate", "ssl_trusted_certificate":
 				if err := updateNginxConfigWithCert(directive.Directive, directive.Args[0], nginxConfig, aux, hostDir, directoryMap, allowedDirectories); err != nil {
 					return true, err
 				}
@@ -312,10 +312,17 @@ func updateNginxConfigWithCert(
 		}
 	}
 
-	if directive == "ssl_certificate" || directive == "proxy_ssl_certificate" {
-		cert, err := LoadCertificate(file)
-		if err != nil {
-			return fmt.Errorf("configs: could not load cert(%s): %s", file, err)
+	certDirectives := []string{
+		"ssl_certificate",
+		"proxy_ssl_certificate",
+		"ssl_client_certificate",
+		"ssl_trusted_certificate",
+	}
+
+	if contains(certDirectives, directive) {
+		cert, cErr := LoadCertificate(file)
+		if cErr != nil {
+			return fmt.Errorf("configs: could not load cert(%s): %s", file, cErr)
 		}
 
 		fingerprint := sha256.Sum256(cert.Raw)
@@ -371,6 +378,16 @@ func updateNginxConfigWithCert(
 	}
 
 	return nil
+}
+
+func contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
 }
 
 func getAccessLogDirectiveFormat(directive *crossplane.Directive) string {

--- a/sdk/config_helpers_test.go
+++ b/sdk/config_helpers_test.go
@@ -139,6 +139,7 @@ var tests = []struct {
 		
 			access_log    /tmp/testdata/logs/access1.log  $upstream_time;
 			ssl_certificate     /tmp/testdata/nginx/ca.crt;
+			ssl_trusted_certificate     /tmp/testdata/nginx/trusted.crt;
 		
 			server {
 				listen        127.0.0.1:80;
@@ -183,10 +184,15 @@ var tests = []struct {
 							{
 								Name:        "nginx.conf",
 								Permissions: "0644",
-								Lines:       int32(57),
+								Lines:       int32(58),
 							},
 							{
 								Name:        "ca.crt",
+								Permissions: "0644",
+								Lines:       int32(31),
+							},
+							{
+								Name:        "trusted.crt",
 								Permissions: "0644",
 								Lines:       int32(31),
 							},
@@ -259,6 +265,38 @@ var tests = []struct {
 						Version:                3,
 					},
 					{
+						FileName: "/tmp/testdata/nginx/trusted.crt",
+						Validity: &proto.CertificateDates{
+							NotBefore: 1632834204,
+							NotAfter:  1635426204,
+						},
+						Issuer: &proto.CertificateName{
+							CommonName:         "ca.local",
+							Country:            []string{"IE"},
+							Locality:           []string{"Cork"},
+							Organization:       []string{"NGINX"},
+							OrganizationalUnit: nil,
+						},
+						Subject: &proto.CertificateName{
+							CommonName:         "ca.local",
+							Country:            []string{"IE"},
+							Locality:           []string{"Cork"},
+							Organization:       []string{"NGINX"},
+							State:              []string{"Cork"},
+							OrganizationalUnit: nil,
+						},
+						Mtime:                  &types.Timestamp{Seconds: 1633343804, Nanos: 15240107},
+						SubjAltNames:           nil,
+						PublicKeyAlgorithm:     "RSA",
+						SignatureAlgorithm:     "SHA512-RSA",
+						SerialNumber:           "12554968962670027276",
+						SubjectKeyIdentifier:   "75:50:E2:24:8F:6F:13:1D:81:20:E1:01:0B:57:2B:98:39:E5:2E:C3",
+						Fingerprint:            "48:6D:05:D4:78:10:91:15:69:74:9C:6A:54:F7:F2:FC:C8:93:46:E8:28:42:24:41:68:41:51:1E:1E:43:E0:12",
+						FingerprintAlgorithm:   "SHA512-RSA",
+						AuthorityKeyIdentifier: "3A:79:E0:3E:61:CD:94:29:1D:BB:45:37:0B:E9:78:E9:2F:40:67:CA",
+						Version:                3,
+					},
+					{
 						FileName: "/tmp/testdata/nginx/proxy.crt",
 						Validity: &proto.CertificateDates{
 							NotBefore: 1632834204,
@@ -298,13 +336,14 @@ var tests = []struct {
 			},
 			Zconfig: &proto.ZippedFile{
 				Contents:      []uint8{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 1, 0, 0, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0},
-				Checksum:      "9e05884e8c5d1db866d1b4a55fbef7f8b54b88b7a2e0a17bc7a11e6ff5b5b500",
+				Checksum:      "10a784ba872f62e36fd94fade5d048e6384205bfe39dd06a128aa78a81358931",
 				RootDirectory: "/tmp/testdata/nginx",
 			},
 		},
 		expectedAuxFiles: map[string]struct{}{
 			"/tmp/testdata/root/test.html":          {},
 			"/tmp/testdata/nginx/ca.crt":            {},
+			"/tmp/testdata/nginx/trusted.crt":       {},
 			"/tmp/testdata/nginx/proxy.crt":         {},
 			"/tmp/testdata/root/my-nap-policy.json": {},
 			"/tmp/testdata/root/log-default.json":   {},
@@ -337,7 +376,7 @@ var tests = []struct {
 			charset       utf-8;
 		
 			access_log    /tmp/testdata/logs/access1.log  $upstream_time;
-			ssl_certificate     /tmp/testdata/nginx/ca.crt;
+			ssl_certificate     /tmp/testdata/nginx/ca.crt;	
 		
 			server {
 				listen        127.0.0.1:80;
@@ -443,7 +482,7 @@ var tests = []struct {
 			},
 			Zconfig: &proto.ZippedFile{
 				Contents:      []uint8{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 1, 0, 0, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0},
-				Checksum:      "433837974aaab32148c9bb034f1c59ab878482af506a13d9a834a8a99384efbd",
+				Checksum:      "737493b580f29636e998efd2e85cf552217ad9a22e69c3bf6192eedaec681976",
 				RootDirectory: "/tmp/testdata/nginx",
 			},
 		},
@@ -657,7 +696,7 @@ func TestGetNginxConfig(t *testing.T) {
 			allowedDirs["/tmp/testdata/nginx/"] = struct{}{}
 		}
 		result, err := GetNginxConfigWithIgnoreDirectives(test.fileName, nginxID, systemID, allowedDirs, ignoreDirectives)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, test.expected.Action, result.Action)
 		assert.Equal(t, len(test.expected.DirectoryMap.Directories), len(result.DirectoryMap.Directories))
@@ -1268,6 +1307,14 @@ func generateCertificates() error {
 
 	// create proxy.crt copy
 	copyCmd := exec.Command("cp", "/tmp/testdata/nginx/ca.crt", "/tmp/testdata/nginx/proxy.crt")
+
+	err = copyCmd.Run()
+	if err != nil {
+		return err
+	}
+
+	// create trusted.crt copy
+	copyCmd = exec.Command("cp", "/tmp/testdata/nginx/ca.crt", "/tmp/testdata/nginx/trusted.crt")
 
 	err = copyCmd.Run()
 	if err != nil {

--- a/test/integration/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/test/integration/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -192,7 +192,7 @@ func updateNginxConfigFromPayload(
 			return fmt.Errorf("configs: could not read file info(%s): %s", xpConf.File, err)
 		}
 
-		if err := directoryMap.appendFile(base, info); err != nil {
+		if err = directoryMap.appendFile(base, info); err != nil {
 			return err
 		}
 
@@ -259,7 +259,7 @@ func updateNginxConfigFileConfig(
 				if err := updateNginxConfigFileWithRoot(aux, directive.Args[0], seen, allowedDirectories, directoryMap); err != nil {
 					return true, err
 				}
-			case "ssl_certificate", "proxy_ssl_certificate", "ssl_trusted_certificate":
+			case "ssl_certificate", "proxy_ssl_certificate", "ssl_client_certificate", "ssl_trusted_certificate":
 				if err := updateNginxConfigWithCert(directive.Directive, directive.Args[0], nginxConfig, aux, hostDir, directoryMap, allowedDirectories); err != nil {
 					return true, err
 				}
@@ -312,10 +312,17 @@ func updateNginxConfigWithCert(
 		}
 	}
 
-	if directive == "ssl_certificate" || directive == "proxy_ssl_certificate" {
-		cert, err := LoadCertificate(file)
-		if err != nil {
-			return fmt.Errorf("configs: could not load cert(%s): %s", file, err)
+	certDirectives := []string{
+		"ssl_certificate",
+		"proxy_ssl_certificate",
+		"ssl_client_certificate",
+		"ssl_trusted_certificate",
+	}
+
+	if contains(certDirectives, directive) {
+		cert, cErr := LoadCertificate(file)
+		if cErr != nil {
+			return fmt.Errorf("configs: could not load cert(%s): %s", file, cErr)
 		}
 
 		fingerprint := sha256.Sum256(cert.Raw)
@@ -371,6 +378,16 @@ func updateNginxConfigWithCert(
 	}
 
 	return nil
+}
+
+func contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
 }
 
 func getAccessLogDirectiveFormat(directive *crossplane.Directive) string {

--- a/test/performance/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/test/performance/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -192,7 +192,7 @@ func updateNginxConfigFromPayload(
 			return fmt.Errorf("configs: could not read file info(%s): %s", xpConf.File, err)
 		}
 
-		if err := directoryMap.appendFile(base, info); err != nil {
+		if err = directoryMap.appendFile(base, info); err != nil {
 			return err
 		}
 
@@ -259,7 +259,7 @@ func updateNginxConfigFileConfig(
 				if err := updateNginxConfigFileWithRoot(aux, directive.Args[0], seen, allowedDirectories, directoryMap); err != nil {
 					return true, err
 				}
-			case "ssl_certificate", "proxy_ssl_certificate", "ssl_trusted_certificate":
+			case "ssl_certificate", "proxy_ssl_certificate", "ssl_client_certificate", "ssl_trusted_certificate":
 				if err := updateNginxConfigWithCert(directive.Directive, directive.Args[0], nginxConfig, aux, hostDir, directoryMap, allowedDirectories); err != nil {
 					return true, err
 				}
@@ -312,10 +312,17 @@ func updateNginxConfigWithCert(
 		}
 	}
 
-	if directive == "ssl_certificate" || directive == "proxy_ssl_certificate" {
-		cert, err := LoadCertificate(file)
-		if err != nil {
-			return fmt.Errorf("configs: could not load cert(%s): %s", file, err)
+	certDirectives := []string{
+		"ssl_certificate",
+		"proxy_ssl_certificate",
+		"ssl_client_certificate",
+		"ssl_trusted_certificate",
+	}
+
+	if contains(certDirectives, directive) {
+		cert, cErr := LoadCertificate(file)
+		if cErr != nil {
+			return fmt.Errorf("configs: could not load cert(%s): %s", file, cErr)
 		}
 
 		fingerprint := sha256.Sum256(cert.Raw)
@@ -371,6 +378,16 @@ func updateNginxConfigWithCert(
 	}
 
 	return nil
+}
+
+func contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
 }
 
 func getAccessLogDirectiveFormat(directive *crossplane.Directive) string {

--- a/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -192,7 +192,7 @@ func updateNginxConfigFromPayload(
 			return fmt.Errorf("configs: could not read file info(%s): %s", xpConf.File, err)
 		}
 
-		if err := directoryMap.appendFile(base, info); err != nil {
+		if err = directoryMap.appendFile(base, info); err != nil {
 			return err
 		}
 
@@ -259,7 +259,7 @@ func updateNginxConfigFileConfig(
 				if err := updateNginxConfigFileWithRoot(aux, directive.Args[0], seen, allowedDirectories, directoryMap); err != nil {
 					return true, err
 				}
-			case "ssl_certificate", "proxy_ssl_certificate", "ssl_trusted_certificate":
+			case "ssl_certificate", "proxy_ssl_certificate", "ssl_client_certificate", "ssl_trusted_certificate":
 				if err := updateNginxConfigWithCert(directive.Directive, directive.Args[0], nginxConfig, aux, hostDir, directoryMap, allowedDirectories); err != nil {
 					return true, err
 				}
@@ -312,10 +312,17 @@ func updateNginxConfigWithCert(
 		}
 	}
 
-	if directive == "ssl_certificate" || directive == "proxy_ssl_certificate" {
-		cert, err := LoadCertificate(file)
-		if err != nil {
-			return fmt.Errorf("configs: could not load cert(%s): %s", file, err)
+	certDirectives := []string{
+		"ssl_certificate",
+		"proxy_ssl_certificate",
+		"ssl_client_certificate",
+		"ssl_trusted_certificate",
+	}
+
+	if contains(certDirectives, directive) {
+		cert, cErr := LoadCertificate(file)
+		if cErr != nil {
+			return fmt.Errorf("configs: could not load cert(%s): %s", file, cErr)
 		}
 
 		fingerprint := sha256.Sum256(cert.Raw)
@@ -371,6 +378,16 @@ func updateNginxConfigWithCert(
 	}
 
 	return nil
+}
+
+func contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
 }
 
 func getAccessLogDirectiveFormat(directive *crossplane.Directive) string {


### PR DESCRIPTION
### Proposed changes

Add support for the `ssl_client_certificate` and `ssl_trusted_certificate` directives to treat them the same as `ssl_certificate` and `ssl_proxy_certificate`.  Certificates managed in NMS can then appropriately display the associations for NGINX Instance and Instance Groups when configured.

This change is required to complete the expected end-to-end behavior of NMS-43701.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
