### PR TITLE
Restrict config apply directory permissions

### DIFF
--- a/src/core/environment.go
+++ b/src/core/environment.go
@@ -286,8 +286,8 @@ func (env *EnvironmentType) WriteFile(backup ConfigApplyMarker, file *proto.File
 	directory := filepath.Dir(fileFullPath)
 	_, err := os.Stat(directory)
 	if os.IsNotExist(err) {
-		log.Debugf("Creating directory %s with permissions 755", directory)
-		err = os.MkdirAll(directory, 0o755)
+		log.Debugf("Creating directory %s with permissions 750", directory)
+		err = os.MkdirAll(directory, 0o750)
 		if err != nil {
 			return err
 		}

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/environment.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/environment.go
@@ -286,8 +286,8 @@ func (env *EnvironmentType) WriteFile(backup ConfigApplyMarker, file *proto.File
 	directory := filepath.Dir(fileFullPath)
 	_, err := os.Stat(directory)
 	if os.IsNotExist(err) {
-		log.Debugf("Creating directory %s with permissions 755", directory)
-		err = os.MkdirAll(directory, 0o755)
+		log.Debugf("Creating directory %s with permissions 750", directory)
+		err = os.MkdirAll(directory, 0o750)
 		if err != nil {
 			return err
 		}

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/environment.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/environment.go
@@ -286,8 +286,8 @@ func (env *EnvironmentType) WriteFile(backup ConfigApplyMarker, file *proto.File
 	directory := filepath.Dir(fileFullPath)
 	_, err := os.Stat(directory)
 	if os.IsNotExist(err) {
-		log.Debugf("Creating directory %s with permissions 755", directory)
-		err = os.MkdirAll(directory, 0o755)
+		log.Debugf("Creating directory %s with permissions 750", directory)
+		err = os.MkdirAll(directory, 0o750)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Proposed changes

* Restrict permissions of config apply directory `755` -> `750`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
