### PR TITLE
fix worker metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ NGINX Agent provides an API interface for submission of updated configuration fi
 ## Collecting Metrics
 NGINX Agent interfaces with NGINX process information and parses NGINX logs to calculate and report metrics. When interfacing with NGINX Plus, NGINX Agent pulls relevant information from the NGINX Plus API. Reported metrics may be aggregated by [Prometheus](https://prometheus.io/) and visualized with tools like [Grafana](https://grafana.com/).
 
+The NGINX Agent keeps a connection open to the NGINX Plus API and queries based on the collection interval. This connection gets reported in the metrics and depending on the phase of reporting this connection can show up as idle or active.
+
 ### NGINX Open Source
 When running alongside an open source instance of NGINX, NGINX Agent requires that NGINX Access and Error logs are turned on and contain all default variables.
 

--- a/src/core/metrics/sources/nginx_plus.go
+++ b/src/core/metrics/sources/nginx_plus.go
@@ -855,10 +855,7 @@ func (c *NginxPlus) workerMetrics(stats, prevStats *plusclient.Stats) []*metrics
 		if _, exists := prevWorkerProcs[w.ProcessID]; exists {
 			w.Connections.Accepted = w.Connections.Accepted - prevWorkerProcs[w.ProcessID].Connections.Accepted
 			w.Connections.Dropped = w.Connections.Dropped - prevWorkerProcs[w.ProcessID].Connections.Dropped
-			w.Connections.Active = w.Connections.Active - prevWorkerProcs[w.ProcessID].Connections.Active
-			w.Connections.Idle = w.Connections.Idle - prevWorkerProcs[w.ProcessID].Connections.Idle
 			w.HTTP.HTTPRequests.Total = w.HTTP.HTTPRequests.Total - prevWorkerProcs[w.ProcessID].HTTP.HTTPRequests.Total
-			w.HTTP.HTTPRequests.Current = w.HTTP.HTTPRequests.Current - prevWorkerProcs[w.ProcessID].HTTP.HTTPRequests.Current
 		}
 
 		simpleMetrics := l.convertSamplesToSimpleMetrics(map[string]float64{

--- a/src/core/metrics/sources/nginx_plus_test.go
+++ b/src/core/metrics/sources/nginx_plus_test.go
@@ -829,10 +829,10 @@ func TestNginxPlus_Collect(t *testing.T) {
 	expectedWorkerMetrics := map[string]float64{
 		"plus.worker.conn.accepted":        currentWorkerConnAccepted - previousWorkerConnAccepted,
 		"plus.worker.conn.dropped":         currentWorkerConnDropped - previousWorkerConnDropped,
-		"plus.worker.conn.active":          currentWorkerConnActive - previousWorkerConnActive,
-		"plus.worker.conn.idle":            currentWorkerConnIdle - previousWorkerConnIdle,
+		"plus.worker.conn.active":          currentWorkerConnActive,
+		"plus.worker.conn.idle":            currentWorkerConnIdle,
 		"plus.worker.http.request.total":   currentWorkerHTTPRequestTotal - previousWorkerHTTPRequestTotal,
-		"plus.worker.http.request.current": currentWorkerHTTPRequestCurrent - previousWorkerHTTPRequestCurrent,
+		"plus.worker.http.request.current": currentWorkerHTTPRequestCurrent,
 	}
 
 	tests := []struct {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/nginx_plus.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/nginx_plus.go
@@ -855,10 +855,7 @@ func (c *NginxPlus) workerMetrics(stats, prevStats *plusclient.Stats) []*metrics
 		if _, exists := prevWorkerProcs[w.ProcessID]; exists {
 			w.Connections.Accepted = w.Connections.Accepted - prevWorkerProcs[w.ProcessID].Connections.Accepted
 			w.Connections.Dropped = w.Connections.Dropped - prevWorkerProcs[w.ProcessID].Connections.Dropped
-			w.Connections.Active = w.Connections.Active - prevWorkerProcs[w.ProcessID].Connections.Active
-			w.Connections.Idle = w.Connections.Idle - prevWorkerProcs[w.ProcessID].Connections.Idle
 			w.HTTP.HTTPRequests.Total = w.HTTP.HTTPRequests.Total - prevWorkerProcs[w.ProcessID].HTTP.HTTPRequests.Total
-			w.HTTP.HTTPRequests.Current = w.HTTP.HTTPRequests.Current - prevWorkerProcs[w.ProcessID].HTTP.HTTPRequests.Current
 		}
 
 		simpleMetrics := l.convertSamplesToSimpleMetrics(map[string]float64{


### PR DESCRIPTION
### Proposed changes
`plus.worker.conn.idle`, `plus.worker.conn.active` and `plus.worker.http.request.current` are `avgs` but were being treated like `sums` when converting to `simpleMetrics`  in `nginx_plus.go`

Removed calculation of `stats - prevStats` from `conn.idle`, `conn.active` and `http.request.current`

Added note about Agent showing up as a connection in `plus.worker.conn.idle` or `plus.worker.conn.active`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
