### PR TITLE
Fix how status API URL is determined when both stub status and NGINX Plus APIs are configured

### DIFF
--- a/sdk/config_helpers_test.go
+++ b/sdk/config_helpers_test.go
@@ -1095,6 +1095,39 @@ server {
 }
 		`,
 		},
+		{
+			oss: []string{
+				"http://localhost:80/stub_status",
+				"http://127.0.0.1:80/stub_status",
+			},
+			plus: []string{
+				"http://localhost:80/api/",
+				"http://127.0.0.1:80/api/",
+			},
+			conf: `
+server {
+	server_name   localhost;
+	listen        80;
+
+	error_page    500 502 503 504  /50x.html;
+	# ssl_certificate /usr/local/nginx/conf/cert.pem;
+
+	location      / {
+		root      /tmp/testdata/foo;
+	}
+
+	location = /stub_status {
+		stub_status;
+	}
+
+	location /api/ {
+        api write=on;
+        allow 127.0.0.1;
+        deny all;
+    }
+}
+		`,
+		},
 	} {
 		f, err := os.CreateTemp(tmpDir, "conf")
 		assert.NoError(t, err)
@@ -1114,7 +1147,8 @@ server {
 		for _, xpConf := range payload.Config {
 			assert.Equal(t, len(xpConf.Parsed), 1)
 			err = CrossplaneConfigTraverse(&xpConf, func(parent *crossplane.Directive, current *crossplane.Directive) (bool, error) {
-				_plus, _oss := parseStatusAPIEndpoints(parent, current)
+				_oss := getUrlsForLocationDirective(parent, current, stubStatusAPIDirective)
+				_plus := getUrlsForLocationDirective(parent, current, plusAPIDirective)
 				oss = append(oss, _oss...)
 				plus = append(plus, _plus...)
 				return true, nil

--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -203,11 +203,21 @@ func (n *NginxBinaryType) GetNginxDetailsFromProcess(nginxProcess *Process) *pro
 		nginxDetailsFacade.ConfPath = path
 	}
 
-	url, err := sdk.GetStatusApiInfoWithIgnoreDirectives(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
+	stubStatusApiUrl, err := sdk.GetStubStatusApiUrl(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
 	if err != nil {
-		log.Tracef("Unable to get status api from the configuration: NGINX metrics will be unavailable for this system. please configure a status API to get NGINX metrics: %v", err)
+		log.Tracef("Unable to get Stub Status API URL from the configuration: NGINX OSS metrics will be unavailable for this system. please configure aStub Status API to get NGINX OSS metrics: %v", err)
 	}
-	nginxDetailsFacade.StatusUrl = url
+
+	nginxPlusApiUrl, err := sdk.GetNginxPlusApiUrl(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
+	if err != nil {
+		log.Tracef("Unable to get NGINX Plus API URL from the configuration: NGINX Plus metrics will be unavailable for this system. please configure a NGINX Plus API to get NGINX Plus metrics: %v", err)
+	}
+
+	if nginxDetailsFacade.Plus.Enabled {
+		nginxDetailsFacade.StatusUrl = nginxPlusApiUrl
+	} else {
+		nginxDetailsFacade.StatusUrl = stubStatusApiUrl
+	}
 
 	return nginxDetailsFacade
 }

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/nginx.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/nginx.go
@@ -203,11 +203,21 @@ func (n *NginxBinaryType) GetNginxDetailsFromProcess(nginxProcess *Process) *pro
 		nginxDetailsFacade.ConfPath = path
 	}
 
-	url, err := sdk.GetStatusApiInfoWithIgnoreDirectives(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
+	stubStatusApiUrl, err := sdk.GetStubStatusApiUrl(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
 	if err != nil {
-		log.Tracef("Unable to get status api from the configuration: NGINX metrics will be unavailable for this system. please configure a status API to get NGINX metrics: %v", err)
+		log.Tracef("Unable to get Stub Status API URL from the configuration: NGINX OSS metrics will be unavailable for this system. please configure aStub Status API to get NGINX OSS metrics: %v", err)
 	}
-	nginxDetailsFacade.StatusUrl = url
+
+	nginxPlusApiUrl, err := sdk.GetNginxPlusApiUrl(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
+	if err != nil {
+		log.Tracef("Unable to get NGINX Plus API URL from the configuration: NGINX Plus metrics will be unavailable for this system. please configure a NGINX Plus API to get NGINX Plus metrics: %v", err)
+	}
+
+	if nginxDetailsFacade.Plus.Enabled {
+		nginxDetailsFacade.StatusUrl = nginxPlusApiUrl
+	} else {
+		nginxDetailsFacade.StatusUrl = stubStatusApiUrl
+	}
 
 	return nginxDetailsFacade
 }

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
@@ -203,11 +203,21 @@ func (n *NginxBinaryType) GetNginxDetailsFromProcess(nginxProcess *Process) *pro
 		nginxDetailsFacade.ConfPath = path
 	}
 
-	url, err := sdk.GetStatusApiInfoWithIgnoreDirectives(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
+	stubStatusApiUrl, err := sdk.GetStubStatusApiUrl(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
 	if err != nil {
-		log.Tracef("Unable to get status api from the configuration: NGINX metrics will be unavailable for this system. please configure a status API to get NGINX metrics: %v", err)
+		log.Tracef("Unable to get Stub Status API URL from the configuration: NGINX OSS metrics will be unavailable for this system. please configure aStub Status API to get NGINX OSS metrics: %v", err)
 	}
-	nginxDetailsFacade.StatusUrl = url
+
+	nginxPlusApiUrl, err := sdk.GetNginxPlusApiUrl(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
+	if err != nil {
+		log.Tracef("Unable to get NGINX Plus API URL from the configuration: NGINX Plus metrics will be unavailable for this system. please configure a NGINX Plus API to get NGINX Plus metrics: %v", err)
+	}
+
+	if nginxDetailsFacade.Plus.Enabled {
+		nginxDetailsFacade.StatusUrl = nginxPlusApiUrl
+	} else {
+		nginxDetailsFacade.StatusUrl = stubStatusApiUrl
+	}
 
 	return nginxDetailsFacade
 }


### PR DESCRIPTION
### Proposed changes

Fix how status API URL is determined when both stub status and NGINX Plus APIs are configured.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
