### PR TITLE
fix: fix logic for parsing absolute path to nginx config file

### DIFF
--- a/sdk/config_helpers.go
+++ b/sdk/config_helpers.go
@@ -23,13 +23,14 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/nginx/agent/sdk/v2/backoff"
 	filesSDK "github.com/nginx/agent/sdk/v2/files"
 	"github.com/nginx/agent/sdk/v2/proto"
 	"github.com/nginx/agent/sdk/v2/zip"
 
 	crossplane "github.com/nginxinc/nginx-go-crossplane"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -298,8 +299,8 @@ func updateNginxConfigWithCert(
 	directoryMap *DirectoryMap,
 	allowedDirectories map[string]struct{},
 ) error {
-	if strings.HasPrefix("$", file) {
-		// variable loading, not actual cert file
+	if strings.Contains(file, "$") {
+		// cannot process any filepath with variables
 		return nil
 	}
 

--- a/test/integration/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/test/integration/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -23,13 +23,14 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/nginx/agent/sdk/v2/backoff"
 	filesSDK "github.com/nginx/agent/sdk/v2/files"
 	"github.com/nginx/agent/sdk/v2/proto"
 	"github.com/nginx/agent/sdk/v2/zip"
 
 	crossplane "github.com/nginxinc/nginx-go-crossplane"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -298,8 +299,8 @@ func updateNginxConfigWithCert(
 	directoryMap *DirectoryMap,
 	allowedDirectories map[string]struct{},
 ) error {
-	if strings.HasPrefix("$", file) {
-		// variable loading, not actual cert file
+	if strings.Contains(file, "$") {
+		// cannot process any filepath with variables
 		return nil
 	}
 

--- a/test/performance/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/test/performance/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -23,13 +23,14 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/nginx/agent/sdk/v2/backoff"
 	filesSDK "github.com/nginx/agent/sdk/v2/files"
 	"github.com/nginx/agent/sdk/v2/proto"
 	"github.com/nginx/agent/sdk/v2/zip"
 
 	crossplane "github.com/nginxinc/nginx-go-crossplane"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -298,8 +299,8 @@ func updateNginxConfigWithCert(
 	directoryMap *DirectoryMap,
 	allowedDirectories map[string]struct{},
 ) error {
-	if strings.HasPrefix("$", file) {
-		// variable loading, not actual cert file
+	if strings.Contains(file, "$") {
+		// cannot process any filepath with variables
 		return nil
 	}
 


### PR DESCRIPTION
### Proposed changes


#### Issue
- From the NGINX UI, was unable to publish config changes for an instance when a `.conf` file was created under `/etc/nginx/conf.d`. The absolute path used to update the config changes contain variables with `$` (e.g., `/etc/nginx/$variable_name)` and a `No such file or directory` error occurred.
- Agent log showed errors related to parsing the nginx config files using an absolute path that contains variables.
```
time="2023-08-16T17:26:14Z" level=info msg="Upload sending done e0991342-0956-430a-a4f5-ece28395c421 (chunks=2)"
time="2023-08-16T17:38:42Z" level=warning msg="Error unable to add file watcher for /etc/nginx/conf.d/.config1.conf.swx : stat /etc/nginx/conf.d/.config1.conf.swx: no such file or directory"
time="2023-08-16T17:38:42Z" level=error msg="Error occurred adding watcher for /etc/nginx/conf.d/.config1.conf.swx: stat /etc/nginx/conf.d/.config1.conf.swx: no such file or directory"
time="2023-08-16T17:38:44Z" level=info msg="Upload: Sending data chunk data 0 (messageId=22aca969-1940-4e38-9a0d-a9112917673a)"
time="2023-08-16T17:38:44Z" level=info msg="Upload: Sending data chunk data 1 (messageId=22aca969-1940-4e38-9a0d-a9112917673a)"
time="2023-08-16T17:38:44Z" level=info msg="Upload sending done 22aca969-1940-4e38-9a0d-a9112917673a (chunks=2)"
time="2023-08-16T17:40:10Z" level=warning msg="Error unable to add file watcher for /etc/nginx/conf.d/.config1.conf.swx : stat /etc/nginx/conf.d/.config1.conf.swx: no such file or directory"
time="2023-08-16T17:40:10Z" level=error msg="Error occurred adding watcher for /etc/nginx/conf.d/.config1.conf.swx: stat /etc/nginx/conf.d/.config1.conf.swx: no such file or directory"
time="2023-08-16T17:40:12Z" level=error msg="Unable to read nginx config /etc/nginx/nginx.conf: error assemble payload from /etc/nginx/nginx.conf, error: configs: failed to update nginx config: stat /etc/nginx/$repo_crt: no such file or directory"
time="2023-08-16T17:40:12Z" level=warning msg="Unable to upload config for nginx instance b636d4376dea15405589692d3c5d3869ff3a9b26b0e7bb4bb1aa7e658ace1437, error assemble payload from /etc/nginx/nginx.conf, error: configs: failed to update nginx config: stat /etc/nginx/$repo_crt: no such file or directory"
```

#### Fix
- Modify `updateNginxConfigWithCert` so that it correctly checks for the case when an absolute path to a file contains `$`

#### Testing
- Recompiled the changes for the Agent and restarted the Agent on the instance, and config changes were published successfully.
- Agent log looked healthy
```
ubuntu@ip-172-16-0-236:~$ sudo tail /var/log/nginx-agent/agent.log 
time="2023-08-16T22:12:28Z" level=info msg="Reloading NGINX: /usr/sbin/nginx PID: 4290"
time="2023-08-16T22:12:28Z" level=info msg="NGINX with process Id: 4290 reloaded"
time="2023-08-16T22:12:29Z" level=info msg="Finished monitoring post reload"
time="2023-08-16T22:12:29Z" level=info msg="No errors found in NGINX errors logs after NGINX reload"
time="2023-08-16T22:12:29Z" level=info msg="Upload: Sending data chunk data 0 (messageId=8f442622-77d9-4507-9027-98a094451e36)"
time="2023-08-16T22:12:29Z" level=info msg="Upload: Sending data chunk data 1 (messageId=8f442622-77d9-4507-9027-98a094451e36)"
time="2023-08-16T22:12:29Z" level=info msg="Upload sending done 8f442622-77d9-4507-9027-98a094451e36 (chunks=2)"
time="2023-08-16T22:12:32Z" level=info msg="Upload: Sending data chunk data 0 (messageId=9377b069-36fb-4901-aa6e-ad49465870d4)"
time="2023-08-16T22:12:32Z" level=info msg="Upload: Sending data chunk data 1 (messageId=9377b069-36fb-4901-aa6e-ad49465870d4)"
time="2023-08-16T22:12:32Z" level=info msg="Upload sending done 9377b069-36fb-4901-aa6e-ad49465870d4 (chunks=2)"
```


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
