### PR TITLE
fix: add missing catalog entry

### DIFF
--- a/site/content/installation-upgrade/container-environments/docker-images.md
+++ b/site/content/installation-upgrade/container-environments/docker-images.md
@@ -6,6 +6,7 @@ toc: true
 tags: [ "docs" ]
 categories: ["configuration"]
 doctypes: ["task"]
+docs: "DOCS-1410"
 ---
 
 ## Overview


### PR DESCRIPTION
### Proposed changes

Adds the Documentation Catalog ID to a recent document.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
