### PR TITLE
Get metadata for phpfpm master and workers process 

### DIFF
--- a/sdk/config_helpers.go
+++ b/sdk/config_helpers.go
@@ -23,13 +23,14 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/nginx/agent/sdk/v2/backoff"
 	filesSDK "github.com/nginx/agent/sdk/v2/files"
 	"github.com/nginx/agent/sdk/v2/proto"
 	"github.com/nginx/agent/sdk/v2/zip"
 
 	crossplane "github.com/nginxinc/nginx-go-crossplane"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -298,8 +299,8 @@ func updateNginxConfigWithCert(
 	directoryMap *DirectoryMap,
 	allowedDirectories map[string]struct{},
 ) error {
-	if strings.HasPrefix("$", file) {
-		// variable loading, not actual cert file
+	if strings.Contains(file, "$") {
+		// cannot process any filepath with variables
 		return nil
 	}
 

--- a/src/core/checksum.go
+++ b/src/core/checksum.go
@@ -12,8 +12,8 @@ import (
 	"fmt"
 )
 
-// GenerateNginxID used to get the NGINX ID
-func GenerateNginxID(format string, a ...interface{}) string {
+// GenerateID used to get the ID
+func GenerateID(format string, a ...interface{}) string {
 	h := sha256.New()
 	s := fmt.Sprintf(format, a...)
 	_, _ = h.Write([]byte(s))

--- a/src/core/checksum_test.go
+++ b/src/core/checksum_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGenerateNginxID(t *testing.T) {
-	result := GenerateNginxID("%s_%s_%s", "/tmp", "/tmp/conf", "nim")
+func TestGenerateID(t *testing.T) {
+	result := GenerateID("%s_%s_%s", "/tmp", "/tmp/conf", "nim")
 	assert.Equal(t, "5f17da2acca7a4429fd3070b039016360c32b49c0832ed2ced5751d3a1575488", result)
 }

--- a/src/core/environment.go
+++ b/src/core/environment.go
@@ -676,14 +676,14 @@ type Shell interface {
 	Exec(cmd string, arg ...string) ([]byte, error)
 }
 
-type execShellCommand struct{}
+type ExecShellCommand struct{}
 
-func (e execShellCommand) Exec(cmd string, arg ...string) ([]byte, error) {
+func (e ExecShellCommand) Exec(cmd string, arg ...string) ([]byte, error) {
 	execCmd := exec.Command(cmd, arg...)
 	return execCmd.Output()
 }
 
-var shell Shell = execShellCommand{}
+var shell Shell = ExecShellCommand{}
 
 func getProcessorCacheInfo(cpuInfo cpuid.CPUInfo) map[string]string {
 	cache := getDefaultProcessorCacheInfo(cpuInfo)

--- a/src/core/environment_test.go
+++ b/src/core/environment_test.go
@@ -10,13 +10,13 @@ package core
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/nginx/agent/sdk/v2"
 	"github.com/nginx/agent/sdk/v2/proto"
+	sysutils "github.com/nginx/agent/v2/test/utils/system"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -471,22 +471,6 @@ func TestProcessors(t *testing.T) {
 	assert.Equal(t, "arm64", processorInfo[0].GetArchitecture())
 }
 
-type fakeShell struct {
-	output map[string]string
-	errors map[string]error
-}
-
-func (f *fakeShell) Exec(cmd string, arg ...string) ([]byte, error) {
-	key := strings.Join(append([]string{cmd}, arg...), " ")
-	if err, ok := f.errors[key]; ok {
-		return nil, err
-	}
-	if out, ok := f.output[key]; ok {
-		return []byte(out), nil
-	}
-	return nil, fmt.Errorf("unexpected command %s", key)
-}
-
 func TestGetCacheInfo(t *testing.T) {
 	tempShellCommander := shell
 	defer func() { shell = tempShellCommander }()
@@ -498,8 +482,8 @@ func TestGetCacheInfo(t *testing.T) {
 	}{
 		{
 			name: "lscpu error",
-			shell: &fakeShell{
-				errors: map[string]error{
+			shell: &sysutils.FakeShell{
+				Errors: map[string]error{
 					"lscpu": errors.New("nope"),
 				},
 			},
@@ -518,8 +502,8 @@ func TestGetCacheInfo(t *testing.T) {
 		},
 		{
 			name: "default cache info absent",
-			shell: &fakeShell{
-				output: map[string]string{
+			shell: &sysutils.FakeShell{
+				Output: map[string]string{
 					"lscpu": lscpuInfo1,
 				},
 			},
@@ -538,8 +522,8 @@ func TestGetCacheInfo(t *testing.T) {
 		},
 		{
 			name: "os-release present with quote",
-			shell: &fakeShell{
-				output: map[string]string{
+			shell: &sysutils.FakeShell{
+				Output: map[string]string{
 					"lscpu": lscpuInfo2,
 				},
 			},

--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -154,7 +154,7 @@ func (n *NginxBinaryType) GetNginxIDForProcess(nginxProcess *Process) string {
 }
 
 func (n *NginxBinaryType) getNginxIDFromProcessInfo(nginxProcess *Process, info *nginxInfo) string {
-	return GenerateNginxID("%s_%s_%s", nginxProcess.Path, info.confPath, info.prefix)
+	return GenerateID("%s_%s_%s", nginxProcess.Path, info.confPath, info.prefix)
 }
 
 func (n *NginxBinaryType) GetNginxDetailsByID(nginxID string) *proto.NginxDetails {

--- a/src/extensions/php-fpm-metrics/manager.go
+++ b/src/extensions/php-fpm-metrics/manager.go
@@ -1,0 +1,43 @@
+package phpfpm
+
+import (
+	"fmt"
+
+	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/manager"
+	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/master"
+	log "github.com/sirupsen/logrus"
+)
+
+type Manager struct {
+	Uuid, Host, Agent string
+}
+
+func NewManager(uuid, host, agent string) *Manager {
+	return &Manager{
+		Uuid:  uuid,
+		Host:  host,
+		Agent: agent,
+	}
+}
+
+// GetMetaData returns meta-data for list of phpfpm master processes
+func (m *Manager) GetMetaData() (map[string]*master.MetaData, error) {
+	// search for the php fpm master process.
+	master_mg := manager.NewMaster(m.Uuid, m.Host, m.Agent)
+	md, err := master_mg.GetMetaData()
+	if err != nil {
+		return nil, err
+	}
+
+	for ppid, meta := range md {
+		// Todo : Get process (i.e ppid) health status
+		dir := fmt.Sprintf("/etc/php/%s/fpm/pool.d/", meta.Version)
+		pool_mg := manager.NewPool(meta.Uuid, meta.Agent, meta.LocalId, dir, m.Host)
+		meta.Pools, err = pool_mg.GetMetaData()
+		if err != nil {
+			log.Warnf("failed to retrieve children for master process : %s, %v", ppid, err)
+		}
+	}
+
+	return md, nil
+}

--- a/src/extensions/php-fpm-metrics/manager.go
+++ b/src/extensions/php-fpm-metrics/manager.go
@@ -1,10 +1,14 @@
 package phpfpm
 
 import (
+	"context"
 	"fmt"
+	"strings"
 
 	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/manager"
 	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/master"
+	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/pkg/phpfpm"
+	"github.com/shirou/gopsutil/process"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -21,23 +25,80 @@ func NewManager(uuid, host, agent string) *Manager {
 }
 
 // GetMetaData returns meta-data for list of phpfpm master processes
-func (m *Manager) GetMetaData() (map[string]*master.MetaData, error) {
-	// search for the php fpm master process.
+func (m *Manager) GetMetaData() (map[int32]*master.MetaData, error) {
+	phpProcess, err := m.processes()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ps := range phpProcess {
+		log.Infof("%v", ps)
+	}
+
 	master_mg := manager.NewMaster(m.Uuid, m.Host, m.Agent)
-	md, err := master_mg.GetMetaData()
+	md, err := master_mg.GetMetaData(phpProcess)
 	if err != nil {
 		return nil, err
 	}
 
 	for ppid, meta := range md {
-		// Todo : Get process (i.e ppid) health status
-		dir := fmt.Sprintf("/etc/php/%s/fpm/pool.d/", meta.Version)
+		cmdSplit := strings.Split(meta.Cmd, "/")
+		dir := fmt.Sprintf("/etc/php/%s/fpm/pool.d/", cmdSplit[3])
 		pool_mg := manager.NewPool(meta.Uuid, meta.Agent, meta.LocalId, dir, m.Host)
 		meta.Pools, err = pool_mg.GetMetaData()
 		if err != nil {
-			log.Warnf("failed to retrieve children for master process : %s, %v", ppid, err)
+			log.Errorf("failed to retrieve children for master process : %d, %v", ppid, err)
 		}
 	}
 
 	return md, nil
+}
+
+// Processes returns a slice of phpfpm master and worker processes currently running
+func (m *Manager) processes() ([]*phpfpm.PhpProcess, error) {
+	var phpProcessList []*phpfpm.PhpProcess
+	ctx := context.Background()
+	defer ctx.Done()
+
+	pids, err := process.PidsWithContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	phpProcesses := make(map[int32]*process.Process)
+	for _, pid := range pids {
+
+		p, _ := process.NewProcessWithContext(ctx, pid)
+		name, _ := p.NameWithContext(ctx)
+
+		if strings.Contains(name, "php-fpm") {
+			phpProcesses[pid] = p
+		}
+	}
+
+	for pid, phpProcess := range phpProcesses {
+		name, _ := phpProcess.NameWithContext(ctx)
+		ppid, _ := phpProcess.PpidWithContext(ctx)
+		cmd, _ := phpProcess.CmdlineWithContext(ctx)
+		exe, _ := phpProcess.Exe()
+		isMaster := false
+
+		_, ok := phpProcesses[ppid]
+		if !ok {
+			isMaster = true
+		}
+
+		newPhpProcess := &phpfpm.PhpProcess{
+			Pid:       pid,
+			Name:      name,
+			ParentPid: ppid,
+			Command:   cmd,
+			IsMaster:  isMaster,
+			BinPath:   exe,
+		}
+
+		phpProcessList = append(phpProcessList, newPhpProcess)
+	}
+
+	return phpProcessList, nil
 }

--- a/src/extensions/php-fpm-metrics/manager/master.go
+++ b/src/extensions/php-fpm-metrics/manager/master.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"github.com/nginx/agent/v2/src/core"
 	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/master"
+	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/pkg/phpfpm"
 )
 
 type Master struct {
@@ -18,9 +19,9 @@ func NewMaster(uuid, host, agent string) *Master {
 }
 
 // GetMetaData returns meta-data for php-fpm master processes
-func (m_mg *Master) GetMetaData() (map[string]*master.MetaData, error) {
+func (m_mg *Master) GetMetaData(process []*phpfpm.PhpProcess) (map[int32]*master.MetaData, error) {
 	master := master.New(m_mg.host)
-	mdByPid, err := master.GetAll()
+	mdByPid, err := master.GetAll(process)
 	if err != nil {
 		return nil, err
 	}
@@ -28,6 +29,7 @@ func (m_mg *Master) GetMetaData() (map[string]*master.MetaData, error) {
 	for _, meta := range mdByPid {
 		meta.Agent = m_mg.agent
 		meta.Uuid = m_mg.uuid
+		meta.Status = phpfpm.RUNNING.String()
 		if len(meta.Cmd) > 0 && len(meta.ConfPath) > 0 {
 			meta.LocalId = core.GenerateID("%s_%s", meta.Cmd, meta.ConfPath)
 		}

--- a/src/extensions/php-fpm-metrics/manager/master.go
+++ b/src/extensions/php-fpm-metrics/manager/master.go
@@ -1,0 +1,36 @@
+package manager
+
+import (
+	"github.com/nginx/agent/v2/src/core"
+	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/master"
+)
+
+type Master struct {
+	uuid, host, agent string
+}
+
+func NewMaster(uuid, host, agent string) *Master {
+	return &Master{
+		uuid:  uuid,
+		host:  host,
+		agent: agent,
+	}
+}
+
+// GetMetaData returns meta-data for php-fpm master processes
+func (m_mg *Master) GetMetaData() (map[string]*master.MetaData, error) {
+	master := master.New(m_mg.host)
+	mdByPid, err := master.GetAll()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, meta := range mdByPid {
+		meta.Agent = m_mg.agent
+		meta.Uuid = m_mg.uuid
+		if len(meta.Cmd) > 0 && len(meta.ConfPath) > 0 {
+			meta.LocalId = core.GenerateID("%s_%s", meta.Cmd, meta.ConfPath)
+		}
+	}
+	return mdByPid, nil
+}

--- a/src/extensions/php-fpm-metrics/manager/master_metadata_test.go
+++ b/src/extensions/php-fpm-metrics/manager/master_metadata_test.go
@@ -8,173 +8,196 @@ import (
 	"github.com/nginx/agent/v2/src/core"
 	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/manager"
 	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/master"
+	phpfpm "github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/pkg/phpfpm"
+
 	sysutils "github.com/nginx/agent/v2/test/utils/system"
 	"github.com/stretchr/testify/assert"
 )
 
-var phpFpmProcess = `
-654040       1 php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)
-654042  654040 php-fpm: pool sample_site
-654043  654040 php-fpm: pool sample_site
-654044  654040 php-fpm: pool sample_site
-654045  654040 php-fpm: pool sample_site
-654046  654040 php-fpm: pool sample_site
-654047  654040 php-fpm: pool sample_site
-654048  654040 php-fpm: pool sample_site
-654049  654040 php-fpm: pool sample_site
-654050  654040 php-fpm: pool sample_site
-654051  654040 php-fpm: pool sample_site
-654052  654040 php-fpm: pool www
-654053  654040 php-fpm: pool www
-856283       1 php-fpm: master process (/etc/php/7.3/fpm/php-fpm.conf)
-856284  856283 php-fpm: pool samplepress-site
-856285  856283 php-fpm: pool samplepress-site
-856286  856283 php-fpm: pool samplepress-site
-856287  856283 php-fpm: pool samplepress-site
-856288  856283 php-fpm: pool samplepress-site
-856289  856283 php-fpm: pool samplepress-site
-856290  856283 php-fpm: pool samplepress-site
-856292  856283 php-fpm: pool samplepress-site
-856293  856283 php-fpm: pool samplepress-site
-856294  856283 php-fpm: pool samplepress-site
-`
+var phpFpmProcesss = []*phpfpm.PhpProcess{
+	{
+		Pid:      int32(856283),
+		Name:     "php-fpm7.3",
+		IsMaster: true,
+		Command:  "php-fpm: master process (/etc/php/7.3/fpm/php-fpm.conf)",
+		BinPath:  "/usr/sbin/php-fpm7.3",
+	},
+	{
+		Pid:       int32(856284),
+		Name:      "php-fpm7.3",
+		Command:   "php-fpm: pool samplepress-site",
+		BinPath:   "/usr/sbin/php-fpm7.3",
+		ParentPid: int32(856283),
+	},
+	{
+		Pid:       int32(856285),
+		Name:      "php-fpm7.3",
+		Command:   "php-fpm: pool samplepress-site",
+		BinPath:   "/usr/sbin/php-fpm7.3",
+		ParentPid: int32(856283),
+	},
+	{
+		Pid:       int32(856286),
+		Name:      "php-fpm7.3",
+		Command:   "php-fpm: pool samplepress-site",
+		BinPath:   "/usr/sbin/php-fpm7.3",
+		ParentPid: int32(856283),
+	},
+	{
+		Pid:      int32(654040),
+		Name:     "php-fpm7.4",
+		IsMaster: true,
+		Command:  "php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)",
+		BinPath:  "/usr/sbin/php-fpm7.4",
+	},
+	{
+		Pid:       int32(654041),
+		Name:      "php-fpm7.4",
+		Command:   "php-fpm: pool sample-site",
+		BinPath:   "/usr/sbin/php-fpm7.4",
+		ParentPid: int32(654040),
+	},
+	{
+		Pid:       int32(654042),
+		Name:      "php-fpm7.4",
+		Command:   "php-fpm: pool sample-site",
+		BinPath:   "/usr/sbin/php-fpm7.4",
+		ParentPid: int32(654040),
+	},
+}
 
-var phpFpmProcessWithMaster = `
-654040       1 php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)
-`
-
-var phpFpmBin7_4 = `
-lrwxrwxrwx 1 root root 0 Aug 24 21:09 /proc/654040/exe -> /usr/sbin/php-fpm7.4
-`
-
-var phpFpmBin7_3 = `
-lrwxrwxrwx 1 root root 0 Aug 27 05:39 /proc/856283/exe -> /usr/sbin/php-fpm7.3
-`
-
-var phpFpmBin7_4_version = `
-PHP 7.4.33 (fpm-fcgi) (built: Feb 14 2023 18:31:23)
-Copyright (c) The PHP Group
-Zend Engine v3.4.0, Copyright (c) Zend Technologies
-    with Zend OPcache v7.4.33, Copyright (c), by Zend Technologies
-`
-
-var phpFpmBin7_3_version = `
-PHP 7.3.33-12+ubuntu20.04.1+deb.sury.org+1 (fpm-fcgi) (built: Aug 14 2023 06:41:12)
+var phpFpmBin7_3_version = `PHP 7.3.33-12+ubuntu20.04.1+deb.sury.org+1 (fpm-fcgi) (built: Aug 14 2023 06:41:12)
 Copyright (c) 1997-2018 The PHP Group
 Zend Engine v3.3.33, Copyright (c) 1998-2018 Zend Technologies
     with Zend OPcache v7.3.33-12+ubuntu20.04.1+deb.sury.org+1, Copyright (c) 1999-2018, by Zend Technologies
 `
 
+var phpFpmBin7_4_version = `PHP 7.4.33 (fpm-fcgi) (built: Feb 14 2023 18:31:23)
+Copyright (c) The PHP Group
+Zend Engine v3.4.0, Copyright (c) Zend Technologies
+    with Zend OPcache v7.4.33, Copyright (c), by Zend Technologies
+`
+
+var phpFpmProcesssRunning = []*phpfpm.PhpProcess{
+	{
+		Pid:      int32(654040),
+		Name:     "php-fpm7.4",
+		IsMaster: true,
+		Command:  "php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)",
+		BinPath:  "/usr/sbin/php-fpm7.4",
+	},
+}
+
 func TestPhpFpmMasterMetaData(t *testing.T) {
-	tempShellCommander := master.Shell
-	defer func() { master.Shell = tempShellCommander }()
 	uuid := uuid.New().String()
 	host := "Ubuntu"
 	agent := "2.28.0"
 	tests := []struct {
 		name    string
 		shell   core.Shell
-		expect  map[string]*master.MetaData
+		expect  map[int32]*master.MetaData
+		input   []*phpfpm.PhpProcess
 		manager *manager.Master
 	}{
 		{
 			name: "get meta data with master and worker processes running",
 			shell: &sysutils.FakeShell{
 				Output: map[string]string{
-					"ps xao pid,ppid,command | grep 'php-fpm[:]'": phpFpmProcess,
-					"sudo ls -la /proc/856283/exe":                phpFpmBin7_3,
-					"sudo /usr/sbin/php-fpm7.3 --version":         phpFpmBin7_3_version,
-					"sudo ls -la /proc/654040/exe":                phpFpmBin7_4,
-					"sudo /usr/sbin/php-fpm7.4 --version":         phpFpmBin7_4_version,
+					"/usr/sbin/php-fpm7.3 --version": phpFpmBin7_3_version,
+					"/usr/sbin/php-fpm7.4 --version": phpFpmBin7_4_version,
 				},
 			},
+			input:   phpFpmProcesss,
 			manager: manager.NewMaster(uuid, host, agent),
-			expect: map[string]*master.MetaData{
-				"654040": {
+			expect: map[int32]*master.MetaData{
+				int32(654040): {
 					Type:        "phpfpm",
 					Uuid:        uuid,
 					Cmd:         "php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)",
 					Name:        "master",
 					DisplayName: "phpfpm master @ Ubuntu",
 					ConfPath:    "/etc/php/7.4/fpm/php-fpm.conf",
-					NumWorkers:  12,
+					NumWorkers:  2,
 					Version:     "7.4.33",
 					VersionLine: "PHP 7.4.33 (fpm-fcgi) (built: Feb 14 2023 18:31:23)",
 					Pid:         654040,
 					BinPath:     "/usr/sbin/php-fpm7.4",
 					Agent:       "2.28.0",
+					Status:      "RUNNING",
 					LocalId:     core.GenerateID("%s_%s", "php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)", "/etc/php/7.4/fpm/php-fpm.conf"),
 				},
-				"856283": {
+				int32(856283): {
 					Type:        "phpfpm",
 					Uuid:        uuid,
 					Cmd:         "php-fpm: master process (/etc/php/7.3/fpm/php-fpm.conf)",
 					Name:        "master",
 					DisplayName: "phpfpm master @ Ubuntu",
 					ConfPath:    "/etc/php/7.3/fpm/php-fpm.conf",
-					NumWorkers:  10,
+					NumWorkers:  3,
 					Version:     "7.3.33-12",
 					VersionLine: "PHP 7.3.33-12+ubuntu20.04.1+deb.sury.org+1 (fpm-fcgi) (built: Aug 14 2023 06:41:12)",
 					Pid:         856283,
 					BinPath:     "/usr/sbin/php-fpm7.3",
 					Agent:       "2.28.0",
+					Status:      "RUNNING",
 					LocalId:     core.GenerateID("%s_%s", "php-fpm: master process (/etc/php/7.3/fpm/php-fpm.conf)", "/etc/php/7.3/fpm/php-fpm.conf"),
 				},
 			},
 		},
 		{
-			name: "proc error",
+			name:    "error in finding version",
+			input:   phpFpmProcesss,
+			manager: manager.NewMaster(uuid, host, agent),
 			shell: &sysutils.FakeShell{
-				Output: map[string]string{
-					"ps xao pid,ppid,command | grep 'php-fpm[:]'": phpFpmProcess,
-					"sudo /usr/sbin/php-fpm7.3 --version":         phpFpmBin7_3_version,
-					"sudo /usr/sbin/php-fpm7.4 --version":         phpFpmBin7_4_version,
-				},
 				Errors: map[string]error{
-					"sudo ls -la /proc/654040/exe": errors.New("proc not supported"),
-					"sudo ls -la /proc/856283/exe": errors.New("proc not supported"),
+					"sudo /usr/sbin/php-fpm7.3 --version": errors.New("proc not supported"),
+					"sudo /usr/sbin/php-fpm7.4 --version": errors.New("proc not supported"),
 				},
 			},
-			manager: manager.NewMaster(uuid, host, agent),
-			expect: map[string]*master.MetaData{
-				"654040": {
+			expect: map[int32]*master.MetaData{
+				int32(654040): {
 					Type:        "phpfpm",
 					Uuid:        uuid,
 					Cmd:         "php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)",
 					Name:        "master",
 					DisplayName: "phpfpm master @ Ubuntu",
 					ConfPath:    "/etc/php/7.4/fpm/php-fpm.conf",
-					NumWorkers:  12,
+					NumWorkers:  2,
 					Pid:         654040,
+					Version:     "7.4",
 					Agent:       "2.28.0",
+					Status:      "RUNNING",
+					BinPath:     "/usr/sbin/php-fpm7.4",
 					LocalId:     core.GenerateID("%s_%s", "php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)", "/etc/php/7.4/fpm/php-fpm.conf"),
 				},
-				"856283": {
+				int32(856283): {
 					Type:        "phpfpm",
 					Uuid:        uuid,
 					Cmd:         "php-fpm: master process (/etc/php/7.3/fpm/php-fpm.conf)",
 					Name:        "master",
 					DisplayName: "phpfpm master @ Ubuntu",
 					ConfPath:    "/etc/php/7.3/fpm/php-fpm.conf",
-					NumWorkers:  10,
+					Version:     "7.3",
+					NumWorkers:  3,
 					Pid:         856283,
 					Agent:       "2.28.0",
+					Status:      "RUNNING",
+					BinPath:     "/usr/sbin/php-fpm7.3",
 					LocalId:     core.GenerateID("%s_%s", "php-fpm: master process (/etc/php/7.3/fpm/php-fpm.conf)", "/etc/php/7.3/fpm/php-fpm.conf"),
 				},
 			},
 		},
 		{
-			name: "get meta data for phpfpm process with only master running",
+			name:    "get meta data for phpfpm process with only master running",
+			manager: manager.NewMaster(uuid, host, agent),
+			input:   phpFpmProcesssRunning,
 			shell: &sysutils.FakeShell{
 				Output: map[string]string{
-					"ps xao pid,ppid,command | grep 'php-fpm[:]'": phpFpmProcessWithMaster,
-					"sudo ls -la /proc/654040/exe":                phpFpmBin7_4,
-					"sudo /usr/sbin/php-fpm7.4 --version":         phpFpmBin7_4_version,
+					"/usr/sbin/php-fpm7.4 --version": phpFpmBin7_4_version,
 				},
 			},
-			manager: manager.NewMaster(uuid, host, agent),
-			expect: map[string]*master.MetaData{
-				"654040": {
+			expect: map[int32]*master.MetaData{
+				int32(654040): {
 					Type:        "phpfpm",
 					Uuid:        uuid,
 					Cmd:         "php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)",
@@ -187,25 +210,21 @@ func TestPhpFpmMasterMetaData(t *testing.T) {
 					Pid:         654040,
 					BinPath:     "/usr/sbin/php-fpm7.4",
 					Agent:       "2.28.0",
+					Status:      "RUNNING",
 					LocalId:     core.GenerateID("%s_%s", "php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)", "/etc/php/7.4/fpm/php-fpm.conf"),
 				},
 			},
 		},
 		{
-			name: "no master process running",
-			shell: &sysutils.FakeShell{
-				Output: map[string]string{
-					"ps xao pid,ppid,command | grep 'php-fpm[:]'": "",
-				},
-			},
+			name:    "no master process running",
 			manager: manager.NewMaster(uuid, host, agent),
-			expect:  map[string]*master.MetaData{},
+			expect:  map[int32]*master.MetaData{},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			master.Shell = tt.shell
-			actual, _ := tt.manager.GetMetaData()
+			actual, _ := tt.manager.GetMetaData(tt.input)
 			assert.Equal(t, tt.expect, actual)
 		})
 	}

--- a/src/extensions/php-fpm-metrics/manager/master_metadata_test.go
+++ b/src/extensions/php-fpm-metrics/manager/master_metadata_test.go
@@ -1,0 +1,212 @@
+package manager_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nginx/agent/v2/src/core"
+	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/manager"
+	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/master"
+	sysutils "github.com/nginx/agent/v2/test/utils/system"
+	"github.com/stretchr/testify/assert"
+)
+
+var phpFpmProcess = `
+654040       1 php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)
+654042  654040 php-fpm: pool sample_site
+654043  654040 php-fpm: pool sample_site
+654044  654040 php-fpm: pool sample_site
+654045  654040 php-fpm: pool sample_site
+654046  654040 php-fpm: pool sample_site
+654047  654040 php-fpm: pool sample_site
+654048  654040 php-fpm: pool sample_site
+654049  654040 php-fpm: pool sample_site
+654050  654040 php-fpm: pool sample_site
+654051  654040 php-fpm: pool sample_site
+654052  654040 php-fpm: pool www
+654053  654040 php-fpm: pool www
+856283       1 php-fpm: master process (/etc/php/7.3/fpm/php-fpm.conf)
+856284  856283 php-fpm: pool samplepress-site
+856285  856283 php-fpm: pool samplepress-site
+856286  856283 php-fpm: pool samplepress-site
+856287  856283 php-fpm: pool samplepress-site
+856288  856283 php-fpm: pool samplepress-site
+856289  856283 php-fpm: pool samplepress-site
+856290  856283 php-fpm: pool samplepress-site
+856292  856283 php-fpm: pool samplepress-site
+856293  856283 php-fpm: pool samplepress-site
+856294  856283 php-fpm: pool samplepress-site
+`
+
+var phpFpmProcessWithMaster = `
+654040       1 php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)
+`
+
+var phpFpmBin7_4 = `
+lrwxrwxrwx 1 root root 0 Aug 24 21:09 /proc/654040/exe -> /usr/sbin/php-fpm7.4
+`
+
+var phpFpmBin7_3 = `
+lrwxrwxrwx 1 root root 0 Aug 27 05:39 /proc/856283/exe -> /usr/sbin/php-fpm7.3
+`
+
+var phpFpmBin7_4_version = `
+PHP 7.4.33 (fpm-fcgi) (built: Feb 14 2023 18:31:23)
+Copyright (c) The PHP Group
+Zend Engine v3.4.0, Copyright (c) Zend Technologies
+    with Zend OPcache v7.4.33, Copyright (c), by Zend Technologies
+`
+
+var phpFpmBin7_3_version = `
+PHP 7.3.33-12+ubuntu20.04.1+deb.sury.org+1 (fpm-fcgi) (built: Aug 14 2023 06:41:12)
+Copyright (c) 1997-2018 The PHP Group
+Zend Engine v3.3.33, Copyright (c) 1998-2018 Zend Technologies
+    with Zend OPcache v7.3.33-12+ubuntu20.04.1+deb.sury.org+1, Copyright (c) 1999-2018, by Zend Technologies
+`
+
+func TestPhpFpmMasterMetaData(t *testing.T) {
+	tempShellCommander := master.Shell
+	defer func() { master.Shell = tempShellCommander }()
+	uuid := uuid.New().String()
+	host := "Ubuntu"
+	agent := "2.28.0"
+	tests := []struct {
+		name    string
+		shell   core.Shell
+		expect  map[string]*master.MetaData
+		manager *manager.Master
+	}{
+		{
+			name: "get meta data with master and worker processes running",
+			shell: &sysutils.FakeShell{
+				Output: map[string]string{
+					"ps xao pid,ppid,command | grep 'php-fpm[:]'": phpFpmProcess,
+					"sudo ls -la /proc/856283/exe":                phpFpmBin7_3,
+					"sudo /usr/sbin/php-fpm7.3 --version":         phpFpmBin7_3_version,
+					"sudo ls -la /proc/654040/exe":                phpFpmBin7_4,
+					"sudo /usr/sbin/php-fpm7.4 --version":         phpFpmBin7_4_version,
+				},
+			},
+			manager: manager.NewMaster(uuid, host, agent),
+			expect: map[string]*master.MetaData{
+				"654040": {
+					Type:        "phpfpm",
+					Uuid:        uuid,
+					Cmd:         "php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)",
+					Name:        "master",
+					DisplayName: "phpfpm master @ Ubuntu",
+					ConfPath:    "/etc/php/7.4/fpm/php-fpm.conf",
+					NumWorkers:  12,
+					Version:     "7.4.33",
+					VersionLine: "PHP 7.4.33 (fpm-fcgi) (built: Feb 14 2023 18:31:23)",
+					Pid:         654040,
+					BinPath:     "/usr/sbin/php-fpm7.4",
+					Agent:       "2.28.0",
+					LocalId:     core.GenerateID("%s_%s", "php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)", "/etc/php/7.4/fpm/php-fpm.conf"),
+				},
+				"856283": {
+					Type:        "phpfpm",
+					Uuid:        uuid,
+					Cmd:         "php-fpm: master process (/etc/php/7.3/fpm/php-fpm.conf)",
+					Name:        "master",
+					DisplayName: "phpfpm master @ Ubuntu",
+					ConfPath:    "/etc/php/7.3/fpm/php-fpm.conf",
+					NumWorkers:  10,
+					Version:     "7.3.33-12",
+					VersionLine: "PHP 7.3.33-12+ubuntu20.04.1+deb.sury.org+1 (fpm-fcgi) (built: Aug 14 2023 06:41:12)",
+					Pid:         856283,
+					BinPath:     "/usr/sbin/php-fpm7.3",
+					Agent:       "2.28.0",
+					LocalId:     core.GenerateID("%s_%s", "php-fpm: master process (/etc/php/7.3/fpm/php-fpm.conf)", "/etc/php/7.3/fpm/php-fpm.conf"),
+				},
+			},
+		},
+		{
+			name: "proc error",
+			shell: &sysutils.FakeShell{
+				Output: map[string]string{
+					"ps xao pid,ppid,command | grep 'php-fpm[:]'": phpFpmProcess,
+					"sudo /usr/sbin/php-fpm7.3 --version":         phpFpmBin7_3_version,
+					"sudo /usr/sbin/php-fpm7.4 --version":         phpFpmBin7_4_version,
+				},
+				Errors: map[string]error{
+					"sudo ls -la /proc/654040/exe": errors.New("proc not supported"),
+					"sudo ls -la /proc/856283/exe": errors.New("proc not supported"),
+				},
+			},
+			manager: manager.NewMaster(uuid, host, agent),
+			expect: map[string]*master.MetaData{
+				"654040": {
+					Type:        "phpfpm",
+					Uuid:        uuid,
+					Cmd:         "php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)",
+					Name:        "master",
+					DisplayName: "phpfpm master @ Ubuntu",
+					ConfPath:    "/etc/php/7.4/fpm/php-fpm.conf",
+					NumWorkers:  12,
+					Pid:         654040,
+					Agent:       "2.28.0",
+					LocalId:     core.GenerateID("%s_%s", "php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)", "/etc/php/7.4/fpm/php-fpm.conf"),
+				},
+				"856283": {
+					Type:        "phpfpm",
+					Uuid:        uuid,
+					Cmd:         "php-fpm: master process (/etc/php/7.3/fpm/php-fpm.conf)",
+					Name:        "master",
+					DisplayName: "phpfpm master @ Ubuntu",
+					ConfPath:    "/etc/php/7.3/fpm/php-fpm.conf",
+					NumWorkers:  10,
+					Pid:         856283,
+					Agent:       "2.28.0",
+					LocalId:     core.GenerateID("%s_%s", "php-fpm: master process (/etc/php/7.3/fpm/php-fpm.conf)", "/etc/php/7.3/fpm/php-fpm.conf"),
+				},
+			},
+		},
+		{
+			name: "get meta data for phpfpm process with only master running",
+			shell: &sysutils.FakeShell{
+				Output: map[string]string{
+					"ps xao pid,ppid,command | grep 'php-fpm[:]'": phpFpmProcessWithMaster,
+					"sudo ls -la /proc/654040/exe":                phpFpmBin7_4,
+					"sudo /usr/sbin/php-fpm7.4 --version":         phpFpmBin7_4_version,
+				},
+			},
+			manager: manager.NewMaster(uuid, host, agent),
+			expect: map[string]*master.MetaData{
+				"654040": {
+					Type:        "phpfpm",
+					Uuid:        uuid,
+					Cmd:         "php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)",
+					Name:        "master",
+					DisplayName: "phpfpm master @ Ubuntu",
+					ConfPath:    "/etc/php/7.4/fpm/php-fpm.conf",
+					NumWorkers:  0,
+					Version:     "7.4.33",
+					VersionLine: "PHP 7.4.33 (fpm-fcgi) (built: Feb 14 2023 18:31:23)",
+					Pid:         654040,
+					BinPath:     "/usr/sbin/php-fpm7.4",
+					Agent:       "2.28.0",
+					LocalId:     core.GenerateID("%s_%s", "php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)", "/etc/php/7.4/fpm/php-fpm.conf"),
+				},
+			},
+		},
+		{
+			name: "no master process running",
+			shell: &sysutils.FakeShell{
+				Output: map[string]string{
+					"ps xao pid,ppid,command | grep 'php-fpm[:]'": "",
+				},
+			},
+			manager: manager.NewMaster(uuid, host, agent),
+			expect:  map[string]*master.MetaData{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			master.Shell = tt.shell
+			actual, _ := tt.manager.GetMetaData()
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}

--- a/src/extensions/php-fpm-metrics/manager/pool.go
+++ b/src/extensions/php-fpm-metrics/manager/pool.go
@@ -1,0 +1,54 @@
+package manager
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nginx/agent/v2/src/core"
+	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/pool"
+	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/pool/worker"
+	log "github.com/sirupsen/logrus"
+)
+
+type Pool struct {
+	uuid, agent, masterUuid, dir, host string
+}
+
+func NewPool(uuid, agent, masterUuid, dir, host string) *Pool {
+	return &Pool{
+		uuid:       uuid,
+		agent:      agent,
+		masterUuid: masterUuid,
+		dir:        dir,
+		host:       host,
+	}
+}
+
+// GetMetaData returns meta data for phpfpm workers
+func (p_mg *Pool) GetMetaData() ([]*worker.MetaData, error) {
+	p := pool.New(p_mg.dir)
+	files, err := p.GetConfigs(p_mg.dir)
+	if err != nil {
+		return nil, err
+	}
+
+	children := []*worker.MetaData{}
+	for _, file := range files {
+		b, err := os.ReadFile(fmt.Sprintf("%s/%s", p_mg.dir, file))
+		if err != nil {
+			log.Warnf("error reading file to get phpfpm pool info: %v", err)
+			continue
+		}
+		worker := worker.New(string(b), p_mg.dir, p_mg.host)
+		pool := worker.GetMetaData()
+		pool.CanHaveChildren = false
+		pool.Agent = p_mg.agent
+		pool.Uuid = p_mg.uuid
+		pool.ParentLocalId = p_mg.masterUuid
+		pool.Type = "phpfpm_pool"
+		pool.LocalId = core.GenerateID("%s_%s", pool.ParentLocalId, pool.Name)
+		children = append(children, pool)
+	}
+
+	return children, nil
+}

--- a/src/extensions/php-fpm-metrics/manager/pool_metadata_test.go
+++ b/src/extensions/php-fpm-metrics/manager/pool_metadata_test.go
@@ -1,0 +1,87 @@
+package manager_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nginx/agent/v2/src/core"
+
+	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/manager"
+	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/pool"
+	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/pool/worker"
+	sysutils "github.com/nginx/agent/v2/test/utils/system"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPhpFpmPoolMetaData(t *testing.T) {
+	localDirectory := "../../../../test/testdata/configs/php/pool"
+	phpConfigFiles := "sample_pool.conf   www.conf"
+	tempShellCommander := pool.Shell
+	agentVersion := "2.28.0"
+	parentLocalId := uuid.New().String()
+	uuid := uuid.New().String()
+	defer func() { pool.Shell = tempShellCommander }()
+	tests := []struct {
+		name    string
+		shell   core.Shell
+		manager *manager.Pool
+		expect  []*worker.MetaData
+	}{
+		{
+			name: "get metadata",
+			shell: &sysutils.FakeShell{
+				Output: map[string]string{
+					"ls " + localDirectory: phpConfigFiles,
+				},
+			},
+			manager: manager.NewPool(uuid, agentVersion, parentLocalId, localDirectory, "Ubuntu"),
+			expect: []*worker.MetaData{
+				{
+					Type:            "phpfpm_pool",
+					Uuid:            uuid,
+					Name:            "sample-site",
+					DisplayName:     "phpfpm sample-site @ Ubuntu",
+					Listen:          "/var/run/php/php7.4-fpm-$pool.sock",
+					Flisten:         "/var/run/php/php7.4-fpm-sample-site.sock",
+					StatusPath:      "/fpm_status",
+					CanHaveChildren: false,
+					Agent:           agentVersion,
+					ParentLocalId:   parentLocalId,
+					Includes:        []string{},
+					LocalId:         core.GenerateID("%s_%s", parentLocalId, "sample-site"),
+				},
+				{
+					Type:            "phpfpm_pool",
+					Uuid:            uuid,
+					Name:            "www",
+					DisplayName:     "phpfpm www @ Ubuntu",
+					Listen:          "/run/php/php7.4-fpm.sock",
+					Flisten:         "/run/php/php7.4-fpm.sock",
+					StatusPath:      "/status",
+					CanHaveChildren: false,
+					Agent:           agentVersion,
+					ParentLocalId:   parentLocalId,
+					Includes:        []string{localDirectory + "/site1", localDirectory + "/site2", localDirectory + "/sample_site3.conf"},
+					LocalId:         core.GenerateID("%s_%s", parentLocalId, "www"),
+				},
+			},
+		},
+		{
+			name: "no metadata found",
+			shell: &sysutils.FakeShell{
+				Errors: map[string]error{
+					"ls " + localDirectory: errors.New("no such directory or file"),
+				},
+			},
+			manager: manager.NewPool(uuid, agentVersion, parentLocalId, localDirectory, "Ubuntu"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool.Shell = tt.shell
+			actual, _ := tt.manager.GetMetaData()
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}

--- a/src/extensions/php-fpm-metrics/master/master.go
+++ b/src/extensions/php-fpm-metrics/master/master.go
@@ -1,22 +1,21 @@
 package master
 
 import (
+	//"bytes"
 	"fmt"
+	//"os/exec"
 	re "regexp"
-	"strconv"
 	"strings"
 	"unicode"
 
 	"github.com/nginx/agent/v2/src/core"
+	"github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/pkg/phpfpm"
 	log "github.com/sirupsen/logrus"
 )
 
-// Todo: Leverage gopsutil
-var Shell core.Shell = core.ExecShellCommand{}
-
 var (
-	master_re, _ = re.Compile(`.*\((?P<conf_path>\/[^\)]*)\).*`)
-	process_re   = re.MustCompile(`\s*(?P<pid>\d+)\s+(?P<ppid>\d+)\s+(?P<cmd>.+)\s*`)
+	master_re, _            = re.Compile(`.*\((?P<conf_path>\/[^\)]*)\).*`)
+	Shell        core.Shell = core.ExecShellCommand{}
 )
 
 type Master struct {
@@ -30,40 +29,26 @@ func New(host string) *Master {
 }
 
 // GetAll gets meta data of phpfpm master processes
-func (m *Master) GetAll() (map[string]*MetaData, error) {
-	masterByPid := make(map[string]*MetaData)
-	ps, err := Shell.Exec("ps xao pid,ppid,command | grep 'php-fpm[:]'")
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve ps info about php-fpm: %v", err)
-	}
-
-	psSplit := strings.Split(string(ps), "\n")
-	for _, l := range psSplit {
-		if len(l) == 0 {
-			continue
-		}
-		// find master process pid and creates corresponding metadata object, or else increment worker count for pid
-		find(l, masterByPid)
+func (m *Master) GetAll(phpProcess []*phpfpm.PhpProcess) (map[int32]*MetaData, error) {
+	masterByPid := make(map[int32]*MetaData)
+	for _, process := range phpProcess {
+		find(process, masterByPid)
 	}
 	m.updateMetaData(masterByPid)
 	return masterByPid, nil
 }
 
 // updateMetaData updates meta data of master processes from their config
-func (m *Master) updateMetaData(masterByPid map[string]*MetaData) {
-	for ppid, meta := range masterByPid {
+func (m *Master) updateMetaData(masterByPid map[int32]*MetaData) {
+	for _, meta := range masterByPid {
 		meta.DisplayName = hostName(meta.Name, m.host)
-		binPath, err := findBinPath(ppid)
-		if err != nil {
-			continue
-		}
-		meta.BinPath = binPath
 		cmdSplit := strings.Split(meta.Cmd, "/")
 		if len(cmdSplit) < 3 && cmdSplit[0] != "etc" && cmdSplit[1] != "php" {
 			continue
 		}
 		meta.Version = cmdSplit[3]
 		version, version_line, e := findVersion(meta.BinPath)
+
 		if e == nil {
 			meta.Version = version
 			meta.VersionLine = version_line
@@ -71,53 +56,39 @@ func (m *Master) updateMetaData(masterByPid map[string]*MetaData) {
 	}
 }
 
-func find(l string, masterByPid map[string]*MetaData) {
-	parsed := parseProcess(l)
-	pid, ppid, cmd := parsed[1], parsed[2], parsed[3]
-
-	// get master info, otherwise a pool worker
-	if strings.Contains(cmd, "master process") {
-		md := &MetaData{}
-		masterByPid[pid] = md
-		md.Cmd = cmd
+func find(p *phpfpm.PhpProcess, masterByPid map[int32]*MetaData) {
+	if p.IsMaster {
+		_, ok := masterByPid[p.Pid]
+		if !ok {
+			masterByPid[p.Pid] = &MetaData{}
+		}
+		md := masterByPid[p.Pid]
 		md.Name = "master"
 		md.Type = "phpfpm"
-		md.ConfPath = configPath(cmd)
-		pidAsInt, err := strconv.Atoi(pid)
-		if err != nil {
-			log.Warnf("failed to convert pid %s to integer", pid)
-			return
+		md.Cmd = p.Command
+		md.ConfPath = configPath(md.Cmd)
+		md.Pid = p.Pid
+		md.BinPath = p.BinPath
+	} else {
+		_, ok := masterByPid[p.ParentPid]
+		if !ok {
+			md := &MetaData{}
+			masterByPid[p.ParentPid] = md
 		}
-		md.Pid = int32(pidAsInt)
-	} else {
-		masterByPid[ppid].NumWorkers++
-	}
-}
-
-func findBinPath(ppid string) (string, error) {
-	// Example: lrwxrwxrwx 1 root root 0 Aug 24 21:09 /proc/654040/exe -> /usr/sbin/php-fpm7.4
-	binCmd := fmt.Sprintf("/proc/%s/exe", ppid)
-	output, err := Shell.Exec("sudo", "ls", "-la", binCmd)
-	if err != nil {
-		log.Warnf("failed to run bin command : %s, %v", binCmd, err)
-		return "", err
-	} else {
-		binFields := strings.Fields(string(output))
-		l := len(binFields) - 1
-		return binFields[l], nil
+		masterByPid[p.ParentPid].NumWorkers++
 	}
 }
 
 func findVersion(bin_path string) (string, string, error) {
-	output, err := Shell.Exec(fmt.Sprintf("sudo %s --version", bin_path))
+	output, err := Shell.Exec(bin_path, "--version")
 	if err != nil {
-		log.Warnf("failed to get version and version line for php master process%v", err)
+		log.Warnf("failed to get version and version line for php master process :  %v", err)
 		return "", "", err
 	}
 
 	raw_lines := strings.Split(string(output), "\n")
 	// Example: "PHP 7.4.33 (fpm-fcgi) (built: Feb 14 2023 18:31:23)"
-	version_line := raw_lines[1]
+	version_line := raw_lines[0]
 	raw_version := strings.Fields(version_line)[1]
 
 	var version string
@@ -140,10 +111,4 @@ func configPath(line string) string {
 
 func hostName(name, host string) string {
 	return fmt.Sprintf("phpfpm %s @ %s", name, host)
-}
-
-func parseProcess(line string) []string {
-	// parse ps response line.
-	// Example: line = 36  1 php-fpm: master process (/etc/php/7.0/fpm/php-fpm.conf)
-	return process_re.FindStringSubmatch(line)
 }

--- a/src/extensions/php-fpm-metrics/master/master.go
+++ b/src/extensions/php-fpm-metrics/master/master.go
@@ -1,0 +1,149 @@
+package master
+
+import (
+	"fmt"
+	re "regexp"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/nginx/agent/v2/src/core"
+	log "github.com/sirupsen/logrus"
+)
+
+// Todo: Leverage gopsutil
+var Shell core.Shell = core.ExecShellCommand{}
+
+var (
+	master_re, _ = re.Compile(`.*\((?P<conf_path>\/[^\)]*)\).*`)
+	process_re   = re.MustCompile(`\s*(?P<pid>\d+)\s+(?P<ppid>\d+)\s+(?P<cmd>.+)\s*`)
+)
+
+type Master struct {
+	host string
+}
+
+func New(host string) *Master {
+	return &Master{
+		host: host,
+	}
+}
+
+// GetAll gets meta data of phpfpm master processes
+func (m *Master) GetAll() (map[string]*MetaData, error) {
+	masterByPid := make(map[string]*MetaData)
+	ps, err := Shell.Exec("ps xao pid,ppid,command | grep 'php-fpm[:]'")
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve ps info about php-fpm: %v", err)
+	}
+
+	psSplit := strings.Split(string(ps), "\n")
+	for _, l := range psSplit {
+		if len(l) == 0 {
+			continue
+		}
+		// find master process pid and creates corresponding metadata object, or else increment worker count for pid
+		find(l, masterByPid)
+	}
+	m.updateMetaData(masterByPid)
+	return masterByPid, nil
+}
+
+// updateMetaData updates meta data of master processes from their config
+func (m *Master) updateMetaData(masterByPid map[string]*MetaData) {
+	for ppid, meta := range masterByPid {
+		meta.DisplayName = hostName(meta.Name, m.host)
+		binPath, err := findBinPath(ppid)
+		if err != nil {
+			continue
+		}
+		meta.BinPath = binPath
+		cmdSplit := strings.Split(meta.Cmd, "/")
+		if len(cmdSplit) < 3 && cmdSplit[0] != "etc" && cmdSplit[1] != "php" {
+			continue
+		}
+		meta.Version = cmdSplit[3]
+		version, version_line, e := findVersion(meta.BinPath)
+		if e == nil {
+			meta.Version = version
+			meta.VersionLine = version_line
+		}
+	}
+}
+
+func find(l string, masterByPid map[string]*MetaData) {
+	parsed := parseProcess(l)
+	pid, ppid, cmd := parsed[1], parsed[2], parsed[3]
+
+	// get master info, otherwise a pool worker
+	if strings.Contains(cmd, "master process") {
+		md := &MetaData{}
+		masterByPid[pid] = md
+		md.Cmd = cmd
+		md.Name = "master"
+		md.Type = "phpfpm"
+		md.ConfPath = configPath(cmd)
+		pidAsInt, err := strconv.Atoi(pid)
+		if err != nil {
+			log.Warnf("failed to convert pid %s to integer", pid)
+			return
+		}
+		md.Pid = int32(pidAsInt)
+	} else {
+		masterByPid[ppid].NumWorkers++
+	}
+}
+
+func findBinPath(ppid string) (string, error) {
+	// Example: lrwxrwxrwx 1 root root 0 Aug 24 21:09 /proc/654040/exe -> /usr/sbin/php-fpm7.4
+	binCmd := fmt.Sprintf("/proc/%s/exe", ppid)
+	output, err := Shell.Exec("sudo", "ls", "-la", binCmd)
+	if err != nil {
+		log.Warnf("failed to run bin command : %s, %v", binCmd, err)
+		return "", err
+	} else {
+		binFields := strings.Fields(string(output))
+		l := len(binFields) - 1
+		return binFields[l], nil
+	}
+}
+
+func findVersion(bin_path string) (string, string, error) {
+	output, err := Shell.Exec(fmt.Sprintf("sudo %s --version", bin_path))
+	if err != nil {
+		log.Warnf("failed to get version and version line for php master process%v", err)
+		return "", "", err
+	}
+
+	raw_lines := strings.Split(string(output), "\n")
+	// Example: "PHP 7.4.33 (fpm-fcgi) (built: Feb 14 2023 18:31:23)"
+	version_line := raw_lines[1]
+	raw_version := strings.Fields(version_line)[1]
+
+	var version string
+	for _, character := range raw_version {
+		if unicode.IsDigit(character) || character == '.' || character == '-' {
+			version = fmt.Sprintf("%s%c", version, character)
+		} else {
+			break
+		}
+	}
+
+	return version, version_line, nil
+}
+
+func configPath(line string) string {
+	// Example: line = "php-fpm: master process (/etc/php/7.4/fpm/php-fpm.conf)"
+	configPath := master_re.FindStringSubmatch(line)
+	return configPath[1]
+}
+
+func hostName(name, host string) string {
+	return fmt.Sprintf("phpfpm %s @ %s", name, host)
+}
+
+func parseProcess(line string) []string {
+	// parse ps response line.
+	// Example: line = 36  1 php-fpm: master process (/etc/php/7.0/fpm/php-fpm.conf)
+	return process_re.FindStringSubmatch(line)
+}

--- a/src/extensions/php-fpm-metrics/master/types.go
+++ b/src/extensions/php-fpm-metrics/master/types.go
@@ -1,0 +1,21 @@
+package master
+
+import "github.com/nginx/agent/v2/src/extensions/php-fpm-metrics/pool/worker"
+
+type MetaData struct {
+	Type        string
+	LocalId     string
+	Uuid        string
+	Cmd         string
+	Name        string
+	DisplayName string
+	ConfPath    string
+	NumWorkers  int32
+	Version     string
+	VersionLine string
+	Pools       []*worker.MetaData
+	Status      string
+	Pid         int32
+	BinPath     string
+	Agent       string
+}

--- a/src/extensions/php-fpm-metrics/pkg/phpfpm/php_process.go
+++ b/src/extensions/php-fpm-metrics/pkg/phpfpm/php_process.go
@@ -1,0 +1,10 @@
+package phpfpm
+
+type PhpProcess struct {
+	Pid       int32
+	Name      string
+	IsMaster  bool
+	ParentPid int32
+	Command   string
+	BinPath   string
+}

--- a/src/extensions/php-fpm-metrics/pkg/phpfpm/status.go
+++ b/src/extensions/php-fpm-metrics/pkg/phpfpm/status.go
@@ -1,0 +1,30 @@
+package phpfpm
+
+import (
+	"github.com/nginx/agent/v2/src/core"
+)
+
+var Shell core.Shell = core.ExecShellCommand{}
+
+// Status is an Enum that represents the status of PhpFpm.
+type Status int
+
+const (
+	UNKNOWN Status = iota
+	INSTALLED
+	RUNNING
+	MISSING
+)
+
+// String get the string representation of the enum
+func (s Status) String() string {
+	switch s {
+	case INSTALLED:
+		return "INSTALLED"
+	case RUNNING:
+		return "RUNNING"
+	case MISSING:
+		return "MISSING"
+	}
+	return "UNKNOWN"
+}

--- a/src/extensions/php-fpm-metrics/pool/pool.go
+++ b/src/extensions/php-fpm-metrics/pool/pool.go
@@ -1,14 +1,10 @@
 package pool
 
 import (
-	"fmt"
-	"strings"
+	"os"
 
-	"github.com/nginx/agent/v2/src/core"
+	log "github.com/sirupsen/logrus"
 )
-
-// Todo: Leverage gopsutil
-var Shell core.Shell = core.ExecShellCommand{}
 
 type Pool struct {
 	dir string
@@ -22,14 +18,15 @@ func New(dir string) *Pool {
 
 // GetConfigs returns workers configuration in dir
 func (p *Pool) GetConfigs(dir string) ([]string, error) {
-	output, err := Shell.Exec("ls", dir)
+	var files []string
+	fileInfo, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve pool conf files in dir %s: %v", dir, err)
+		log.Warnf("Unable to reading directory %s: %v ", dir, err)
+		return nil, err
 	}
 
-	files := strings.Fields(string(output))
-	if len(files) == 0 {
-		return nil, fmt.Errorf("no conf files in dir %s. pool configurations must be located in this dir. Err: %v", dir, err)
+	for _, file := range fileInfo {
+		files = append(files, file.Name())
 	}
 
 	return files, nil

--- a/src/extensions/php-fpm-metrics/pool/pool.go
+++ b/src/extensions/php-fpm-metrics/pool/pool.go
@@ -1,0 +1,36 @@
+package pool
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nginx/agent/v2/src/core"
+)
+
+// Todo: Leverage gopsutil
+var Shell core.Shell = core.ExecShellCommand{}
+
+type Pool struct {
+	dir string
+}
+
+func New(dir string) *Pool {
+	return &Pool{
+		dir: dir,
+	}
+}
+
+// GetConfigs returns workers configuration in dir
+func (p *Pool) GetConfigs(dir string) ([]string, error) {
+	output, err := Shell.Exec("ls", dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve pool conf files in dir %s: %v", dir, err)
+	}
+
+	files := strings.Fields(string(output))
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no conf files in dir %s. pool configurations must be located in this dir. Err: %v", dir, err)
+	}
+
+	return files, nil
+}

--- a/src/extensions/php-fpm-metrics/pool/worker/types.go
+++ b/src/extensions/php-fpm-metrics/pool/worker/types.go
@@ -1,0 +1,16 @@
+package worker
+
+type MetaData struct {
+	Type            string
+	LocalId         string
+	Uuid            string
+	Name            string
+	DisplayName     string
+	Listen          string
+	Flisten         string
+	StatusPath      string
+	CanHaveChildren bool
+	Agent           string
+	ParentLocalId   string
+	Includes        []string
+}

--- a/src/extensions/php-fpm-metrics/pool/worker/worker.go
+++ b/src/extensions/php-fpm-metrics/pool/worker/worker.go
@@ -1,0 +1,154 @@
+package worker
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	re "regexp"
+
+	"github.com/nginx/agent/v2/src/core"
+)
+
+// Todo: Leverage gopsutil
+var Shell core.Shell = core.ExecShellCommand{}
+
+type Worker struct {
+	cfg, dir, host string
+}
+
+func New(config, dir, host string) *Worker {
+	return &Worker{
+		cfg:  config,
+		dir:  dir,
+		host: host,
+	}
+}
+
+var listen_re, _ = re.Compile(`(\$\w+)`)
+
+// GetConfigs returns workers configuration in dir
+func GetConfigs(dir string) ([]string, error) {
+	output, err := Shell.Exec("ls", dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve pool conf files in dir %s: %v", dir, err)
+	}
+
+	files := strings.Fields(string(output))
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no conf files in dir %s. pool configurations must be located in this dir. Err: %v", dir, err)
+	}
+
+	return files, nil
+}
+
+// GetMetaData returns phpfpm worker meta-data
+func (w *Worker) GetMetaData() *MetaData {
+	pools := []*MetaData{}
+	var currentPool *MetaData
+
+	poolConfLines := strings.Split(w.cfg, "\n")
+	for _, line := range poolConfLines {
+		// skip comments, empty lines
+		if len(line) == 0 || string(line[0]) == ";" {
+			continue
+		}
+
+		// strip
+		line = strings.ReplaceAll(line, " ", "")
+
+		// first check if this is a new pool declaration
+		if string(line[0]) == "[" {
+			// found a new context
+			if currentPool != nil {
+				// if this is not the first pool, append
+				pools = append(pools, currentPool)
+			}
+			// and then reset struct
+			currentPool = &MetaData{
+				Includes: []string{},
+				Name:     getName(line),
+			}
+			// and then move to the next line
+			continue
+		}
+
+		// otherwise, it is a directive within a pool
+		directive := strings.Split(line, "=")
+		// this is a malformed directive and should be ignored
+		if len(directive) != 2 {
+			continue
+		}
+		if directive[0] == "include" {
+			// found an include
+			currentPool.Includes = getIncludes(w.dir, directive[1])
+		} else if directive[0] == "listen" {
+			// found listen socket
+			currentPool.Listen = directive[1]
+			currentPool.Flisten = getFlisten(currentPool, directive[1], line)
+		} else if directive[0] == "pm.status_path" {
+			// found status page
+			currentPool.StatusPath = directive[1]
+		}
+	}
+
+	// append the last active pool that has info collected on
+	pools = append(pools, currentPool)
+
+	pools[0].DisplayName = hostName(pools[0].Name, w.host)
+	return pools[0]
+}
+
+func hostName(name, host string) string {
+	return fmt.Sprintf("phpfpm %s @ %s", name, host)
+}
+
+func getIncludes(dir, includes string) []string {
+	var result []string
+	m := make(map[string]struct{})
+	// Example: includes = site1,site2,*site3*
+	include_rule := strings.Split(includes, ",")
+	for _, include := range include_rule {
+		relative_rule := resolveLocalPath(dir, include)
+		if strings.Contains(relative_rule, "*") {
+			files, err := filepath.Glob(relative_rule)
+			if err == nil {
+				for _, file := range files {
+					if _, ok := m[file]; !ok {
+						m[file] = struct{}{}
+						result = append(result, file)
+					}
+				}
+			}
+		} else if _, ok := m[relative_rule]; !ok {
+			m[relative_rule] = struct{}{}
+			result = append(result, relative_rule)
+		}
+	}
+	return result
+}
+
+func resolveLocalPath(dir, include string) string {
+	result := strings.ReplaceAll(include, "\"", "")
+	if strings.HasPrefix(result, "/") {
+		return result
+	}
+	return fmt.Sprintf("%s/%s", dir, result)
+}
+
+func getName(rawName string) string {
+	// Example: rawName = "[sample-site]"
+	name := strings.ReplaceAll(rawName, "[", "")
+	name = strings.ReplaceAll(name, "]", "")
+	return name
+}
+
+func getFlisten(pool *MetaData, value, line string) string {
+	pool.Flisten = value
+	match := listen_re.FindStringSubmatch(line)
+	// Example: match = "/var/run/php/php7.4-fpm-$pool.sock"
+	if found, _ := core.SliceContainsString(match, "$pool"); found {
+		return strings.ReplaceAll(pool.Flisten, "$pool", pool.Name)
+	}
+	return pool.Flisten
+}

--- a/src/plugins/metrics.go
+++ b/src/plugins/metrics.go
@@ -252,7 +252,7 @@ func (m *Metrics) registerStatsSources() {
 	// if NGINX is not running/detected, still run the static collector to output nginx.status = 0.
 	if !hasNginxCollector {
 		// Just use the default NGINX process path and default NGINX config path to create the NginxID.
-		nginxID := core.GenerateNginxID("%s_%s_%s", "/usr/sbin/nginx", "/etc/nginx/nginx.conf", "prefix")
+		nginxID := core.GenerateID("%s_%s_%s", "/usr/sbin/nginx", "/etc/nginx/nginx.conf", "prefix")
 		tempCollectors = append(tempCollectors,
 			collectors.NewNginxCollector(m.conf, m.env, &metrics.NginxCollectorConfig{NginxId: nginxID}, m.binary),
 		)

--- a/test/integration/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/test/integration/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -23,13 +23,14 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/nginx/agent/sdk/v2/backoff"
 	filesSDK "github.com/nginx/agent/sdk/v2/files"
 	"github.com/nginx/agent/sdk/v2/proto"
 	"github.com/nginx/agent/sdk/v2/zip"
 
 	crossplane "github.com/nginxinc/nginx-go-crossplane"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -298,8 +299,8 @@ func updateNginxConfigWithCert(
 	directoryMap *DirectoryMap,
 	allowedDirectories map[string]struct{},
 ) error {
-	if strings.HasPrefix("$", file) {
-		// variable loading, not actual cert file
+	if strings.Contains(file, "$") {
+		// cannot process any filepath with variables
 		return nil
 	}
 

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/checksum.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/checksum.go
@@ -12,8 +12,8 @@ import (
 	"fmt"
 )
 
-// GenerateNginxID used to get the NGINX ID
-func GenerateNginxID(format string, a ...interface{}) string {
+// GenerateID used to get the ID
+func GenerateID(format string, a ...interface{}) string {
 	h := sha256.New()
 	s := fmt.Sprintf(format, a...)
 	_, _ = h.Write([]byte(s))

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/environment.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/environment.go
@@ -676,14 +676,14 @@ type Shell interface {
 	Exec(cmd string, arg ...string) ([]byte, error)
 }
 
-type execShellCommand struct{}
+type ExecShellCommand struct{}
 
-func (e execShellCommand) Exec(cmd string, arg ...string) ([]byte, error) {
+func (e ExecShellCommand) Exec(cmd string, arg ...string) ([]byte, error) {
 	execCmd := exec.Command(cmd, arg...)
 	return execCmd.Output()
 }
 
-var shell Shell = execShellCommand{}
+var shell Shell = ExecShellCommand{}
 
 func getProcessorCacheInfo(cpuInfo cpuid.CPUInfo) map[string]string {
 	cache := getDefaultProcessorCacheInfo(cpuInfo)

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/nginx.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/nginx.go
@@ -154,7 +154,7 @@ func (n *NginxBinaryType) GetNginxIDForProcess(nginxProcess *Process) string {
 }
 
 func (n *NginxBinaryType) getNginxIDFromProcessInfo(nginxProcess *Process, info *nginxInfo) string {
-	return GenerateNginxID("%s_%s_%s", nginxProcess.Path, info.confPath, info.prefix)
+	return GenerateID("%s_%s_%s", nginxProcess.Path, info.confPath, info.prefix)
 }
 
 func (n *NginxBinaryType) GetNginxDetailsByID(nginxID string) *proto.NginxDetails {

--- a/test/integration/vendor/github.com/nginx/agent/v2/test/utils/system/shell.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/test/utils/system/shell.go
@@ -1,0 +1,24 @@
+package sysutils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FakeShell mocks shell command output and errors
+type FakeShell struct {
+	Output map[string]string
+	Errors map[string]error
+}
+
+// Exec facilitates mocking shell command execution
+func (f *FakeShell) Exec(cmd string, arg ...string) ([]byte, error) {
+	key := strings.Join(append([]string{cmd}, arg...), " ")
+	if err, ok := f.Errors[key]; ok {
+		return nil, err
+	}
+	if out, ok := f.Output[key]; ok {
+		return []byte(out), nil
+	}
+	return nil, fmt.Errorf("unexpected command %s", key)
+}

--- a/test/performance/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/test/performance/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -23,13 +23,14 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/nginx/agent/sdk/v2/backoff"
 	filesSDK "github.com/nginx/agent/sdk/v2/files"
 	"github.com/nginx/agent/sdk/v2/proto"
 	"github.com/nginx/agent/sdk/v2/zip"
 
 	crossplane "github.com/nginxinc/nginx-go-crossplane"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -298,8 +299,8 @@ func updateNginxConfigWithCert(
 	directoryMap *DirectoryMap,
 	allowedDirectories map[string]struct{},
 ) error {
-	if strings.HasPrefix("$", file) {
-		// variable loading, not actual cert file
+	if strings.Contains(file, "$") {
+		// cannot process any filepath with variables
 		return nil
 	}
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/checksum.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/checksum.go
@@ -12,8 +12,8 @@ import (
 	"fmt"
 )
 
-// GenerateNginxID used to get the NGINX ID
-func GenerateNginxID(format string, a ...interface{}) string {
+// GenerateID used to get the ID
+func GenerateID(format string, a ...interface{}) string {
 	h := sha256.New()
 	s := fmt.Sprintf(format, a...)
 	_, _ = h.Write([]byte(s))

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/environment.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/environment.go
@@ -676,14 +676,14 @@ type Shell interface {
 	Exec(cmd string, arg ...string) ([]byte, error)
 }
 
-type execShellCommand struct{}
+type ExecShellCommand struct{}
 
-func (e execShellCommand) Exec(cmd string, arg ...string) ([]byte, error) {
+func (e ExecShellCommand) Exec(cmd string, arg ...string) ([]byte, error) {
 	execCmd := exec.Command(cmd, arg...)
 	return execCmd.Output()
 }
 
-var shell Shell = execShellCommand{}
+var shell Shell = ExecShellCommand{}
 
 func getProcessorCacheInfo(cpuInfo cpuid.CPUInfo) map[string]string {
 	cache := getDefaultProcessorCacheInfo(cpuInfo)

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
@@ -154,7 +154,7 @@ func (n *NginxBinaryType) GetNginxIDForProcess(nginxProcess *Process) string {
 }
 
 func (n *NginxBinaryType) getNginxIDFromProcessInfo(nginxProcess *Process, info *nginxInfo) string {
-	return GenerateNginxID("%s_%s_%s", nginxProcess.Path, info.confPath, info.prefix)
+	return GenerateID("%s_%s_%s", nginxProcess.Path, info.confPath, info.prefix)
 }
 
 func (n *NginxBinaryType) GetNginxDetailsByID(nginxID string) *proto.NginxDetails {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/metrics.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/metrics.go
@@ -252,7 +252,7 @@ func (m *Metrics) registerStatsSources() {
 	// if NGINX is not running/detected, still run the static collector to output nginx.status = 0.
 	if !hasNginxCollector {
 		// Just use the default NGINX process path and default NGINX config path to create the NginxID.
-		nginxID := core.GenerateNginxID("%s_%s_%s", "/usr/sbin/nginx", "/etc/nginx/nginx.conf", "prefix")
+		nginxID := core.GenerateID("%s_%s_%s", "/usr/sbin/nginx", "/etc/nginx/nginx.conf", "prefix")
 		tempCollectors = append(tempCollectors,
 			collectors.NewNginxCollector(m.conf, m.env, &metrics.NginxCollectorConfig{NginxId: nginxID}, m.binary),
 		)

--- a/test/performance/vendor/github.com/nginx/agent/v2/test/utils/system/shell.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/test/utils/system/shell.go
@@ -1,0 +1,24 @@
+package sysutils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FakeShell mocks shell command output and errors
+type FakeShell struct {
+	Output map[string]string
+	Errors map[string]error
+}
+
+// Exec facilitates mocking shell command execution
+func (f *FakeShell) Exec(cmd string, arg ...string) ([]byte, error) {
+	key := strings.Join(append([]string{cmd}, arg...), " ")
+	if err, ok := f.Errors[key]; ok {
+		return nil, err
+	}
+	if out, ok := f.Output[key]; ok {
+		return []byte(out), nil
+	}
+	return nil, fmt.Errorf("unexpected command %s", key)
+}

--- a/test/testdata/configs/php/pool/sample_pool.conf
+++ b/test/testdata/configs/php/pool/sample_pool.conf
@@ -1,0 +1,14 @@
+[sample-site]
+user = sample_user
+group = sample_user
+listen = /var/run/php/php7.4-fpm-$pool.sock
+listen.owner = www-data
+listen.group = www-data
+listen.mode = 0660
+pm = dynamic
+pm.status_path = /fpm_status
+pm.max_children = 75
+pm.start_servers = 10
+pm.min_spare_servers = 5
+pm.max_spare_servers = 20
+pm.process_idle_timeout = 10s

--- a/test/testdata/configs/php/pool/sample_site3.conf
+++ b/test/testdata/configs/php/pool/sample_site3.conf
@@ -1,4 +1,4 @@
-[www]
+[www-site3]
 user = www-data
 group = www-data
 listen = /run/php/php7.4-fpm.sock

--- a/test/testdata/configs/php/pool/sample_site3.conf
+++ b/test/testdata/configs/php/pool/sample_site3.conf
@@ -1,0 +1,13 @@
+[www]
+user = www-data
+group = www-data
+listen = /run/php/php7.4-fpm.sock
+listen.owner = sample-site
+listen.group = sample-site
+listen.mode = 0660
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+pm.status_path = /site3_status

--- a/test/testdata/configs/php/pool/www.conf
+++ b/test/testdata/configs/php/pool/www.conf
@@ -1,0 +1,14 @@
+[www]
+user = www-data
+group = www-data
+listen = /run/php/php7.4-fpm.sock
+listen.owner = sample-site
+listen.group = sample-site
+listen.mode = 0660
+pm = dynamic
+include = site1,site2,*site3*,site*
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+pm.status_path = /status

--- a/test/utils/system/shell.go
+++ b/test/utils/system/shell.go
@@ -1,0 +1,24 @@
+package sysutils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FakeShell mocks shell command output and errors
+type FakeShell struct {
+	Output map[string]string
+	Errors map[string]error
+}
+
+// Exec facilitates mocking shell command execution
+func (f *FakeShell) Exec(cmd string, arg ...string) ([]byte, error) {
+	key := strings.Join(append([]string{cmd}, arg...), " ")
+	if err, ok := f.Errors[key]; ok {
+		return nil, err
+	}
+	if out, ok := f.Output[key]; ok {
+		return []byte(out), nil
+	}
+	return nil, fmt.Errorf("unexpected command %s", key)
+}

--- a/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
+++ b/vendor/github.com/nginx/agent/sdk/v2/config_helpers.go
@@ -23,13 +23,14 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/nginx/agent/sdk/v2/backoff"
 	filesSDK "github.com/nginx/agent/sdk/v2/files"
 	"github.com/nginx/agent/sdk/v2/proto"
 	"github.com/nginx/agent/sdk/v2/zip"
 
 	crossplane "github.com/nginxinc/nginx-go-crossplane"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -298,8 +299,8 @@ func updateNginxConfigWithCert(
 	directoryMap *DirectoryMap,
 	allowedDirectories map[string]struct{},
 ) error {
-	if strings.HasPrefix("$", file) {
-		// variable loading, not actual cert file
+	if strings.Contains(file, "$") {
+		// cannot process any filepath with variables
 		return nil
 	}
 


### PR DESCRIPTION
### Proposed changes

 This change determines metadata for php-fpm master and worker metadata with focuss on parity/functionality with old agent)

### Testing
Unit tests/shell commands execution. Future:- will leverage `gopsutil` package for `shell` command execution.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [X] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
