### PR TITLE
Add error log if duplicate NGINX IDs are found

### DIFF
--- a/src/core/nginx.go
+++ b/src/core/nginx.go
@@ -123,13 +123,24 @@ func (n *NginxBinaryType) UpdateNginxDetailsFromProcesses(nginxProcesses []*Proc
 	n.statusUrls = map[string]string{}
 	n.statusUrlMutex.Unlock()
 
+	numberOfMasterProcesses := 0
+
 	for _, process := range nginxProcesses {
 		nginxDetails := n.GetNginxDetailsFromProcess(process)
 		if process.IsMaster {
+			numberOfMasterProcesses++
 			n.nginxDetailsMap[nginxDetails.GetNginxId()] = nginxDetails
 		} else {
 			n.nginxWorkersMap[nginxDetails.GetNginxId()] = append(n.nginxWorkersMap[nginxDetails.GetNginxId()], nginxDetails)
 		}
+	}
+
+	if len(n.nginxDetailsMap) != numberOfMasterProcesses {
+		log.Errorf(
+			"Multiple NGINX master processes detected with the same NGINX ID. Number of master processes is %d. Number of unique NGINX IDs is %d.",
+			numberOfMasterProcesses,
+			len(n.nginxDetailsMap),
+		)
 	}
 }
 

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/nginx.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/nginx.go
@@ -123,13 +123,24 @@ func (n *NginxBinaryType) UpdateNginxDetailsFromProcesses(nginxProcesses []*Proc
 	n.statusUrls = map[string]string{}
 	n.statusUrlMutex.Unlock()
 
+	numberOfMasterProcesses := 0
+
 	for _, process := range nginxProcesses {
 		nginxDetails := n.GetNginxDetailsFromProcess(process)
 		if process.IsMaster {
+			numberOfMasterProcesses++
 			n.nginxDetailsMap[nginxDetails.GetNginxId()] = nginxDetails
 		} else {
 			n.nginxWorkersMap[nginxDetails.GetNginxId()] = append(n.nginxWorkersMap[nginxDetails.GetNginxId()], nginxDetails)
 		}
+	}
+
+	if len(n.nginxDetailsMap) != numberOfMasterProcesses {
+		log.Errorf(
+			"Multiple NGINX master processes detected with the same NGINX ID. Number of master processes is %d. Number of unique NGINX IDs is %d.",
+			numberOfMasterProcesses,
+			len(n.nginxDetailsMap),
+		)
 	}
 }
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/nginx.go
@@ -123,13 +123,24 @@ func (n *NginxBinaryType) UpdateNginxDetailsFromProcesses(nginxProcesses []*Proc
 	n.statusUrls = map[string]string{}
 	n.statusUrlMutex.Unlock()
 
+	numberOfMasterProcesses := 0
+
 	for _, process := range nginxProcesses {
 		nginxDetails := n.GetNginxDetailsFromProcess(process)
 		if process.IsMaster {
+			numberOfMasterProcesses++
 			n.nginxDetailsMap[nginxDetails.GetNginxId()] = nginxDetails
 		} else {
 			n.nginxWorkersMap[nginxDetails.GetNginxId()] = append(n.nginxWorkersMap[nginxDetails.GetNginxId()], nginxDetails)
 		}
+	}
+
+	if len(n.nginxDetailsMap) != numberOfMasterProcesses {
+		log.Errorf(
+			"Multiple NGINX master processes detected with the same NGINX ID. Number of master processes is %d. Number of unique NGINX IDs is %d.",
+			numberOfMasterProcesses,
+			len(n.nginxDetailsMap),
+		)
 	}
 }
 


### PR DESCRIPTION
### Proposed changes

Add error log if duplicate NGINX IDs are found due to multiple NGINX instances running.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
