### PR TITLE
Add default temp config directory for mock management plane grpc file server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ OSS_PACKAGES_REPO 	:= "packages.nginx.org"
 PACKAGE_PREFIX 		:= nginx-agent
 PACKAGE_NAME 		:= "$(PACKAGE_PREFIX)-$(shell echo $(VERSION) | tr -d 'v')-SNAPSHOT-$(COMMIT)"
 
-MOCK_MANAGEMENT_PLANE_CONFIG_DIRECTORY ?= test/config/nginx
+MOCK_MANAGEMENT_PLANE_CONFIG_DIRECTORY ?= 
 OLD_BENCHMARK_RESULTS_FILE ?= $(TEST_BUILD_DIR)/benchmark.txt
 
 uname_m    := $(shell uname -m)

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ PACKAGE_PREFIX 		:= nginx-agent
 PACKAGE_NAME 		:= "$(PACKAGE_PREFIX)-$(shell echo $(VERSION) | tr -d 'v')-SNAPSHOT-$(COMMIT)"
 
 MOCK_MANAGEMENT_PLANE_CONFIG_DIRECTORY ?= 
+MOCK_MANAGEMENT_PLANE_LOG_LEVEL ?= INFO
 OLD_BENCHMARK_RESULTS_FILE ?= $(TEST_BUILD_DIR)/benchmark.txt
 
 uname_m    := $(shell uname -m)
@@ -143,7 +144,7 @@ dev: ## Run agent executable
 
 run-mock-management-grpc-server: ## Run mock management plane gRPC server
 	@echo "🚀 Running mock management plane gRPC server"
-	$(GORUN) test/mock/grpc/cmd/main.go -configDirectory=$(MOCK_MANAGEMENT_PLANE_CONFIG_DIRECTORY)
+	$(GORUN) test/mock/grpc/cmd/main.go -configDirectory=$(MOCK_MANAGEMENT_PLANE_CONFIG_DIRECTORY) -logLevel=$(MOCK_MANAGEMENT_PLANE_LOG_LEVEL)
 
 run-mock-management-http-server: ## Run mock management HTTP server
 	@echo "🚀 Running mock management plane HTTP server"

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -31,14 +31,14 @@ func New(params config.Log) *slog.Logger {
 	handler := slog.NewTextHandler(
 		getLogWriter(params.Path),
 		&slog.HandlerOptions{
-			Level: getLogLevel(params.Level),
+			Level: GetLogLevel(params.Level),
 		},
 	)
 
 	return slog.New(handler)
 }
 
-func getLogLevel(level string) slog.Level {
+func GetLogLevel(level string) slog.Level {
 	if level == "" {
 		return slog.LevelInfo
 	}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -58,7 +58,7 @@ func TestGetLogLevel(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			result := getLogLevel(test.input)
+			result := GetLogLevel(test.input)
 			assert.IsType(tt, test.expected, result)
 		})
 	}

--- a/test/mock/grpc/cmd/main.go
+++ b/test/mock/grpc/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 
 	"github.com/nginx/agent/v3/api/grpc/mpi/v1"
+	"github.com/nginx/agent/v3/internal/logger"
 	mockGrpc "github.com/nginx/agent/v3/test/mock/grpc"
 	"google.golang.org/grpc"
 )
@@ -26,8 +27,8 @@ func main() {
 	var configDirectory string
 	var grpcAddress string
 	var apiAddress string
-
 	var address string
+	var logLevel string
 
 	flag.StringVar(
 		&configDirectory,
@@ -57,7 +58,19 @@ func main() {
 		"set the API address to run the server on",
 	)
 
+	flag.StringVar(
+		&logLevel,
+		"logLevel",
+		"INFO",
+		"set the log level",
+	)
+
 	flag.Parse()
+
+	newLogger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: logger.GetLogLevel(logLevel),
+	}))
+	slog.SetDefault(newLogger)
 
 	if configDirectory == "" {
 		defaultConfigDirectory, err := generateDefaultConfigDirectory()
@@ -135,5 +148,5 @@ func generateDefaultConfigDirectory() (string, error) {
 		return "", err
 	}
 
-	return filepath.Join(tempDirectory, "config/"), nil
+	return filepath.Join(tempDirectory, "config"), nil
 }

