### PR TITLE
Increase plugin test coverage

### DIFF
--- a/internal/plugin/grpc_client_plugin_test.go
+++ b/internal/plugin/grpc_client_plugin_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	v1 "github.com/nginx/agent/v3/api/grpc/mpi/v1"
+
 	"github.com/nginx/agent/v3/test/helpers"
 	"github.com/nginx/agent/v3/test/protos"
 
@@ -153,6 +155,55 @@ func TestGrpcClient_Process_ResourceTopic(t *testing.T) {
 	client.Process(ctx, mockMessage)
 
 	assert.True(t, client.isConnected.Load())
+}
+
+func TestGrpcClient_ProcessRequest(t *testing.T) {
+	ctx := context.Background()
+
+	agentConfig := types.GetAgentConfig()
+	client := NewGrpcClient(agentConfig)
+	pipe := &bus.FakeMessagePipe{}
+	client.messagePipe = pipe
+	assert.NotNil(t, client)
+
+	tests := []struct {
+		name     string
+		request  *v1.ManagementPlaneRequest
+		expected *bus.Message
+	}{
+		{
+			name: "Test 1: Config Apply Request",
+			request: &v1.ManagementPlaneRequest{
+				Request: &v1.ManagementPlaneRequest_ConfigApplyRequest{
+					ConfigApplyRequest: &v1.ConfigApplyRequest{
+						ConfigVersion: protos.CreateConfigVersion(),
+					},
+				},
+			},
+			expected: &bus.Message{
+				Topic: bus.InstanceConfigUpdateRequestTopic,
+				Data: &v1.ManagementPlaneRequest_ConfigApplyRequest{
+					ConfigApplyRequest: &v1.ConfigApplyRequest{
+						ConfigVersion: protos.CreateConfigVersion(),
+					},
+				},
+			},
+		},
+		{
+			name: "Test 2: Invalid Request",
+			request: &v1.ManagementPlaneRequest{
+				Request: &v1.ManagementPlaneRequest_ActionRequest{},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			client.ProcessRequest(ctx, test.request)
+			pipe.GetMessages()
+		})
+	}
 }
 
 func TestGrpcClient_Close(t *testing.T) {

--- a/internal/plugin/grpc_client_plugin_test.go
+++ b/internal/plugin/grpc_client_plugin_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	v1 "github.com/nginx/agent/v3/api/grpc/mpi/v1"
+	"github.com/nginx/agent/v3/api/grpc/mpi/v1"
 
 	"github.com/nginx/agent/v3/test/helpers"
 	"github.com/nginx/agent/v3/test/protos"


### PR DESCRIPTION
### Proposed changes

Increasing plugin test coverage as a fix for the coverage failing randomly by a few percent 
Added ProcessRequest unit test 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
