### PR TITLE
fix: avoid re-use of context by commander for Download and Upload requests

### DIFF
--- a/sdk/client/commander.go
+++ b/sdk/client/commander.go
@@ -198,7 +198,10 @@ func (c *commander) Download(ctx context.Context, metadata *proto.Metadata) (*pr
 			body   []byte
 		)
 
-		downloader, err := c.client.Download(c.ctx, &proto.DownloadRequest{Meta: metadata})
+		reqCtx, cancel := context.WithCancel(c.ctx)
+		defer cancel()
+
+		downloader, err := c.client.Download(reqCtx, &proto.DownloadRequest{Meta: metadata})
 		if err != nil {
 			isRetrying = true
 			return c.handleGrpcError("Commander Downloader", err)
@@ -270,7 +273,10 @@ func (c *commander) Upload(ctx context.Context, cfg *proto.NginxConfig, messageI
 			}
 		}
 
-		sender, err := c.client.Upload(c.ctx)
+		reqCtx, cancel := context.WithCancel(c.ctx)
+		defer cancel()
+
+		sender, err := c.client.Upload(reqCtx)
 		if err != nil {
 			isRetrying = true
 			return c.handleGrpcError("Commander Upload", err)


### PR DESCRIPTION
### Proposed changes

When agent reconnects to NIM after a disconnect, config apply doesn’t work as the DPM handler that was established with the original context is no longer valid. To resolve this the gRPC client Download and Upload needs to establish new contexts for each request.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
