### PR TITLE
Fix version for forked repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 # Variable Definitions                                                                                            #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 VERSION = $(shell git describe --match "v[0-9]*" --abbrev=0 --tags)
+ifeq ($(VERSION),)
+	VERSION = $(shell curl https://api.github.com/repos/nginx/agent/releases/latest -s | jq .name -r)
+endif
 COMMIT = $(shell git rev-parse --short HEAD)
 DATE = $(shell date +%F_%H-%M-%S)
 


### PR DESCRIPTION
### Proposed changes

If someone forks just the main branch of the repo, they wont have any tags in their forked repo.
To fix this we should query the github api to get the latest tag. That way when someone builds a package it will have a valid version number instead of it being blank.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
