### PR TITLE
Change environment variable list to table with CLI references

### DIFF
--- a/site/content/configuration/configuration-overview.md
+++ b/site/content/configuration/configuration-overview.md
@@ -215,42 +215,42 @@ Default location in FreeBSD environments: `/var/db/nginx-agent/agent-dynamic.con
 
 ### NGINX Agent Environment Variables
 
-This section displays the configurable options for NGINX Agent that can be set with environment variables. A list of the configurable environment variables can be seen below:
+This section displays the configurable options for NGINX Agent that can be set with environment variables. Each environment variable maps to a CLI flag, [explained above](#nginx-agent-cli-flags-usage).
 
-<details open>
-  <summary>NGINX Agent Environment Variables</summary>
+{{<bootstrap-table "table table-striped table-bordered">}}
 
-```text
-- NMS_INSTANCE_GROUP
-- NMS_DISPLAY_NAME
-- NMS_FEATURES
-- NMS_LOG_LEVEL
-- NMS_LOG_PATH
-- NMS_PATH
-- NMS_METRICS_COLLECTION_INTERVAL
-- NMS_METRICS_MODE
-- NMS_METRICS_BULK_SIZE
-- NMS_METRICS_REPORT_INTERVAL
-- NMS_NGINX_EXCLUDE_LOGS
-- NMS_NGINX_SOCKET
-- NMS_NGINX_TREAT_WARNINGS_AS_ERRORS
-- NMS_SERVER_GRPCPORT
-- NMS_SERVER_HOST
-- NMS_SERVER_TOKEN
-- NMS_SERVER_COMMAND
-- NMS_SERVER_METRICS
-- NMS_TAGS
-- NMS_TLS_CA
-- NMS_TLS_CERT
-- NMS_TLS_ENABLE
-- NMS_TLS_KEY
-- NMS_TLS_SKIP_VERIFY
-- NMS_CONFIG_DIRS
-- NMS_QUEUE_SIZE
-- NMS_DATAPLANE_REPORT_INTERVAL
-- NMS_DATAPLANE_STATUS_POLL_INTERVAL
-```
-</details>
+| Environment variable                 | CLI flag                                 |
+| ------------------------------------ | ---------------------------------------- |
+| *NMS_CONFIG_DIRS*                    | *--config-dirs*                          |
+| *NMS_DATAPLANE_REPORT_INTERVAL*      | *--dataplane-report-interval*            |
+| *NMS_DATAPLANE_STATUS_POLL_INTERVAL* | *--dataplane-status-poll-interval*       |
+| *NMS_DISPLAY_NAME*                   | *--display-name*                         |  
+| *NMS_FEATURES*                       | *--features*                             |
+| *NMS_INSTANCE_GROUP*                 | *--instance-group*                       |
+| *NMS_LOG_LEVEL*                      | *--log-level*                            |
+| *NMS_LOG_PATH*                       | *--log-path*                             |
+| *NMS_PATH*                           | N/A, defines path for `nginx-agent.conf` |
+| *NMS_METRICS_COLLECTION_INTERVAL*    | *--metrics-collection-interval*          |
+| *NMS_METRICS_MODE*                   | *--metrics-mode*                         |
+| *NMS_METRICS_BULK_SIZE*              | *--metrics-bulk-size*                    |
+| *NMS_METRICS_REPORT_INTERVAL*        | *--metrics-report-interval*              |
+| *NMS_NGINX_EXCLUDE_LOGS*             | *--nginx-exclude-log*                    |
+| *NMS_NGINX_SOCKET*                   | *--nginx-socket*                         |
+| *NMS_NGINX_TREAT_WARNINGS_AS_ERRORS* | *--nginx-treat-warnings-as-errors*       |
+| *NMS_QUEUE_SIZE*                     | *--queue-size*                           |
+| *NMS_SERVER_GRPCPORT*                | *--server-grpcport*                      |
+| *NMS_SERVER_HOST*                    | *--server-host*                          |
+| *NMS_SERVER_TOKEN*                   | *--server-token*                         |
+| *NMS_SERVER_COMMAND*                 | *--server-command*                       |
+| *NMS_SERVER_METRICS*                 | *--server-metrics*                       |
+| *NMS_TAGS*                           | *--tags*                                 |
+| *NMS_TLS_CA*                         | *--tls-ca*                               |
+| *NMS_TLS_CERT*                       | *--tls-cert*                             |
+| *NMS_TLS_ENABLE*                     | *--tls-enable*                           |
+| *NMS_TLS_KEY*                        | *--tls-key*                              |
+| *NMS_TLS_SKIP_VERIFY*                | *--tls-skip-verify*                      |
+
+{{</bootstrap-table>}}
 
 ### NGINX Agent Log Rotation
 

--- a/site/content/installation-upgrade/container-environments/docker-images.md
+++ b/site/content/installation-upgrade/container-environments/docker-images.md
@@ -170,7 +170,7 @@ docker run --name nginx-agent -d nginx-agent
 To connect your NGINX Agent container to your NGINX One or NGINX Instance Manager instance, you must enable the gRPC interface. To do this, you must edit the NGINX Agent configuration file, *nginx-agent.conf*. For example:
 
 ```yaml
-erver:
+server:
   host: 127.0.0.1 # mock control plane host
   grpcPort: 54789 # mock control plane gRPC port
 


### PR DESCRIPTION
### Proposed changes

This commit changes the list of NGINX Agent variables to a table showing how it maps to the CLI flags, with an exception for the variable that doesn't have a flag yet. It links to the CLI flag section so that the reader can view the descriptions for additional context.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
