### PR TITLE
Only send a resource update message if instances other than the agent instance are found

### DIFF
--- a/internal/plugin/grpc_client_plugin.go
+++ b/internal/plugin/grpc_client_plugin.go
@@ -212,6 +212,11 @@ func (gc *GrpcClient) Process(ctx context.Context, msg *bus.Message) {
 	switch msg.Topic {
 	case bus.ResourceUpdateTopic:
 		if resource, ok := msg.Data.(*v1.Resource); ok {
+			// Only send a resource update message if instances other than the agent instance are found
+			if len(resource.GetInstances()) <= 1 {
+				return
+			}
+
 			err := gc.createConnection(ctx, resource)
 			if err != nil {
 				return

--- a/internal/resource/resource_service_test.go
+++ b/internal/resource/resource_service_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/nginx/agent/v3/api/grpc/mpi/v1"
 	"github.com/nginx/agent/v3/test/protos"
+	"github.com/nginx/agent/v3/test/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,6 +28,7 @@ func TestResourceService_AddInstance(t *testing.T) {
 		{
 			name: "Test 1: Add One Instance",
 			instanceList: []*v1.Instance{
+				protos.GetAgentInstance(1, types.GetAgentConfig()),
 				protos.GetNginxOssInstance([]string{}),
 			},
 			resource: protos.GetHostResource(),
@@ -34,12 +36,14 @@ func TestResourceService_AddInstance(t *testing.T) {
 		{
 			name: "Test 2: Add Multiple Instance",
 			instanceList: []*v1.Instance{
+				protos.GetAgentInstance(1, types.GetAgentConfig()),
 				protos.GetNginxOssInstance([]string{}),
 				protos.GetNginxPlusInstance([]string{}),
 			},
 			resource: &v1.Resource{
 				ResourceId: protos.GetHostResource().GetResourceId(),
 				Instances: []*v1.Instance{
+					protos.GetAgentInstance(1, types.GetAgentConfig()),
 					protos.GetNginxOssInstance([]string{}),
 					protos.GetNginxPlusInstance([]string{}),
 				},

--- a/internal/watcher/instance_watcher_service.go
+++ b/internal/watcher/instance_watcher_service.go
@@ -135,7 +135,11 @@ func (iw *InstanceWatcherService) checkForUpdates(
 		}
 	}
 
-	if len(instanceUpdates.newInstances) > 0 || len(instanceUpdates.deletedInstances) > 0 {
+	numberOfChanges := len(instanceUpdates.newInstances) +
+		len(instanceUpdates.updatedInstances) +
+		len(instanceUpdates.deletedInstances)
+
+	if numberOfChanges > 0 {
 		instancesChannel <- InstanceUpdatesMessage{
 			correlationID:   correlationID,
 			instanceUpdates: instanceUpdates,

--- a/test/protos/resource.go
+++ b/test/protos/resource.go
@@ -5,7 +5,10 @@
 
 package protos
 
-import "github.com/nginx/agent/v3/api/grpc/mpi/v1"
+import (
+	"github.com/nginx/agent/v3/api/grpc/mpi/v1"
+	"github.com/nginx/agent/v3/test/types"
+)
 
 func GetContainerizedResource() *v1.Resource {
 	return &v1.Resource{
@@ -23,6 +26,7 @@ func GetHostResource() *v1.Resource {
 	return &v1.Resource{
 		ResourceId: GetHostInfo().GetHostId(),
 		Instances: []*v1.Instance{
+			GetAgentInstance(1, types.GetAgentConfig()),
 			GetNginxOssInstance([]string{}),
 		},
 		Info: &v1.Resource_HostInfo{


### PR DESCRIPTION
### Proposed changes

This stops a createConnection message from being sent to the management plane if no NGINX instances are found.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
