### PR TITLE
chore: specify toolchain version in sdk go.mod

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -2,6 +2,8 @@ module github.com/nginx/agent/sdk/v2
 
 go 1.21
 
+toolchain go1.21.6
+
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/gogo/protobuf v1.3.2


### PR DESCRIPTION
### Proposed changes

Added the `toolchain go1.21.6` directive to the `go.mod` file to ensure consistent use of the Go 1.21.6 toolchain

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
