### PR TITLE
Fix send data plane status update nil pointer exception

### DIFF
--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -64,20 +64,3 @@ func WaitUntil(
 
 	return backoff.Retry(operation, backoffWithContext)
 }
-
-func WaitUntilWithOperationContext(
-	ctx context.Context,
-	backoffSettings *config.CommonSettings,
-	operation backoff.OperationWithData[context.Context],
-) (context.Context, error) {
-	eb := backoff.NewExponentialBackOff()
-	eb.InitialInterval = backoffSettings.InitialInterval
-	eb.MaxInterval = backoffSettings.MaxInterval
-	eb.MaxElapsedTime = backoffSettings.MaxElapsedTime
-	eb.RandomizationFactor = backoffSettings.RandomizationFactor
-	eb.Multiplier = backoffSettings.Multiplier
-
-	backoffWithContext := backoff.WithContext(eb, ctx)
-
-	return backoff.RetryWithData(operation, backoffWithContext)
-}

--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -64,3 +64,20 @@ func WaitUntil(
 
 	return backoff.Retry(operation, backoffWithContext)
 }
+
+func WaitUntilWithOperationContext(
+	ctx context.Context,
+	backoffSettings *config.CommonSettings,
+	operation backoff.OperationWithData[context.Context],
+) (context.Context, error) {
+	eb := backoff.NewExponentialBackOff()
+	eb.InitialInterval = backoffSettings.InitialInterval
+	eb.MaxInterval = backoffSettings.MaxInterval
+	eb.MaxElapsedTime = backoffSettings.MaxElapsedTime
+	eb.RandomizationFactor = backoffSettings.RandomizationFactor
+	eb.Multiplier = backoffSettings.Multiplier
+
+	backoffWithContext := backoff.WithContext(eb, ctx)
+
+	return backoff.RetryWithData(operation, backoffWithContext)
+}

--- a/internal/plugin/grpc_client_plugin.go
+++ b/internal/plugin/grpc_client_plugin.go
@@ -186,9 +186,9 @@ func (gc *GrpcClient) Process(ctx context.Context, msg *bus.Message) {
 		gc.isConnected.Store(true)
 
 		gc.instancesMutex.Lock()
-		defer gc.instancesMutex.Unlock()
-
 		err := gc.sendDataPlaneStatusUpdate(ctx, gc.instances)
+		gc.instancesMutex.Unlock()
+
 		if err != nil {
 			slog.ErrorContext(ctx, "Unable to send data plane status update", "error", err)
 		}

--- a/internal/plugin/grpc_client_plugin.go
+++ b/internal/plugin/grpc_client_plugin.go
@@ -126,7 +126,8 @@ func (gc *GrpcClient) createConnection() error {
 		},
 	}
 
-	reqCtx, reqCancel := context.WithTimeout(context.Background(), gc.config.Common.MaxElapsedTime)
+	ctx := context.Background()
+	reqCtx, reqCancel := context.WithTimeout(ctx, gc.config.Common.MaxElapsedTime)
 	defer reqCancel()
 
 	response, err := gc.commandServiceClient.CreateConnection(reqCtx, req)
@@ -135,7 +136,7 @@ func (gc *GrpcClient) createConnection() error {
 	}
 
 	slog.Debug("Connection created", "response", response)
-	gc.messagePipe.Process(reqCtx, &bus.Message{Topic: bus.GrpcConnectedTopic, Data: response})
+	gc.messagePipe.Process(ctx, &bus.Message{Topic: bus.GrpcConnectedTopic, Data: response})
 
 	return nil
 }

--- a/internal/plugin/grpc_client_plugin.go
+++ b/internal/plugin/grpc_client_plugin.go
@@ -31,9 +31,12 @@ type (
 		messagePipe          bus.MessagePipeInterface
 		config               *config.Config
 		conn                 *grpc.ClientConn
+		isConnected          bool
 		commandServiceClient v1.CommandServiceClient
 		cancel               context.CancelFunc
+		instances            []*v1.Instance
 		connectionMutex      sync.Mutex
+		instancesMutex       sync.Mutex
 	}
 )
 
