### PR TITLE
Fix NGINX Plus Instance, NGINX Version

### DIFF
--- a/internal/service/instance/nginx_instance_service.go
+++ b/internal/service/instance/nginx_instance_service.go
@@ -31,7 +31,6 @@ var (
 type Info struct {
 	ProcessID       int32
 	Version         string
-	PlusVersion     string
 	Prefix          string
 	ConfPath        string
 	ConfigureArgs   map[string]interface{}
@@ -132,7 +131,7 @@ func convertInfoToProcess(nginxInfo Info) *v1.Instance {
 	nginxType := v1.InstanceMeta_INSTANCE_TYPE_NGINX
 	version := nginxInfo.Version
 
-	if nginxInfo.PlusVersion == "" {
+	if !strings.Contains(nginxInfo.Version, "plus") {
 		instanceRuntime = &v1.InstanceRuntime{
 			ProcessId:  nginxInfo.ProcessID,
 			BinaryPath: nginxInfo.ExePath,
@@ -165,7 +164,7 @@ func convertInfoToProcess(nginxInfo Info) *v1.Instance {
 		}
 
 		nginxType = v1.InstanceMeta_INSTANCE_TYPE_NGINX_PLUS
-		version = nginxInfo.PlusVersion
+		version = nginxInfo.Version
 	}
 
 	return &v1.Instance{
@@ -190,7 +189,7 @@ func parseNginxVersionCommandOutput(ctx context.Context, output *bytes.Buffer) *
 		line := strings.TrimSpace(scanner.Text())
 		switch {
 		case strings.HasPrefix(line, "nginx version"):
-			nginxInfo.Version, nginxInfo.PlusVersion = parseNginxVersion(line)
+			nginxInfo.Version = parseNginxVersion(line)
 		case strings.HasPrefix(line, "configure arguments"):
 			nginxInfo.ConfigureArgs = parseConfigureArguments(line)
 		}
@@ -202,29 +201,15 @@ func parseNginxVersionCommandOutput(ctx context.Context, output *bytes.Buffer) *
 	return nginxInfo
 }
 
-func parseNginxVersion(line string) (version, plusVersion string) {
-	ossVersionMatches := ossVersionRegex.FindStringSubmatch(line)
-	plusVersionMatches := plusVersionRegex.FindStringSubmatch(line)
+func parseNginxVersion(line string) string {
+	ossVersionMatches := ossVersionRegex.FindString(line)
+	plusVersionMatches := plusVersionRegex.FindString(line)
 
-	ossSubNames := ossVersionRegex.SubexpNames()
-	plusSubNames := plusVersionRegex.SubexpNames()
-
-	for index, value := range ossVersionMatches {
-		if ossSubNames[index] == "version" {
-			version = value
-		}
+	if plusVersionMatches == "" {
+		return strings.TrimPrefix(ossVersionMatches, "nginx/")
 	}
 
-	for index, value := range plusVersionMatches {
-		switch plusSubNames[index] {
-		case "plus":
-			plusVersion = value
-		case "version":
-			version = value
-		}
-	}
-
-	return version, plusVersion
+	return strings.TrimPrefix(plusVersionMatches, "nginx/")
 }
 
 func parseConfigureArguments(line string) map[string]interface{} {

--- a/internal/service/instance/nginx_instance_service.go
+++ b/internal/service/instance/nginx_instance_service.go
@@ -23,10 +23,7 @@ import (
 	"github.com/nginx/agent/v3/internal/uuid"
 )
 
-var (
-	ossVersionRegex  = regexp.MustCompile(`(?P<name>\S+)/(?P<version>\S+)`)
-	plusVersionRegex = regexp.MustCompile(`(?P<name>\S+)/(?P<version>\S+).\((?P<plus>\S+plus\S+)\)`)
-)
+var versionRegex = regexp.MustCompile(`(?P<name>\S+)\/(?P<version>.*)`)
 
 type Info struct {
 	ProcessID       int32
@@ -202,14 +199,7 @@ func parseNginxVersionCommandOutput(ctx context.Context, output *bytes.Buffer) *
 }
 
 func parseNginxVersion(line string) string {
-	ossVersionMatches := ossVersionRegex.FindString(line)
-	plusVersionMatches := plusVersionRegex.FindString(line)
-
-	if plusVersionMatches == "" {
-		return strings.TrimPrefix(ossVersionMatches, "nginx/")
-	}
-
-	return strings.TrimPrefix(plusVersionMatches, "nginx/")
+	return strings.TrimPrefix(versionRegex.FindString(line), "nginx/")
 }
 
 func parseConfigureArguments(line string) map[string]interface{} {

--- a/internal/service/instance/nginx_instance_service_test.go
+++ b/internal/service/instance/nginx_instance_service_test.go
@@ -214,11 +214,10 @@ func TestGetInfo(t *testing.T) {
 				Exe: exePath,
 			},
 			expected: &Info{
-				Version:     "1.25.3",
-				PlusVersion: "",
-				Prefix:      "/usr/local/Cellar/nginx/1.25.3",
-				ConfPath:    "/usr/local/etc/nginx/nginx.conf",
-				ExePath:     exePath,
+				Version:  "1.25.3",
+				Prefix:   "/usr/local/Cellar/nginx/1.25.3",
+				ConfPath: "/usr/local/etc/nginx/nginx.conf",
+				ExePath:  exePath,
 				ConfigureArgs: map[string]interface{}{
 					"conf-path":                  "/usr/local/etc/nginx/nginx.conf",
 					"error-log-path":             "/usr/local/var/log/nginx/error.log",
@@ -281,11 +280,10 @@ func TestGetInfo(t *testing.T) {
 				Exe: exePath,
 			},
 			expected: &Info{
-				Version:     "1.25.3",
-				PlusVersion: "nginx-plus-r31-p1",
-				Prefix:      "/etc/nginx",
-				ConfPath:    "/etc/nginx/nginx.conf",
-				ExePath:     exePath,
+				Version:  "1.25.3 (nginx-plus-r31-p1)",
+				Prefix:   "/etc/nginx",
+				ConfPath: "/etc/nginx/nginx.conf",
+				ExePath:  exePath,
 				ConfigureArgs: map[string]interface{}{
 					"build":                                  "nginx-plus-r31-p1",
 					"conf-path":                              "/etc/nginx/nginx.conf",

--- a/test/protos/instances.go
+++ b/test/protos/instances.go
@@ -56,7 +56,7 @@ func GetNginxPlusInstance(expectedModules []string) *v1.Instance {
 		InstanceMeta: &v1.InstanceMeta{
 			InstanceId:   plusInstanceID,
 			InstanceType: v1.InstanceMeta_INSTANCE_TYPE_NGINX_PLUS,
-			Version:      "nginx-plus-r31-p1",
+			Version:      "1.25.3 (nginx-plus-r31-p1)",
 		},
 		InstanceRuntime: &v1.InstanceRuntime{
 			ProcessId:  processID,


### PR DESCRIPTION
### Proposed changes

The version sent for a NGINX Plus Instance currently in the instance meta looks like `version: nginx-plus-r30-p2` when it should also contain the NGINX version `1.25.3 (nginx-plus-r31-p1)`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
