### PR TITLE
fix: update crossplane version to use the latest parsing logic for NGINX config files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -238,7 +238,7 @@ require (
 	github.com/muesli/termenv v0.15.1 // indirect
 	github.com/nakabonne/nestif v0.3.1 // indirect
 	github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354 // indirect
-	github.com/nginxinc/nginx-go-crossplane v0.4.17 // indirect
+	github.com/nginxinc/nginx-go-crossplane v0.4.24 // indirect
 	github.com/nishanths/exhaustive v0.9.5 // indirect
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/nunnatsa/ginkgolinter v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -675,8 +675,8 @@ github.com/nakabonne/nestif v0.3.1 h1:wm28nZjhQY5HyYPx+weN3Q65k6ilSBxDb8v5S81B81
 github.com/nakabonne/nestif v0.3.1/go.mod h1:9EtoZochLn5iUprVDmDjqGKPofoUEBL8U4Ngq6aY7OE=
 github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354 h1:4kuARK6Y6FxaNu/BnU2OAaLF86eTVhP2hjTB6iMvItA=
 github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
-github.com/nginxinc/nginx-go-crossplane v0.4.17 h1:kBISwQT36Uv4h57ran0bT4MIWUqaoJrMwoTMpryBZcg=
-github.com/nginxinc/nginx-go-crossplane v0.4.17/go.mod h1:UzbZnyFv0vPlt1Urbnp/mrFCzBL4tYCReFuNBpFQEfI=
+github.com/nginxinc/nginx-go-crossplane v0.4.24 h1:6gwZ8Boh8FS/kiZlfwSImO6UFnCjPeZ2uleHGSx4b+4=
+github.com/nginxinc/nginx-go-crossplane v0.4.24/go.mod h1:UzbZnyFv0vPlt1Urbnp/mrFCzBL4tYCReFuNBpFQEfI=
 github.com/nginxinc/nginx-plus-go-client v0.10.0 h1:3zsMMkPvRDo8D7ZSprXtbAEW/SDmezZWzxdyS+6oAlc=
 github.com/nginxinc/nginx-plus-go-client v0.10.0/go.mod h1:0v3RsQCvRn/IyrMtW+DK6CNkz+PxEsXDJPjQ3yUMBF0=
 github.com/nginxinc/nginx-prometheus-exporter v0.11.0 h1:21xjnqNgxtni2jDgAQ90bl15uDnrTreO9sIlu1YsX/U=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1235,6 +1235,7 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-sqlite3 v1.6.0 h1:TDwTWbeII+88Qy55nWlof0DclgAtI4LqGujkYMzmQII=
+github.com/maxbrunsfeld/counterfeiter/v6 v6.6.1/go.mod h1:qbKwBR+qQODzH2WD/s53mdgp/xVcXMlJb59GRFOp6Z4=
 github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517 h1:zpIH83+oKzcpryru8ceC6BxnoG8TBrhgAvRg8obzup0=
 github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
@@ -1519,6 +1520,7 @@ golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhp
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 h1:4+4C/Iv2U4fMZBiMCc98MG1In4gJY5YRhtpDNeDeHWs=
 golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.10.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.11.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/nginxinc/nginx-go-crossplane v0.4.17
+	github.com/nginxinc/nginx-go-crossplane v0.4.24
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	google.golang.org/grpc v1.56.2

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -49,8 +49,8 @@ github.com/maxbrunsfeld/counterfeiter/v6 v6.6.2 h1:CEy7VRV/Vbm7YLuZo3pGKa5GlPX4z
 github.com/maxbrunsfeld/counterfeiter/v6 v6.6.2/go.mod h1:otjOyjeqm3LALYcmX2AQIGH0VlojDoSd8aGOzsHAnBc=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/nginxinc/nginx-go-crossplane v0.4.17 h1:kBISwQT36Uv4h57ran0bT4MIWUqaoJrMwoTMpryBZcg=
-github.com/nginxinc/nginx-go-crossplane v0.4.17/go.mod h1:UzbZnyFv0vPlt1Urbnp/mrFCzBL4tYCReFuNBpFQEfI=
+github.com/nginxinc/nginx-go-crossplane v0.4.24 h1:6gwZ8Boh8FS/kiZlfwSImO6UFnCjPeZ2uleHGSx4b+4=
+github.com/nginxinc/nginx-go-crossplane v0.4.24/go.mod h1:UzbZnyFv0vPlt1Urbnp/mrFCzBL4tYCReFuNBpFQEfI=
 github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/sdk/vendor/github.com/nginxinc/nginx-go-crossplane/.golangci.yml
+++ b/sdk/vendor/github.com/nginxinc/nginx-go-crossplane/.golangci.yml
@@ -4,6 +4,9 @@
 linters:
   enable-all: true
   disable:
+    - cyclop
+    - depguard
+    - varnamelen
     - goimports # handled by `make format`
     - gofmt # handled by `make format`
     - wsl # hyper specific to a the creator and not configurable enough to be useful - https://github.com/bombsimon/wsl
@@ -11,7 +14,6 @@ linters:
     - gomnd
     - godox
     - nlreturn
-    - exhaustivestruct
     - wrapcheck
     - thelper
     - testpackage
@@ -25,11 +27,13 @@ linters:
     - golint
     - maligned
     - scopelint
+    - exhaustruct
     # deprecated
     - deadcode
     - varcheck
     - structcheck
     - nosnakecase
+    - exhaustivestruct
 
 
 # Run options

--- a/sdk/vendor/github.com/nginxinc/nginx-go-crossplane/analyze_map.go
+++ b/sdk/vendor/github.com/nginxinc/nginx-go-crossplane/analyze_map.go
@@ -38,23 +38,26 @@ var mapBodies = map[string]mapParameterMasks{
 	"split_clients": {
 		defaultMasks: ngxConfTake1,
 	},
+	"geoip2": {
+		defaultMasks: ngxConf1More,
+	},
 }
 
 // analyzeMapBody validates the body of a map-like directive. Map-like directives are block directives
 // that don't contain nginx directives, and therefore cannot be analyzed in the same way as other blocks.
 func analyzeMapBody(fname string, parameter *Directive, term string, mapCtx string) error {
 	masks, known := mapBodies[mapCtx]
-
 	// if we're not inside a known map-like directive, don't bother analyzing
 	if !known {
 		return nil
 	}
-
 	if term != ";" {
 		return &ParseError{
-			What: fmt.Sprintf(`unexpected "%s"`, term),
-			File: &fname,
-			Line: &parameter.Line,
+			What:      fmt.Sprintf(`unexpected "%s"`, term),
+			File:      &fname,
+			Line:      &parameter.Line,
+			Statement: parameter.String(),
+			BlockCtx:  mapCtx,
 		}
 	}
 
@@ -65,9 +68,11 @@ func analyzeMapBody(fname string, parameter *Directive, term string, mapCtx stri
 		}
 
 		return &ParseError{
-			What: "invalid number of parameters",
-			File: &fname,
-			Line: &parameter.Line,
+			What:      "invalid number of parameters",
+			File:      &fname,
+			Line:      &parameter.Line,
+			Statement: parameter.String(),
+			BlockCtx:  mapCtx,
 		}
 	}
 
@@ -79,9 +84,11 @@ func analyzeMapBody(fname string, parameter *Directive, term string, mapCtx stri
 	}
 
 	return &ParseError{
-		What: "invalid number of parameters",
-		File: &fname,
-		Line: &parameter.Line,
+		What:      "invalid number of parameters",
+		File:      &fname,
+		Line:      &parameter.Line,
+		Statement: parameter.String(),
+		BlockCtx:  mapCtx,
 	}
 }
 