@@ -46,7 +49,10 @@ func NewGrpcClient(agentConfig *config.Config) *GrpcClient {
 
 		return &GrpcClient{
 			config:          agentConfig,
+			isConnected:     false,
+			instances:       []*v1.Instance{},
 			connectionMutex: sync.Mutex{},
+			instancesMutex:  sync.Mutex{},
 		}
 	}
 
@@ -161,6 +167,10 @@ func (gc *GrpcClient) Process(ctx context.Context, msg *bus.Message) {
 	switch msg.Topic {
 	case bus.InstancesTopic:
 		if newInstances, ok := msg.Data.([]*v1.Instance); ok {
+			gc.instancesMutex.Lock()
+			gc.instances = newInstances
+			gc.instancesMutex.Unlock()
+
 			err := gc.sendDataPlaneStatusUpdate(ctx, newInstances)
 			if err != nil {
 				slog.ErrorContext(ctx, "Unable to send data plane status update", "error", err)
@@ -168,6 +178,15 @@ func (gc *GrpcClient) Process(ctx context.Context, msg *bus.Message) {
 		}
 	case bus.GrpcConnectedTopic:
 		slog.DebugContext(ctx, "Agent connected")
+		gc.isConnected = true
+
+		gc.instancesMutex.Lock()
+		defer gc.instancesMutex.Unlock()
+
+		err := gc.sendDataPlaneStatusUpdate(ctx, gc.instances)
+		if err != nil {
+			slog.ErrorContext(ctx, "Unable to send data plane status update", "error", err)
+		}
 	default:
 		slog.DebugContext(ctx, "Unknown topic", "topic", msg.Topic)
 	}
@@ -184,6 +203,11 @@ func (gc *GrpcClient) sendDataPlaneStatusUpdate(
 	ctx context.Context,
 	instances []*v1.Instance,
 ) error {
+	if !gc.isConnected {
+		slog.DebugContext(ctx, "gRPC client not connected yet. Skipping sending data plane status update")
+		return nil
+	}
+
 	correlationID := logger.GetCorrelationID(ctx)
 
 	request := &v1.UpdateDataPlaneStatusRequest{
@@ -196,6 +220,10 @@ func (gc *GrpcClient) sendDataPlaneStatusUpdate(
 	}
 
 	slog.DebugContext(ctx, "Sending data plane status update request", "request", request)
+	if gc.commandServiceClient == nil {
+		return fmt.Errorf("command service client is not initialized")
+	}
+
 	_, err := gc.commandServiceClient.UpdateDataPlaneStatus(ctx, request)
 
 	return err

--- a/internal/plugin/grpc_client_plugin_test.go
+++ b/internal/plugin/grpc_client_plugin_test.go
@@ -182,7 +182,7 @@ func TestGrpcClient_Process_InstancesTopic(t *testing.T) {
 	fakeCommandServiceClient.UpdateDataPlaneStatusReturns(&v1.UpdateDataPlaneStatusResponse{}, nil)
 
 	client.commandServiceClient = fakeCommandServiceClient
-	client.isConnected = true
+	client.isConnected.Store(true)
 
 	mockMessage := &bus.Message{
 		Topic: bus.InstancesTopic,

--- a/internal/plugin/grpc_client_plugin_test.go
+++ b/internal/plugin/grpc_client_plugin_test.go
@@ -182,6 +182,7 @@ func TestGrpcClient_Process_InstancesTopic(t *testing.T) {
 	fakeCommandServiceClient.UpdateDataPlaneStatusReturns(&v1.UpdateDataPlaneStatusResponse{}, nil)
 
 	client.commandServiceClient = fakeCommandServiceClient
+	client.isConnected = true
 
 	mockMessage := &bus.Message{
 		Topic: bus.InstancesTopic,


### PR DESCRIPTION
### Proposed changes

Need to check that the gRPC client is connected before sending a data plane status update

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
