### PR TITLE
Draft: Race condition during reload

### DIFF
--- a/sdk/config_helpers_test.go
+++ b/sdk/config_helpers_test.go
@@ -1095,6 +1095,39 @@ server {
 }
 		`,
 		},
+		{
+			oss: []string{
+				"http://localhost:80/stub_status",
+				"http://127.0.0.1:80/stub_status",
+			},
+			plus: []string{
+				"http://localhost:80/api/",
+				"http://127.0.0.1:80/api/",
+			},
+			conf: `
+server {
+	server_name   localhost;
+	listen        80;
+
+	error_page    500 502 503 504  /50x.html;
+	# ssl_certificate /usr/local/nginx/conf/cert.pem;
+
+	location      / {
+		root      /tmp/testdata/foo;
+	}
+
+	location = /stub_status {
+		stub_status;
+	}
+
+	location /api/ {
+        api write=on;
+        allow 127.0.0.1;
+        deny all;
+    }
+}
+		`,
+		},
 	} {
 		f, err := os.CreateTemp(tmpDir, "conf")
 		assert.NoError(t, err)
@@ -1114,7 +1147,8 @@ server {
 		for _, xpConf := range payload.Config {
 			assert.Equal(t, len(xpConf.Parsed), 1)
 			err = CrossplaneConfigTraverse(&xpConf, func(parent *crossplane.Directive, current *crossplane.Directive) (bool, error) {
-				_plus, _oss := parseStatusAPIEndpoints(parent, current)
+				_oss := getUrlsForLocationDirective(parent, current, stubStatusAPIDirective)
+				_plus := getUrlsForLocationDirective(parent, current, plusAPIDirective)
 				oss = append(oss, _oss...)
 				plus = append(plus, _plus...)
 				return true, nil

--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -203,11 +203,21 @@ func (n *NginxBinaryType) GetNginxDetailsFromProcess(nginxProcess *Process) *pro
 		nginxDetailsFacade.ConfPath = path
 	}
 
-	url, err := sdk.GetStatusApiInfoWithIgnoreDirectives(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
+	stubStatusApiUrl, err := sdk.GetStubStatusApiUrl(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
 	if err != nil {
-		log.Tracef("Unable to get status api from the configuration: NGINX metrics will be unavailable for this system. please configure a status API to get NGINX metrics: %v", err)
+		log.Tracef("Unable to get Stub Status API URL from the configuration: NGINX OSS metrics will be unavailable for this system. please configure aStub Status API to get NGINX OSS metrics: %v", err)
 	}
-	nginxDetailsFacade.StatusUrl = url
+
+	nginxPlusApiUrl, err := sdk.GetNginxPlusApiUrl(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
+	if err != nil {
+		log.Tracef("Unable to get NGINX Plus API URL from the configuration: NGINX Plus metrics will be unavailable for this system. please configure a NGINX Plus API to get NGINX Plus metrics: %v", err)
+	}
+
+	if nginxDetailsFacade.Plus.Enabled {
+		nginxDetailsFacade.StatusUrl = nginxPlusApiUrl
+	} else {
+		nginxDetailsFacade.StatusUrl = stubStatusApiUrl
+	}
 
 	return nginxDetailsFacade
 }

--- a/src/plugins/dataplane_status.go
+++ b/src/plugins/dataplane_status.go
@@ -38,7 +38,6 @@ type DataPlaneStatus struct {
 	configDirs                  string
 	lastSendDetails             time.Time
 	envHostInfo                 *proto.HostInfo
-	statusUrls                  map[string]string
 	reportInterval              time.Duration
 	softwareDetails             map[string]*proto.DataplaneSoftwareDetails
 	nginxConfigActivityStatuses map[string]*proto.AgentActivityStatus
@@ -66,7 +65,6 @@ func NewDataPlaneStatus(config *config.Config, meta *proto.Metadata, binary core
 		version:                     version,
 		tags:                        &config.Tags,
 		configDirs:                  config.ConfigDirs,
-		statusUrls:                  make(map[string]string),
 		reportInterval:              config.Dataplane.Status.ReportInterval,
 		softwareDetailsMutex:        sync.RWMutex{},
 		nginxConfigActivityStatuses: make(map[string]*proto.AgentActivityStatus),
@@ -83,7 +81,6 @@ func (dps *DataPlaneStatus) Init(pipeline core.MessagePipeInterface) {
 
 func (dps *DataPlaneStatus) Close() {
 	log.Info("DataPlaneStatus is wrapping up")
-	dps.statusUrls = nil
 	dps.nginxConfigActivityStatuses = nil
 
 	dps.softwareDetailsMutex.Lock()
@@ -230,29 +227,18 @@ func (dps *DataPlaneStatus) detailsForProcess(processes []*core.Process, send bo
 	log.Tracef("detailsForProcess processes: %v", processes)
 
 	nowUTC := time.Now().UTC()
-	statusAPIUpdated := false
 	// this sets send if we are forcing details, or it has been 24 hours since the last send
 	for _, p := range processes {
 		if !p.IsMaster {
 			continue
 		}
 		detail := dps.binary.GetNginxDetailsFromProcess(p)
-		if dps.statusUrls[detail.NginxId] != detail.StatusUrl {
-			log.Infof("NGINX status API updated.  Old status API: %v, new status API: %v", dps.statusUrls[detail.NginxId], detail.StatusUrl)
-			dps.statusUrls[detail.NginxId] = detail.StatusUrl
-			statusAPIUpdated = true
-		}
 		details = append(details, detail)
 		// spec says process CreateTime is unix UTC in MS
 		if time.Unix(p.CreateTime/1000, 0).After(dps.lastSendDetails) {
 			// set send because this process has started since the last send
 			send = true
 		}
-	}
-
-	// If the statusAPI was updated send a new NGINX status API updated message
-	if statusAPIUpdated {
-		dps.messagePipeline.Process(core.NewMessage(core.NginxStatusAPIUpdate, ""))
 	}
 
 	if !send {

--- a/src/plugins/metrics.go
+++ b/src/plugins/metrics.go
@@ -290,6 +290,7 @@ func createCollectorConfigsMap(config *config.Config, env core.Environment, bina
 			continue
 		}
 		detail := binary.GetNginxDetailsFromProcess(p)
+		detail = binary.SetStatusUrl(detail)
 
 		stubStatusApi, plusApi := "", ""
 		if detail.Plus.Enabled {

--- a/src/plugins/nginx_test.go
+++ b/src/plugins/nginx_test.go
@@ -535,6 +535,8 @@ func TestNginxConfigApply(t *testing.T) {
 			binary.On("GetNginxDetailsByID", "12345").Return(tutils.GetDetailsMap()["12345"])
 			binary.On("UpdateNginxDetailsFromProcesses", env.Processes())
 			binary.On("GetNginxDetailsMapFromProcesses", env.Processes()).Return(tutils.GetDetailsMap())
+			binary.On("GetNginxDetailsFromProcess", mock.Anything).Return(tutils.GetDetailsMap()["12345"])
+			binary.On("SetStatusUrl", mock.Anything).Return(tutils.GetDetailsMap()["12345"])
 			binary.On("Reload", mock.Anything, mock.Anything).Return(nil)
 			binary.On("GetErrorLogs").Return(make(map[string]string))
 
@@ -851,7 +853,8 @@ func TestNginx_completeConfigApply(t *testing.T) {
 	binary.On("uploadConfig", mock.Anything, mock.Anything).Return(nil)
 	binary.On("GetNginxDetailsByID", "12345").Return(tutils.GetDetailsMap()["12345"])
 	binary.On("ReadConfig", mock.Anything, mock.Anything, mock.Anything).Return(&proto.NginxConfig{}, nil)
-
+	binary.On("GetNginxDetailsFromProcess", mock.Anything).Return(tutils.GetDetailsMap()["12345"])
+	binary.On("SetStatusUrl", mock.Anything).Return(tutils.GetDetailsMap()["12345"])
 	binary.On("UpdateNginxDetailsFromProcesses", env.Processes()).Once()
 	binary.On("GetNginxDetailsMapFromProcesses", env.Processes()).Return(tutils.GetDetailsMap()).Once()
 

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/nginx.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/nginx.go
@@ -203,11 +203,21 @@ func (n *NginxBinaryType) GetNginxDetailsFromProcess(nginxProcess *Process) *pro
 		nginxDetailsFacade.ConfPath = path
 	}
 
-	url, err := sdk.GetStatusApiInfoWithIgnoreDirectives(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
+	stubStatusApiUrl, err := sdk.GetStubStatusApiUrl(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
 	if err != nil {
-		log.Tracef("Unable to get status api from the configuration: NGINX metrics will be unavailable for this system. please configure a status API to get NGINX metrics: %v", err)
+		log.Tracef("Unable to get Stub Status API URL from the configuration: NGINX OSS metrics will be unavailable for this system. please configure aStub Status API to get NGINX OSS metrics: %v", err)
 	}
-	nginxDetailsFacade.StatusUrl = url
+
+	nginxPlusApiUrl, err := sdk.GetNginxPlusApiUrl(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
+	if err != nil {
+		log.Tracef("Unable to get NGINX Plus API URL from the configuration: NGINX Plus metrics will be unavailable for this system. please configure a NGINX Plus API to get NGINX Plus metrics: %v", err)
+	}
+
+	if nginxDetailsFacade.Plus.Enabled {
+		nginxDetailsFacade.StatusUrl = nginxPlusApiUrl
+	} else {
+		nginxDetailsFacade.StatusUrl = stubStatusApiUrl
+	}
 
 	return nginxDetailsFacade
 }

--- a/test/integration/vendor/github.com/nginx/agent/v2/test/utils/nginx.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/test/utils/nginx.go
@@ -148,6 +148,11 @@ func (m *MockNginxBinary) GetErrorLogs() map[string]string {
 	return args.Get(0).(map[string]string)
 }
 
+func (m *MockNginxBinary) SetStatusUrl(nginxDetail *proto.NginxDetails) *proto.NginxDetails {
+	args := m.Called(nginxDetail)
+	return args.Get(0).(*proto.NginxDetails)
+}
+
 func NewMockNginxBinary() *MockNginxBinary {
 	return &MockNginxBinary{}
 }

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
@@ -203,11 +203,21 @@ func (n *NginxBinaryType) GetNginxDetailsFromProcess(nginxProcess *Process) *pro
 		nginxDetailsFacade.ConfPath = path
 	}
 
-	url, err := sdk.GetStatusApiInfoWithIgnoreDirectives(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
+	stubStatusApiUrl, err := sdk.GetStubStatusApiUrl(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
 	if err != nil {
-		log.Tracef("Unable to get status api from the configuration: NGINX metrics will be unavailable for this system. please configure a status API to get NGINX metrics: %v", err)
+		log.Tracef("Unable to get Stub Status API URL from the configuration: NGINX OSS metrics will be unavailable for this system. please configure aStub Status API to get NGINX OSS metrics: %v", err)
 	}
-	nginxDetailsFacade.StatusUrl = url
+
+	nginxPlusApiUrl, err := sdk.GetNginxPlusApiUrl(nginxDetailsFacade.ConfPath, n.config.IgnoreDirectives)
+	if err != nil {
+		log.Tracef("Unable to get NGINX Plus API URL from the configuration: NGINX Plus metrics will be unavailable for this system. please configure a NGINX Plus API to get NGINX Plus metrics: %v", err)
+	}
+
+	if nginxDetailsFacade.Plus.Enabled {
+		nginxDetailsFacade.StatusUrl = nginxPlusApiUrl
+	} else {
+		nginxDetailsFacade.StatusUrl = stubStatusApiUrl
+	}
 
 	return nginxDetailsFacade
 }

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/dataplane_status.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/dataplane_status.go
@@ -38,7 +38,6 @@ type DataPlaneStatus struct {
 	configDirs                  string
 	lastSendDetails             time.Time
 	envHostInfo                 *proto.HostInfo
-	statusUrls                  map[string]string
 	reportInterval              time.Duration
 	softwareDetails             map[string]*proto.DataplaneSoftwareDetails
 	nginxConfigActivityStatuses map[string]*proto.AgentActivityStatus
@@ -66,7 +65,6 @@ func NewDataPlaneStatus(config *config.Config, meta *proto.Metadata, binary core
 		version:                     version,
 		tags:                        &config.Tags,
 		configDirs:                  config.ConfigDirs,
-		statusUrls:                  make(map[string]string),
 		reportInterval:              config.Dataplane.Status.ReportInterval,
 		softwareDetailsMutex:        sync.RWMutex{},
 		nginxConfigActivityStatuses: make(map[string]*proto.AgentActivityStatus),
@@ -83,7 +81,6 @@ func (dps *DataPlaneStatus) Init(pipeline core.MessagePipeInterface) {
 
 func (dps *DataPlaneStatus) Close() {
 	log.Info("DataPlaneStatus is wrapping up")
-	dps.statusUrls = nil
 	dps.nginxConfigActivityStatuses = nil
 
 	dps.softwareDetailsMutex.Lock()
@@ -230,29 +227,18 @@ func (dps *DataPlaneStatus) detailsForProcess(processes []*core.Process, send bo
 	log.Tracef("detailsForProcess processes: %v", processes)
 
 	nowUTC := time.Now().UTC()
-	statusAPIUpdated := false
 	// this sets send if we are forcing details, or it has been 24 hours since the last send
 	for _, p := range processes {
 		if !p.IsMaster {
 			continue
 		}
 		detail := dps.binary.GetNginxDetailsFromProcess(p)
-		if dps.statusUrls[detail.NginxId] != detail.StatusUrl {
-			log.Infof("NGINX status API updated.  Old status API: %v, new status API: %v", dps.statusUrls[detail.NginxId], detail.StatusUrl)
-			dps.statusUrls[detail.NginxId] = detail.StatusUrl
-			statusAPIUpdated = true
-		}
 		details = append(details, detail)
 		// spec says process CreateTime is unix UTC in MS
 		if time.Unix(p.CreateTime/1000, 0).After(dps.lastSendDetails) {
 			// set send because this process has started since the last send
 			send = true
 		}
-	}
-
-	// If the statusAPI was updated send a new NGINX status API updated message
-	if statusAPIUpdated {
-		dps.messagePipeline.Process(core.NewMessage(core.NginxStatusAPIUpdate, ""))
 	}
 
 	if !send {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/metrics.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/metrics.go
@@ -290,6 +290,7 @@ func createCollectorConfigsMap(config *config.Config, env core.Environment, bina
 			continue
 		}
 		detail := binary.GetNginxDetailsFromProcess(p)
+		detail = binary.SetStatusUrl(detail)
 
 		stubStatusApi, plusApi := "", ""
 		if detail.Plus.Enabled {

--- a/test/performance/vendor/github.com/nginx/agent/v2/test/utils/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/test/utils/nginx.go
@@ -148,6 +148,11 @@ func (m *MockNginxBinary) GetErrorLogs() map[string]string {
 	return args.Get(0).(map[string]string)
 }
 
+func (m *MockNginxBinary) SetStatusUrl(nginxDetail *proto.NginxDetails) *proto.NginxDetails {
+	args := m.Called(nginxDetail)
+	return args.Get(0).(*proto.NginxDetails)
+}
+
 func NewMockNginxBinary() *MockNginxBinary {
 	return &MockNginxBinary{}
 }

--- a/test/utils/nginx.go
+++ b/test/utils/nginx.go
@@ -148,6 +148,11 @@ func (m *MockNginxBinary) GetErrorLogs() map[string]string {
 	return args.Get(0).(map[string]string)
 }
 
+func (m *MockNginxBinary) SetStatusUrl(nginxDetail *proto.NginxDetails) *proto.NginxDetails {
+	args := m.Called(nginxDetail)
+	return args.Get(0).(*proto.NginxDetails)
+}
+
 func NewMockNginxBinary() *MockNginxBinary {
 	return &MockNginxBinary{}
 }


### PR DESCRIPTION
### Proposed changes

Centralize the stub status URL so it does not happen in each dataplane status cycle. A race condition was occurring during config apply logic where false error were being put into the NGINX logs and causing intermittent failures

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
