### PR TITLE
fix: Tolerate additional fields in App Protect yaml files

### DIFF
--- a/src/extensions/nginx-app-protect/nap/attack_signatures.go
+++ b/src/extensions/nginx-app-protect/nap/attack_signatures.go
@@ -37,7 +37,7 @@ func getAttackSignaturesVersion(versionFile string) (string, error) {
 
 	// Read bytes into object
 	attackSigVersionDateTime := napRevisionDateTime{}
-	err = yaml.UnmarshalStrict([]byte(versionBytes), &attackSigVersionDateTime)
+	err = yaml.Unmarshal([]byte(versionBytes), &attackSigVersionDateTime)
 	if err != nil {
 		return "", err
 	}

--- a/src/extensions/nginx-app-protect/nap/attack_signatures_test.go
+++ b/src/extensions/nginx-app-protect/nap/attack_signatures_test.go
@@ -20,7 +20,9 @@ const (
 	testAttackSigVersionFileContents = `---
 checksum: t+N7AHGIKPhdDwb8zMZh2w
 filename: signatures.bin.tgz
-revisionDatetime: 2022-02-24T20:32:01Z`
+revisionDatetime: 2022-02-24T20:32:01Z
+distro: focal
+osType: debian`
 )
 
 func TestGetAttackSignaturesVersion(t *testing.T) {

--- a/src/extensions/nginx-app-protect/nap/threat_campaigns.go
+++ b/src/extensions/nginx-app-protect/nap/threat_campaigns.go
@@ -37,7 +37,7 @@ func getThreatCampaignsVersion(versionFile string) (string, error) {
 
 	// Read bytes into object
 	threatCampVersionDateTime := napRevisionDateTime{}
-	err = yaml.UnmarshalStrict([]byte(versionBytes), &threatCampVersionDateTime)
+	err = yaml.Unmarshal([]byte(versionBytes), &threatCampVersionDateTime)
 	if err != nil {
 		return "", err
 	}

--- a/src/extensions/nginx-app-protect/nap/threat_campaigns_test.go
+++ b/src/extensions/nginx-app-protect/nap/threat_campaigns_test.go
@@ -20,7 +20,9 @@ const (
 	testThreatCampaignsVersionFileContents = `---
 checksum: ALCdgk8CQgQQLRJ1ydZA4g
 filename: threat_campaigns.bin.tgz
-revisionDatetime: 2022-03-01T20:32:01Z`
+revisionDatetime: 2022-03-01T20:32:01Z
+distro: focal
+osType: debian`
 )
 
 func TestGetThreatCampaignsVersion(t *testing.T) {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/extensions/nginx-app-protect/nap/attack_signatures.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/extensions/nginx-app-protect/nap/attack_signatures.go
@@ -37,7 +37,7 @@ func getAttackSignaturesVersion(versionFile string) (string, error) {
 
 	// Read bytes into object
 	attackSigVersionDateTime := napRevisionDateTime{}
-	err = yaml.UnmarshalStrict([]byte(versionBytes), &attackSigVersionDateTime)
+	err = yaml.Unmarshal([]byte(versionBytes), &attackSigVersionDateTime)
 	if err != nil {
 		return "", err
 	}

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/extensions/nginx-app-protect/nap/threat_campaigns.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/extensions/nginx-app-protect/nap/threat_campaigns.go
@@ -37,7 +37,7 @@ func getThreatCampaignsVersion(versionFile string) (string, error) {
 
 	// Read bytes into object
 	threatCampVersionDateTime := napRevisionDateTime{}
-	err = yaml.UnmarshalStrict([]byte(versionBytes), &threatCampVersionDateTime)
+	err = yaml.Unmarshal([]byte(versionBytes), &threatCampVersionDateTime)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The format of "/opt/app_protect/var/update_files/signatures/signature_update.yaml" from the latest Attack Signature update (2023.10.04) contained additional items.

### Proposed changes

Changed the parsing of the yaml file to not be "strict" to maintain compatibility across versions.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
