### PR TITLE
Update message pipe to initialise plugins before setting up subscriptions

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -36,7 +36,7 @@ func (a *App) Run(ctx context.Context) error {
 	config.RegisterRunner(func(_ *cobra.Command, _ []string) {
 		err := config.RegisterConfigFile()
 		if err != nil {
-			slog.Error("Failed to load configuration file", "error", err)
+			slog.ErrorContext(ctx, "Failed to load configuration file", "error", err)
 			return
 		}
 
@@ -48,9 +48,9 @@ func (a *App) Run(ctx context.Context) error {
 		slog.Info("Starting NGINX Agent")
 
 		messagePipe := bus.NewMessagePipe(defaultMessagePipeChannelSize)
-		err = messagePipe.Register(defaultQueueSize, plugin.LoadPlugins(agentConfig, slogger))
+		err = messagePipe.Register(ctx, defaultQueueSize, plugin.LoadPlugins(agentConfig, slogger))
 		if err != nil {
-			slog.Error("Failed to register plugins", "error", err)
+			slog.ErrorContext(ctx, "Failed to register plugins", "error", err)
 			return
 		}
 

--- a/internal/bus/fake_message_pipe.go
+++ b/internal/bus/fake_message_pipe.go
@@ -22,7 +22,7 @@ func NewFakeMessagePipe() *FakeMessagePipe {
 	return &FakeMessagePipe{}
 }
 
-func (p *FakeMessagePipe) Register(size int, plugins []Plugin) error {
+func (p *FakeMessagePipe) Register(ctx context.Context, size int, plugins []Plugin) error {
 	p.plugins = append(p.plugins, plugins...)
 	return nil
 }

--- a/internal/bus/message_pipe_test.go
+++ b/internal/bus/message_pipe_test.go
@@ -59,7 +59,7 @@ func TestMessagePipe(t *testing.T) {
 	pipelineDone := make(chan bool)
 
 	messagePipe := NewMessagePipe(100)
-	err := messagePipe.Register(10, []Plugin{plugin})
+	err := messagePipe.Register(ctx, 10, []Plugin{plugin})
 
 	require.NoError(t, err)
 
@@ -79,13 +79,14 @@ func TestMessagePipe(t *testing.T) {
 
 func TestMessagePipe_DeRegister(t *testing.T) {
 	plugin := new(testPlugin)
+	plugin.On("Init").Times(1)
 	plugin.On("Close").Times(1)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	messagePipe := NewMessagePipe(100)
-	err := messagePipe.Register(100, []Plugin{plugin})
+	err := messagePipe.Register(ctx, 100, []Plugin{plugin})
 
 	require.NoError(t, err)
 	assert.Len(t, messagePipe.GetPlugins(), 1)
@@ -106,7 +107,7 @@ func TestMessagePipe_IsPluginRegistered(t *testing.T) {
 	pipelineDone := make(chan bool)
 
 	messagePipe := NewMessagePipe(100)
-	err := messagePipe.Register(10, []Plugin{plugin})
+	err := messagePipe.Register(ctx, 10, []Plugin{plugin})
 
 	require.NoError(t, err)
 

--- a/internal/plugin/config_plugin_test.go
+++ b/internal/plugin/config_plugin_test.go
@@ -150,7 +150,7 @@ func TestConfig_Process(t *testing.T) {
 			messagePipe := bus.NewFakeMessagePipe()
 			configPlugin := NewConfig(&config.Config{})
 
-			err := messagePipe.Register(10, []bus.Plugin{configPlugin})
+			err := messagePipe.Register(ctx, 10, []bus.Plugin{configPlugin})
 			require.NoError(tt, err)
 			messagePipe.Run(ctx)
 
@@ -276,7 +276,7 @@ func TestConfig_Update(t *testing.T) {
 			messagePipe := bus.NewFakeMessagePipe()
 			configPlugin := NewConfig(&agentConfig)
 
-			err := messagePipe.Register(10, []bus.Plugin{configPlugin})
+			err := messagePipe.Register(ctx, 10, []bus.Plugin{configPlugin})
 			require.NoError(tt, err)
 			messagePipe.Run(ctx)
 

--- a/internal/plugin/data_plane_server_test.go
+++ b/internal/plugin/data_plane_server_test.go
@@ -32,7 +32,7 @@ func TestDataPlaneServer_Init(t *testing.T) {
 	dataPlaneServer := NewDataPlaneServer(agentConfig, slog.Default())
 
 	messagePipe := bus.NewMessagePipe(100)
-	err := messagePipe.Register(100, []bus.Plugin{dataPlaneServer})
+	err := messagePipe.Register(ctx, 100, []bus.Plugin{dataPlaneServer})
 	require.NoError(t, err)
 	go messagePipe.Run(ctx)
 
@@ -52,7 +52,7 @@ func TestDataPlaneServer_Process(t *testing.T) {
 
 	messagePipe := bus.NewMessagePipe(
 		100)
-	err := messagePipe.Register(100, []bus.Plugin{dataPlaneServer})
+	err := messagePipe.Register(ctx, 100, []bus.Plugin{dataPlaneServer})
 	require.NoError(t, err)
 	go messagePipe.Run(ctx)
 
@@ -125,7 +125,7 @@ func TestDataPlaneServer_GetInstances(t *testing.T) {
 	dataPlaneServer.instances = []*v1.Instance{instance}
 
 	messagePipe := bus.NewMessagePipe(100)
-	err := messagePipe.Register(100, []bus.Plugin{dataPlaneServer})
+	err := messagePipe.Register(ctx, 100, []bus.Plugin{dataPlaneServer})
 	require.NoError(t, err)
 	go messagePipe.Run(ctx)
 
@@ -176,7 +176,7 @@ func TestDataPlaneServer_UpdateInstanceConfiguration(t *testing.T) {
 	dataPlaneServer.instances = []*v1.Instance{instance}
 
 	messagePipe := bus.NewMessagePipe(100)
-	err := messagePipe.Register(100, []bus.Plugin{dataPlaneServer})
+	err := messagePipe.Register(ctx, 100, []bus.Plugin{dataPlaneServer})
 	require.NoError(t, err)
 	go messagePipe.Run(ctx)
 
@@ -316,7 +316,7 @@ func TestDataPlaneServer_GetInstanceConfigurationStatus(t *testing.T) {
 	dataPlaneServer.instances = []*v1.Instance{instance}
 
 	messagePipe := bus.NewMessagePipe(100)
-	err := messagePipe.Register(100, []bus.Plugin{dataPlaneServer})
+	err := messagePipe.Register(ctx, 100, []bus.Plugin{dataPlaneServer})
 	require.NoError(t, err)
 
 	go messagePipe.Run(ctx)

--- a/internal/plugin/instance_plugin_test.go
+++ b/internal/plugin/instance_plugin_test.go
@@ -47,7 +47,7 @@ func TestInstance_Process(t *testing.T) {
 	instanceMonitor.instanceService = fakeInstanceService
 
 	messagePipe := bus.NewFakeMessagePipe()
-	err := messagePipe.Register(100, []bus.Plugin{instanceMonitor})
+	err := messagePipe.Register(ctx, 100, []bus.Plugin{instanceMonitor})
 	require.NoError(t, err)
 
 	processesMessage := &bus.Message{Topic: bus.OsProcessesTopic, Data: []*model.Process{{Pid: 123, Name: "nginx"}}}
@@ -66,7 +66,7 @@ func TestInstance_Process_Error_Expected(t *testing.T) {
 	instanceMonitor := NewInstance()
 
 	messagePipe := bus.NewFakeMessagePipe()
-	err := messagePipe.Register(2, []bus.Plugin{instanceMonitor})
+	err := messagePipe.Register(ctx, 2, []bus.Plugin{instanceMonitor})
 	require.NoError(t, err)
 
 	messagePipe.Process(ctx, &bus.Message{Topic: bus.OsProcessesTopic, Data: nil})
@@ -86,7 +86,7 @@ func TestInstance_Process_Empty_Instances(t *testing.T) {
 	instanceMonitor := NewInstance()
 
 	messagePipe := bus.NewFakeMessagePipe()
-	err := messagePipe.Register(2, []bus.Plugin{instanceMonitor})
+	err := messagePipe.Register(ctx, 2, []bus.Plugin{instanceMonitor})
 	require.NoError(t, err)
 
 	processesMessage := &bus.Message{Topic: bus.OsProcessesTopic, Data: []*model.Process{}}

--- a/internal/plugin/metrics_plugin_test.go
+++ b/internal/plugin/metrics_plugin_test.go
@@ -40,7 +40,7 @@ func TestMetrics_Init(t *testing.T) {
 	metrics, err := NewMetrics(types.GetAgentConfig(), WithDataSource(scraper))
 	require.NoError(t, err)
 
-	err = messagePipe.Register(100, []bus.Plugin{metrics})
+	err = messagePipe.Register(ctx, 100, []bus.Plugin{metrics})
 	require.NoError(t, err)
 	go messagePipe.Run(ctx)
 

--- a/internal/plugin/process_monitor_plugin_test.go
+++ b/internal/plugin/process_monitor_plugin_test.go
@@ -29,7 +29,7 @@ func TestProcessMonitor_Init(t *testing.T) {
 	}
 
 	messagePipe := bus.NewMessagePipe(100)
-	err := messagePipe.Register(100, []bus.Plugin{processMonitor})
+	err := messagePipe.Register(ctx, 100, []bus.Plugin{processMonitor})
 	require.NoError(t, err)
 	go messagePipe.Run(ctx)
 


### PR DESCRIPTION
### Proposed changes

- Update message pipe to initialise plugins before setting up subscriptions
- Update gRPC plugin to stop storing instances in memory

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
