### PR TITLE
Fix user agent request header to have the correct agent version

### DIFF
--- a/src/core/grpc.go
+++ b/src/core/grpc.go
@@ -68,7 +68,7 @@ func CreateGrpcClients(ctx context.Context, loadedConfig *config.Config) (client
 }
 
 func setDialOptions(loadedConfig *config.Config) []grpc.DialOption {
-	grpcDialOptions := []grpc.DialOption{grpc.WithUserAgent("nginx-agent/" + strings.TrimPrefix(version, "v"))}
+	grpcDialOptions := []grpc.DialOption{grpc.WithUserAgent("nginx-agent/" + strings.TrimPrefix(loadedConfig.Version, "v"))}
 	grpcDialOptions = append(grpcDialOptions, sdkGRPC.DefaultClientDialOptions...)
 	grpcDialOptions = append(grpcDialOptions, sdkGRPC.DataplaneConnectionDialOptions(loadedConfig.Server.Token, sdkGRPC.NewMessageMeta(uuid.NewString()))...)
 	return grpcDialOptions

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/grpc.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/grpc.go
@@ -68,7 +68,7 @@ func CreateGrpcClients(ctx context.Context, loadedConfig *config.Config) (client
 }
 
 func setDialOptions(loadedConfig *config.Config) []grpc.DialOption {
-	grpcDialOptions := []grpc.DialOption{grpc.WithUserAgent("nginx-agent/" + strings.TrimPrefix(version, "v"))}
+	grpcDialOptions := []grpc.DialOption{grpc.WithUserAgent("nginx-agent/" + strings.TrimPrefix(loadedConfig.Version, "v"))}
 	grpcDialOptions = append(grpcDialOptions, sdkGRPC.DefaultClientDialOptions...)
 	grpcDialOptions = append(grpcDialOptions, sdkGRPC.DataplaneConnectionDialOptions(loadedConfig.Server.Token, sdkGRPC.NewMessageMeta(uuid.NewString()))...)
 	return grpcDialOptions

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/grpc.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/grpc.go
@@ -68,7 +68,7 @@ func CreateGrpcClients(ctx context.Context, loadedConfig *config.Config) (client
 }
 
 func setDialOptions(loadedConfig *config.Config) []grpc.DialOption {
-	grpcDialOptions := []grpc.DialOption{grpc.WithUserAgent("nginx-agent/" + strings.TrimPrefix(version, "v"))}
+	grpcDialOptions := []grpc.DialOption{grpc.WithUserAgent("nginx-agent/" + strings.TrimPrefix(loadedConfig.Version, "v"))}
 	grpcDialOptions = append(grpcDialOptions, sdkGRPC.DefaultClientDialOptions...)
 	grpcDialOptions = append(grpcDialOptions, sdkGRPC.DataplaneConnectionDialOptions(loadedConfig.Server.Token, sdkGRPC.NewMessageMeta(uuid.NewString()))...)
 	return grpcDialOptions


### PR DESCRIPTION
### Proposed changes

Fix user agent request header to have the correct agent version

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
