### PR TITLE
Fix alpine plus dockerfile on alpine>=3.17

### DIFF
--- a/scripts/docker/nginx-plus/alpine/Dockerfile
+++ b/scripts/docker/nginx-plus/alpine/Dockerfile
@@ -20,7 +20,7 @@ RUN --mount=type=secret,id=nginx-crt,dst=/etc/apk/cert.pem \
     && apk add --no-cache --virtual .cert-deps \
         openssl \
     && wget -O /tmp/nginx_signing.rsa.pub https://nginx.org/keys/nginx_signing.rsa.pub \
-    && if [ "$(openssl rsa -pubin -in /tmp/nginx_signing.rsa.pub -text -noout | openssl sha512 -r)" = "$KEY_SHA512" ]; then \
+    && if [ "$(openssl rsa -pubin -in /tmp/nginx_signing.rsa.pub -text -noout | sed -e 's/Public-Key/RSA Public-Key/' | openssl sha512 -r)" = "$KEY_SHA512" ]; then \
         echo "key verification succeeded!"; \
         mv /tmp/nginx_signing.rsa.pub /etc/apk/keys/; \
     else \

--- a/scripts/docker/nginx-plus/alpine/Dockerfile
+++ b/scripts/docker/nginx-plus/alpine/Dockerfile
@@ -20,6 +20,7 @@ RUN --mount=type=secret,id=nginx-crt,dst=/etc/apk/cert.pem \
     && apk add --no-cache --virtual .cert-deps \
         openssl \
     && wget -O /tmp/nginx_signing.rsa.pub https://nginx.org/keys/nginx_signing.rsa.pub \
+    # sed replace is required for openssl=v1.x which is used in alpine<=3.16
     && if [ "$(openssl rsa -pubin -in /tmp/nginx_signing.rsa.pub -text -noout | sed -e 's/RSA Public-Key/Public-Key/' | openssl sha512 -r)" = "$KEY_SHA512" ]; then \
         echo "key verification succeeded!"; \
         mv /tmp/nginx_signing.rsa.pub /etc/apk/keys/; \

--- a/scripts/docker/nginx-plus/alpine/Dockerfile
+++ b/scripts/docker/nginx-plus/alpine/Dockerfile
@@ -16,11 +16,11 @@ RUN --mount=type=secret,id=nginx-crt,dst=/etc/apk/cert.pem \
     && addgroup -g 101 -S nginx \
     && adduser -S -D -H -u 101 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx \
     # Check signing key
-    && KEY_SHA512="e7fa8303923d9b95db37a77ad46c68fd4755ff935d0a534d26eba83de193c76166c68bfe7f65471bf8881004ef4aa6df3e34689c305662750c0172fca5d8552a *stdin" \
+    && KEY_SHA512="de7031fdac1354096d3388d6f711a508328ce66c168967ee0658c294226d6e7a161ce7f2628d577d56f8b63ff6892cc576af6f7ef2a6aa2e17c62ff7b6bf0d98 *stdin" \
     && apk add --no-cache --virtual .cert-deps \
         openssl \
     && wget -O /tmp/nginx_signing.rsa.pub https://nginx.org/keys/nginx_signing.rsa.pub \
-    && if [ "$(openssl rsa -pubin -in /tmp/nginx_signing.rsa.pub -text -noout | sed -e 's/Public-Key/RSA Public-Key/' | openssl sha512 -r)" = "$KEY_SHA512" ]; then \
+    && if [ "$(openssl rsa -pubin -in /tmp/nginx_signing.rsa.pub -text -noout | sed -e 's/RSA Public-Key/Public-Key/' | openssl sha512 -r)" = "$KEY_SHA512" ]; then \
         echo "key verification succeeded!"; \
         mv /tmp/nginx_signing.rsa.pub /etc/apk/keys/; \
     else \


### PR DESCRIPTION
### Description of issue

`alpine>=v3.17` upgrades openssl version `v1.1.1w` -> `v3.0.x` which brings a slight format change which broke key verification.

#### Openssl v1 format:
```
$ openssl rsa -pubin -in /tmp/nginx_signing.rsa.pub -text -noout
RSA Public-Key: (2048 bit)
Modulus:
    00:fe:14:f6:0a:1a:b8:86:19:fe:cd:ab:02:9f:58:
...
```

#### Openssl v3 format:
```
$ openssl rsa -pubin -in /tmp/nginx_signing.rsa.pub -text -noout
Public-Key: (2048 bit)
Modulus:
    00:fe:14:f6:0a:1a:b8:86:19:fe:cd:ab:02:9f:58:
...
```
### Proposed changes

* Update expected key to match `openssl=v3.0.x` format
* Add sed replace to make old output format verify successfully against new key
* Add note so sed can be easily and safely removed in the future

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