--- a/sdk/vendor/github.com/nginxinc/nginx-go-crossplane/build.go
+++ b/sdk/vendor/github.com/nginxinc/nginx-go-crossplane/build.go
@@ -25,7 +25,7 @@ type BuildOptions struct {
 
 const MaxIndent = 100
 
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals
 var (
 	marginSpaces = strings.Repeat(" ", MaxIndent)
 	marginTabs   = strings.Repeat("\t", MaxIndent)
@@ -108,7 +108,6 @@ func Build(w io.Writer, config Config, options *BuildOptions) error {
 	return err
 }
 
-//nolint:gocognit
 func buildBlock(sb io.StringWriter, parent *Directive, block Directives, depth int, lastLine int, options *BuildOptions) {
 	for i, stmt := range block {
 		// if the this statement is a comment on the same line as the preview, do not emit EOL for this stmt
@@ -185,7 +184,7 @@ func Enquote(arg string) string {
 	return strings.ReplaceAll(repr(arg), `\\`, `\`)
 }
 
-// nolint:gocyclo,gocognit
+//nolint:gocyclo
 func needsQuote(s string) bool {
 	if s == "" {
 		return true
@@ -201,7 +200,7 @@ func needsQuote(s string) bool {
 	}
 
 	// get first rune
-	char, off := utf8.DecodeRune([]byte(chars))
+	char, off := utf8.DecodeRuneInString(chars)
 
 	// arguments can't start with variable expansion syntax
 	if unicode.IsSpace(char) || strings.ContainsRune("{};\"'", char) || strings.HasPrefix(chars, "${") {
@@ -211,7 +210,7 @@ func needsQuote(s string) bool {
 	chars = chars[off:]
 
 	expanding := false
-	var prev rune = 0
+	var prev rune
 	for _, c := range chars {
 		char = c
 

--- a/sdk/vendor/github.com/nginxinc/nginx-go-crossplane/errors.go
+++ b/sdk/vendor/github.com/nginxinc/nginx-go-crossplane/errors.go
@@ -13,9 +13,13 @@ import (
 )
 
 type ParseError struct {
-	What        string
-	File        *string
-	Line        *int
+	What string
+	File *string
+	Line *int
+	// Raw directive statement causing the parse error.
+	Statement string
+	// Block in which parse error occurred.
+	BlockCtx    string
 	originalErr error
 }
 

--- a/sdk/vendor/github.com/nginxinc/nginx-go-crossplane/lex.go
+++ b/sdk/vendor/github.com/nginxinc/nginx-go-crossplane/lex.go
@@ -33,10 +33,10 @@ const (
 
 const TokenChanCap = 2048
 
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals
 var lexerFile = "lexer" // pseudo file name for use by parse errors
 
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals
 var tokChanCap = TokenChanCap // capacity of lexer token channel
 
 // note: this is only used during tests, should not be changed
@@ -49,7 +49,7 @@ func Lex(reader io.Reader) chan NgxToken {
 	return tc
 }
 
-// nolint:gocyclo,funlen,gocognit
+//nolint:gocyclo,funlen,gocognit
 func tokenize(reader io.Reader, tokenCh chan NgxToken) {
 	token := strings.Builder{}
 	tokenLine := 1
@@ -198,12 +198,11 @@ func tokenize(reader io.Reader, tokenCh chan NgxToken) {
 			token.WriteString(la)
 
 		case inVar:
+			token.WriteString(la)
 			// this is using the same logic as the exiting lexer, but this is wrong since it does not terminate on token boundary
 			if !strings.HasSuffix(token.String(), "}") && !isSpace(la) {
-				token.WriteString(la)
 				continue
 			}
-			token.WriteString(la)
 			lexState = inWord
 
 		case inQuote:

--- a/sdk/vendor/github.com/nginxinc/nginx-go-crossplane/util.go
+++ b/sdk/vendor/github.com/nginxinc/nginx-go-crossplane/util.go
@@ -154,9 +154,10 @@ func performIncludes(old *Payload, fromfile string, block Directives) chan inclu
 				if idx >= len(old.Config) {
 					c <- included{
 						err: &ParseError{
-							What: fmt.Sprintf("include config with index: %d", idx),
-							File: &fromfile,
-							Line: &dir.Line,
+							What:      fmt.Sprintf("include config with index: %d", idx),
+							File:      &fromfile,
+							Line:      &dir.Line,
+							Statement: dir.String(),
 						},
 					}
 					return

--- a/sdk/vendor/modules.txt
+++ b/sdk/vendor/modules.txt
@@ -44,7 +44,7 @@ github.com/maxbrunsfeld/counterfeiter/v6/generator
 # github.com/mitchellh/mapstructure v1.5.0
 ## explicit; go 1.14
 github.com/mitchellh/mapstructure
-# github.com/nginxinc/nginx-go-crossplane v0.4.17
+# github.com/nginxinc/nginx-go-crossplane v0.4.24
 ## explicit; go 1.19
 github.com/nginxinc/nginx-go-crossplane
 # github.com/pmezard/go-difflib v1.0.0

--- a/vendor/github.com/nginxinc/nginx-go-crossplane/.golangci.yml
+++ b/vendor/github.com/nginxinc/nginx-go-crossplane/.golangci.yml
@@ -4,6 +4,9 @@
 linters:
   enable-all: true
   disable:
+    - cyclop
+    - depguard
+    - varnamelen
     - goimports # handled by `make format`
     - gofmt # handled by `make format`
     - wsl # hyper specific to a the creator and not configurable enough to be useful - https://github.com/bombsimon/wsl
@@ -11,7 +14,6 @@ linters:
     - gomnd
     - godox
     - nlreturn
-    - exhaustivestruct
     - wrapcheck
     - thelper
     - testpackage
@@ -25,11 +27,13 @@ linters:
     - golint
     - maligned
     - scopelint
+    - exhaustruct
     # deprecated
     - deadcode
     - varcheck
     - structcheck
     - nosnakecase
+    - exhaustivestruct
 
 
 # Run options

--- a/vendor/github.com/nginxinc/nginx-go-crossplane/analyze_map.go
+++ b/vendor/github.com/nginxinc/nginx-go-crossplane/analyze_map.go
@@ -38,23 +38,26 @@ var mapBodies = map[string]mapParameterMasks{
 	"split_clients": {
 		defaultMasks: ngxConfTake1,
 	},
+	"geoip2": {
+		defaultMasks: ngxConf1More,
+	},
 }
 
 // analyzeMapBody validates the body of a map-like directive. Map-like directives are block directives
 // that don't contain nginx directives, and therefore cannot be analyzed in the same way as other blocks.
 func analyzeMapBody(fname string, parameter *Directive, term string, mapCtx string) error {
 	masks, known := mapBodies[mapCtx]
-
 	// if we're not inside a known map-like directive, don't bother analyzing
 	if !known {
 		return nil
 	}
-
 	if term != ";" {
 		return &ParseError{
-			What: fmt.Sprintf(`unexpected "%s"`, term),
-			File: &fname,
-			Line: &parameter.Line,
+			What:      fmt.Sprintf(`unexpected "%s"`, term),
+			File:      &fname,
+			Line:      &parameter.Line,
+			Statement: parameter.String(),
+			BlockCtx:  mapCtx,
 		}
 	}
 
@@ -65,9 +68,11 @@ func analyzeMapBody(fname string, parameter *Directive, term string, mapCtx stri
 		}
 
 		return &ParseError{
-			What: "invalid number of parameters",
-			File: &fname,
-			Line: &parameter.Line,
+			What:      "invalid number of parameters",
+			File:      &fname,
+			Line:      &parameter.Line,
+			Statement: parameter.String(),
+			BlockCtx:  mapCtx,
 		}
 	}
 
@@ -79,9 +84,11 @@ func analyzeMapBody(fname string, parameter *Directive, term string, mapCtx stri
 	}
 
 	return &ParseError{
-		What: "invalid number of parameters",
-		File: &fname,
-		Line: &parameter.Line,
+		What:      "invalid number of parameters",
+		File:      &fname,
+		Line:      &parameter.Line,
+		Statement: parameter.String(),
+		BlockCtx:  mapCtx,
 	}
 }
 

--- a/vendor/github.com/nginxinc/nginx-go-crossplane/build.go
+++ b/vendor/github.com/nginxinc/nginx-go-crossplane/build.go
@@ -25,7 +25,7 @@ type BuildOptions struct {
 
 const MaxIndent = 100
 
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals
 var (
 	marginSpaces = strings.Repeat(" ", MaxIndent)
 	marginTabs   = strings.Repeat("\t", MaxIndent)
@@ -108,7 +108,6 @@ func Build(w io.Writer, config Config, options *BuildOptions) error {
 	return err
 }
 
-//nolint:gocognit
 func buildBlock(sb io.StringWriter, parent *Directive, block Directives, depth int, lastLine int, options *BuildOptions) {
 	for i, stmt := range block {
 		// if the this statement is a comment on the same line as the preview, do not emit EOL for this stmt
@@ -185,7 +184,7 @@ func Enquote(arg string) string {
 	return strings.ReplaceAll(repr(arg), `\\`, `\`)
 }
 
-// nolint:gocyclo,gocognit
+//nolint:gocyclo
 func needsQuote(s string) bool {
 	if s == "" {
 		return true
@@ -201,7 +200,7 @@ func needsQuote(s string) bool {
 	}
 
 	// get first rune
-	char, off := utf8.DecodeRune([]byte(chars))
+	char, off := utf8.DecodeRuneInString(chars)
 
 	// arguments can't start with variable expansion syntax
 	if unicode.IsSpace(char) || strings.ContainsRune("{};\"'", char) || strings.HasPrefix(chars, "${") {
@@ -211,7 +210,7 @@ func needsQuote(s string) bool {
 	chars = chars[off:]
 
 	expanding := false
-	var prev rune = 0
+	var prev rune
 	for _, c := range chars {
 		char = c
 

--- a/vendor/github.com/nginxinc/nginx-go-crossplane/errors.go
+++ b/vendor/github.com/nginxinc/nginx-go-crossplane/errors.go
@@ -13,9 +13,13 @@ import (
 )
 
 type ParseError struct {
-	What        string
-	File        *string
-	Line        *int
+	What string
+	File *string
+	Line *int
+	// Raw directive statement causing the parse error.
+	Statement string
+	// Block in which parse error occurred.
+	BlockCtx    string
 	originalErr error
 }
 

--- a/vendor/github.com/nginxinc/nginx-go-crossplane/lex.go
+++ b/vendor/github.com/nginxinc/nginx-go-crossplane/lex.go
@@ -33,10 +33,10 @@ const (
 
 const TokenChanCap = 2048
 
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals
 var lexerFile = "lexer" // pseudo file name for use by parse errors
 
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals
 var tokChanCap = TokenChanCap // capacity of lexer token channel
 
 // note: this is only used during tests, should not be changed
@@ -49,7 +49,7 @@ func Lex(reader io.Reader) chan NgxToken {
 	return tc
 }
 
-// nolint:gocyclo,funlen,gocognit
+//nolint:gocyclo,funlen,gocognit
 func tokenize(reader io.Reader, tokenCh chan NgxToken) {
 	token := strings.Builder{}
 	tokenLine := 1
@@ -198,12 +198,11 @@ func tokenize(reader io.Reader, tokenCh chan NgxToken) {
 			token.WriteString(la)
 
 		case inVar:
+			token.WriteString(la)
 			// this is using the same logic as the exiting lexer, but this is wrong since it does not terminate on token boundary
 			if !strings.HasSuffix(token.String(), "}") && !isSpace(la) {
-				token.WriteString(la)
 				continue
 			}
-			token.WriteString(la)
 			lexState = inWord
 
 		case inQuote:

--- a/vendor/github.com/nginxinc/nginx-go-crossplane/util.go
+++ b/vendor/github.com/nginxinc/nginx-go-crossplane/util.go
@@ -154,9 +154,10 @@ func performIncludes(old *Payload, fromfile string, block Directives) chan inclu
 				if idx >= len(old.Config) {
 					c <- included{
 						err: &ParseError{
-							What: fmt.Sprintf("include config with index: %d", idx),
-							File: &fromfile,
-							Line: &dir.Line,
+							What:      fmt.Sprintf("include config with index: %d", idx),
+							File:      &fromfile,
+							Line:      &dir.Line,
+							Statement: dir.String(),
 						},
 					}
 					return

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1132,7 +1132,7 @@ github.com/nginx/agent/sdk/v2/proto
 github.com/nginx/agent/sdk/v2/proto/common
 github.com/nginx/agent/sdk/v2/proto/events
 github.com/nginx/agent/sdk/v2/zip
-# github.com/nginxinc/nginx-go-crossplane v0.4.17
+# github.com/nginxinc/nginx-go-crossplane v0.4.24
 ## explicit; go 1.19
 github.com/nginxinc/nginx-go-crossplane
 # github.com/nginxinc/nginx-plus-go-client v0.10.0


### PR DESCRIPTION
### Proposed changes

Related to this [PR](https://github.com/nginxinc/nginx-go-crossplane/pull/66) from the `nginx-go-crossplane` repo, which fixes the parsing logic for NGINX config files. 

- Update the agent to use the latest version v.0.4.24 tagged in https://github.com/nginxinc/nginx-go-crossplane
- Update `.mod` files for `sdk` and the root directory, and re-vendored the changes

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