--- a/test/mock/grpc/cmd/main.go
+++ b/test/mock/grpc/cmd/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	filePermissions = 0o700
+	filePermissions = 0o640
 )
 
 func main() {

--- a/test/mock/grpc/cmd/main.go
+++ b/test/mock/grpc/cmd/main.go
@@ -7,13 +7,19 @@ package main
 
 import (
 	"flag"
+	"io"
 	"log/slog"
 	"net"
 	"os"
+	"path/filepath"
 
 	"github.com/nginx/agent/v3/api/grpc/mpi/v1"
 	mockGrpc "github.com/nginx/agent/v3/test/mock/grpc"
 	"google.golang.org/grpc"
+)
+
+const (
+	filePermissions = 0o700
 )
 
 func main() {
@@ -21,17 +27,12 @@ func main() {
 	var grpcAddress string
 	var apiAddress string
 
-	currentPath, err := os.Getwd()
-	if err != nil {
-		slog.Error("Unable to get current directory", "error", err)
-	}
-
 	var address string
 
 	flag.StringVar(
 		&configDirectory,
 		"configDirectory",
-		currentPath,
+		"",
 		"set the directory where the config files are stored",
 	)
 
@@ -55,14 +56,24 @@ func main() {
 		"127.0.0.1:0",
 		"set the API address to run the server on",
 	)
+
 	flag.Parse()
+
+	if configDirectory == "" {
+		defaultConfigDirectory, err := generateDefaultConfigDirectory()
+		configDirectory = defaultConfigDirectory
+		if err != nil {
+			slog.Error("Failed to create default config directory", "error", err)
+			os.Exit(1)
+		}
+	}
 
 	commandServer := mockGrpc.NewManagementGrpcServer()
 
 	go func() {
 		listener, listenError := net.Listen("tcp", apiAddress)
 		if listenError != nil {
-			slog.Error("Failed to create listener", "error", err)
+			slog.Error("Failed to create listener", "error", listenError)
 			os.Exit(1)
 		}
 
@@ -71,13 +82,13 @@ func main() {
 
 	fileServer, err := mockGrpc.NewManagementGrpcFileServer(configDirectory)
 	if err != nil {
-		slog.Error("Failed to create file server: %v", err)
+		slog.Error("Failed to create file server", "error", err)
 		os.Exit(1)
 	}
 
 	listener, err := net.Listen("tcp", grpcAddress)
 	if err != nil {
-		slog.Error("Failed to listen: %v", err)
+		slog.Error("Failed to listen", "error", err)
 		os.Exit(1)
 	}
 	var opts []grpc.ServerOption
@@ -93,4 +104,36 @@ func main() {
 		slog.Error("Failed to serve server", "error", err)
 		os.Exit(1)
 	}
+}
+
+func generateDefaultConfigDirectory() (string, error) {
+	tempDirectory := os.TempDir()
+
+	err := os.MkdirAll(filepath.Join(tempDirectory, "config/1/etc/nginx"), filePermissions)
+	if err != nil {
+		slog.Error("Failed to create directories", "error", err)
+		return "", err
+	}
+
+	source, err := os.Open("test/config/nginx/nginx.conf")
+	if err != nil {
+		slog.Error("Failed to open nginx.conf", "error", err)
+		return "", err
+	}
+	defer source.Close()
+
+	destination, err := os.Create(filepath.Join(tempDirectory, "config/1/etc/nginx/nginx.conf"))
+	if err != nil {
+		slog.Error("Failed to create nginx.conf", "error", err)
+		return "", err
+	}
+	defer destination.Close()
+
+	_, err = io.Copy(destination, source)
+	if err != nil {
+		slog.Error("Failed to copy nginx.conf", "error", err)
+		return "", err
+	}
+
+	return filepath.Join(tempDirectory, "config/"), nil
 }

--- a/test/mock/grpc/mock_management_plane_grpc_file_server.go
+++ b/test/mock/grpc/mock_management_plane_grpc_file_server.go
@@ -184,14 +184,14 @@ func getMapOfVersionedFiles(configDirectory string) (map[string][]*v1.File, erro
 		}
 
 		if !info.IsDir() {
-			slog.Info("Found file", "path", path)
+			slog.Debug("Found file", "path", path)
 
-			splitPath := strings.SplitN(strings.Split(path, configDirectory)[1], "/", 3)
+			splitPath := strings.SplitN(strings.Split(path, configDirectory)[1], string(filepath.Separator), 3)
 			if len(splitPath) == 2 {
 				return nil
 			}
 			version := splitPath[1]
-			filePath := "/" + splitPath[2]
+			filePath := string(filepath.Separator) + splitPath[2]
 
 			versionDirectory := filepath.Join(configDirectory, version)
 

--- a/test/mock/grpc/mock_management_plane_grpc_file_server.go
+++ b/test/mock/grpc/mock_management_plane_grpc_file_server.go
@@ -172,16 +172,23 @@ func (mgfs *ManagementGrpcFileServer) getConfigVersions(fileName, fileHash strin
 	return fileConfigVersions
 }
 
+// nolint
 func getMapOfVersionedFiles(configDirectory string) (map[string][]*v1.File, error) {
 	files := make(map[string][]*v1.File)
+
+	slog.Info("Getting map of versioned files", "config_directory", configDirectory)
 
 	err := filepath.Walk(configDirectory, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
+
 		if !info.IsDir() {
-			// nolint: gomnd
+			slog.Info("Found file", "path", path)
 			splitPath := strings.SplitN(strings.Split(path, configDirectory)[1], "/", 3)
+			if len(splitPath) == 2 {
+				return nil
+			}
 			version := splitPath[1]
 			filePath := "/" + splitPath[2]
 			versionDirectory := filepath.Join(configDirectory, version)


### PR DESCRIPTION
### Proposed changes

Add default temp config directory for mock management plane grpc file server

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
