### PR TITLE
fix: bump hugo theme to 0.35.0

### DIFF
--- a/hugo/config/_default/config.toml
+++ b/hugo/config/_default/config.toml
@@ -9,6 +9,8 @@ refLinksErrorLevel = "ERROR"
 enableRobotsTXT = "true"
 #canonifyURLs = true
 pluralizeListTitles = false
+pygmentsCodeFences = true
+pygmentsUseClasses = true
 
 [caches]
   [caches.modules]

--- a/hugo/go.mod
+++ b/hugo/go.mod
@@ -2,4 +2,4 @@ module github.com/nginx/agent/hugo
 
 go 1.18
 
-require github.com/nginxinc/nginx-hugo-theme v0.34.0 // indirect
+require github.com/nginxinc/nginx-hugo-theme v0.35.0 // indirect

--- a/hugo/go.sum
+++ b/hugo/go.sum
@@ -6,3 +6,5 @@ github.com/nginxinc/nginx-hugo-theme v0.34.0-alpha h1:8tKWnkhxP5Nk0V64v8rE9T3cru
 github.com/nginxinc/nginx-hugo-theme v0.34.0-alpha/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
 github.com/nginxinc/nginx-hugo-theme v0.34.0 h1:G7LPVq7w1ls6IS4+OkTwjhFb67rLCzPdfZvW1/sn2Cw=
 github.com/nginxinc/nginx-hugo-theme v0.34.0/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
+github.com/nginxinc/nginx-hugo-theme v0.35.0 h1:7XB2GMy6qeJgKEJy9wOS3SYKYpfvLW3/H+UHRPLM4FU=
+github.com/nginxinc/nginx-hugo-theme v0.35.0/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=


### PR DESCRIPTION
### Proposed changes

- Bumps the Hugo theme to v.0.35.0
- New highlight colors for code blocks that fix some accessibility issues

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
