### PR TITLE
Change environment prefix from nms to nginx_agent

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,6 +59,10 @@ func main() {
 			defer logFile.Close()
 		}
 
+		if config.MigratedEnv {
+			log.Warnf("The environment variable prefix 'NMS' is deprecated. Prefix has been migrated to 'NGINX_AGENT'. Please update your configuration to use the new prefix.")
+		}
+
 		log.Tracef("Config loaded from disk, %v", loadedConfig)
 
 		if loadedConfig.DisplayName == "" {

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -153,8 +153,8 @@ func RegisterFlags() {
 			return
 		}
 
-		oldKey := strings.ToUpper(fmt.Sprintf("%s%s%s", LegacyEnvPrefix, agent_config.KeyDelimiter, strings.ReplaceAll(flag.Name, "-", "_")))
-		newKey := strings.ToUpper(fmt.Sprintf("%s%s%s", EnvPrefix, agent_config.KeyDelimiter, strings.ReplaceAll(flag.Name, "-", "_")))
+		oldKey := strings.ToUpper(LegacyEnvPrefix + agent_config.KeyDelimiter + strings.ReplaceAll(flag.Name, "-", agent_config.KeyDelimiter))
+		newKey := strings.ToUpper(EnvPrefix + agent_config.KeyDelimiter + strings.ReplaceAll(flag.Name, "-", agent_config.KeyDelimiter))
 
 		if os.Getenv(oldKey) != "" && os.Getenv(newKey) == "" {
 			if err := os.Setenv(newKey, os.Getenv(oldKey)); err != nil {

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -136,7 +136,7 @@ func deprecateFlags() {
 }
 
 func RegisterFlags() {
-	Viper.SetEnvPrefix(NewEnvPrefix)
+	Viper.SetEnvPrefix(EnvPrefix)
 	Viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	Viper.AutomaticEnv()
 
@@ -153,8 +153,8 @@ func RegisterFlags() {
 			return
 		}
 
-		oldKey := strings.ToUpper(OldEnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
-		newKey := strings.ToUpper(NewEnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
+		oldKey := strings.ToUpper(LegacyEnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
+		newKey := strings.ToUpper(EnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
 
 		if os.Getenv(oldKey) != "" && os.Getenv(newKey) == "" {
 			if err := os.Setenv(newKey, os.Getenv(oldKey)); err != nil {

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -153,8 +153,8 @@ func RegisterFlags() {
 			return
 		}
 
-		oldKey := strings.ToUpper(LegacyEnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
-		newKey := strings.ToUpper(EnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
+		oldKey := strings.ToUpper(fmt.Sprintf("%s%s%s", LegacyEnvPrefix, agent_config.KeyDelimiter, strings.ReplaceAll(flag.Name, "-", "_")))
+		newKey := strings.ToUpper(fmt.Sprintf("%s%s%s", EnvPrefix, agent_config.KeyDelimiter, strings.ReplaceAll(flag.Name, "-", "_")))
 
 		if os.Getenv(oldKey) != "" && os.Getenv(newKey) == "" {
 			if err := os.Setenv(newKey, os.Getenv(oldKey)); err != nil {

--- a/src/core/config/config_test.go
+++ b/src/core/config/config_test.go
@@ -480,7 +480,7 @@ func TestUpdateAgentConfig(t *testing.T) {
 }
 
 func setEnvVariable(t *testing.T, name string, value string) {
-	key := strings.ToUpper(EnvPrefix + agent_config.KeyDelimiter + name)
+	key := strings.ToUpper(NewEnvPrefix + agent_config.KeyDelimiter + name)
 	err := os.Setenv(key, value)
 	require.NoError(t, err)
 }

--- a/src/core/config/config_test.go
+++ b/src/core/config/config_test.go
@@ -480,7 +480,7 @@ func TestUpdateAgentConfig(t *testing.T) {
 }
 
 func setEnvVariable(t *testing.T, name string, value string) {
-	key := strings.ToUpper(NewEnvPrefix + agent_config.KeyDelimiter + name)
+	key := strings.ToUpper(EnvPrefix + agent_config.KeyDelimiter + name)
 	err := os.Setenv(key, value)
 	require.NoError(t, err)
 }

--- a/src/core/config/config_test.go
+++ b/src/core/config/config_test.go
@@ -479,6 +479,18 @@ func TestUpdateAgentConfig(t *testing.T) {
 	}
 }
 
+func TestDeprecatedEnvPrefixMigration(t *testing.T){
+	want := true
+	
+	t.Setenv("NMS_TLS_SKIP_VERIFY","true")
+
+	SetDefaults()
+	RegisterFlags()
+
+	got := MigratedEnv
+	assert.Equal(t, want, got)
+} 
+
 func setEnvVariable(t *testing.T, name string, value string) {
 	key := strings.ToUpper(EnvPrefix + agent_config.KeyDelimiter + name)
 	err := os.Setenv(key, value)

--- a/src/core/config/config_test.go
+++ b/src/core/config/config_test.go
@@ -479,17 +479,17 @@ func TestUpdateAgentConfig(t *testing.T) {
 	}
 }
 
-func TestDeprecatedEnvPrefixMigration(t *testing.T){
+func TestDeprecatedEnvPrefixMigration(t *testing.T) {
 	want := true
-	
-	t.Setenv("NMS_TLS_SKIP_VERIFY","true")
+
+	t.Setenv("NMS_TLS_SKIP_VERIFY", "true")
 
 	SetDefaults()
 	RegisterFlags()
 
 	got := MigratedEnv
 	assert.Equal(t, want, got)
-} 
+}
 
 func setEnvVariable(t *testing.T, name string, value string) {
 	key := strings.ToUpper(EnvPrefix + agent_config.KeyDelimiter + name)

--- a/src/core/config/defaults.go
+++ b/src/core/config/defaults.go
@@ -103,7 +103,8 @@ const (
 	DynamicConfigFileAbsFreeBsdPath = "/var/db/nginx-agent/agent-dynamic.conf"
 	ConfigFileName                  = "nginx-agent.conf"
 	ConfigFileType                  = "yaml"
-	EnvPrefix                       = "nms"
+	OldEnvPrefix                    = "nms"
+	NewEnvPrefix                    = "nginx_agent"
 	ConfigPathKey                   = "path"
 	DynamicConfigPathKey            = "dynamic_config_path"
 

--- a/src/core/config/defaults.go
+++ b/src/core/config/defaults.go
@@ -103,8 +103,8 @@ const (
 	DynamicConfigFileAbsFreeBsdPath = "/var/db/nginx-agent/agent-dynamic.conf"
 	ConfigFileName                  = "nginx-agent.conf"
 	ConfigFileType                  = "yaml"
-	OldEnvPrefix                    = "nms"
-	NewEnvPrefix                    = "nginx_agent"
+	LegacyEnvPrefix                 = "nms"
+	EnvPrefix                       = "nginx_agent"
 	ConfigPathKey                   = "path"
 	DynamicConfigPathKey            = "dynamic_config_path"
 

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/config/config.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/config/config.go
@@ -153,8 +153,8 @@ func RegisterFlags() {
 			return
 		}
 
-		oldKey := strings.ToUpper(fmt.Sprintf("%s%s%s", LegacyEnvPrefix, agent_config.KeyDelimiter, strings.ReplaceAll(flag.Name, "-", "_")))
-		newKey := strings.ToUpper(fmt.Sprintf("%s%s%s", EnvPrefix, agent_config.KeyDelimiter, strings.ReplaceAll(flag.Name, "-", "_")))
+		oldKey := strings.ToUpper(LegacyEnvPrefix + agent_config.KeyDelimiter + strings.ReplaceAll(flag.Name, "-", agent_config.KeyDelimiter))
+		newKey := strings.ToUpper(EnvPrefix + agent_config.KeyDelimiter + strings.ReplaceAll(flag.Name, "-", agent_config.KeyDelimiter))
 
 		if os.Getenv(oldKey) != "" && os.Getenv(newKey) == "" {
 			if err := os.Setenv(newKey, os.Getenv(oldKey)); err != nil {

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/config/config.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/config/config.go
@@ -136,7 +136,7 @@ func deprecateFlags() {
 }
 
 func RegisterFlags() {
-	Viper.SetEnvPrefix(NewEnvPrefix)
+	Viper.SetEnvPrefix(EnvPrefix)
 	Viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	Viper.AutomaticEnv()
 
@@ -153,8 +153,8 @@ func RegisterFlags() {
 			return
 		}
 
-		oldKey := strings.ToUpper(OldEnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
-		newKey := strings.ToUpper(NewEnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
+		oldKey := strings.ToUpper(LegacyEnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
+		newKey := strings.ToUpper(EnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
 
 		if os.Getenv(oldKey) != "" && os.Getenv(newKey) == "" {
 			if err := os.Setenv(newKey, os.Getenv(oldKey)); err != nil {

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/config/config.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/config/config.go
@@ -153,8 +153,8 @@ func RegisterFlags() {
 			return
 		}
 
-		oldKey := strings.ToUpper(LegacyEnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
-		newKey := strings.ToUpper(EnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
+		oldKey := strings.ToUpper(fmt.Sprintf("%s%s%s", LegacyEnvPrefix, agent_config.KeyDelimiter, strings.ReplaceAll(flag.Name, "-", "_")))
+		newKey := strings.ToUpper(fmt.Sprintf("%s%s%s", EnvPrefix, agent_config.KeyDelimiter, strings.ReplaceAll(flag.Name, "-", "_")))
 
 		if os.Getenv(oldKey) != "" && os.Getenv(newKey) == "" {
 			if err := os.Setenv(newKey, os.Getenv(oldKey)); err != nil {

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/config/defaults.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/config/defaults.go
@@ -103,7 +103,8 @@ const (
 	DynamicConfigFileAbsFreeBsdPath = "/var/db/nginx-agent/agent-dynamic.conf"
 	ConfigFileName                  = "nginx-agent.conf"
 	ConfigFileType                  = "yaml"
-	EnvPrefix                       = "nms"
+	OldEnvPrefix                    = "nms"
+	NewEnvPrefix                    = "nginx_agent"
 	ConfigPathKey                   = "path"
 	DynamicConfigPathKey            = "dynamic_config_path"
 

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/config/defaults.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/config/defaults.go
@@ -103,8 +103,8 @@ const (
 	DynamicConfigFileAbsFreeBsdPath = "/var/db/nginx-agent/agent-dynamic.conf"
 	ConfigFileName                  = "nginx-agent.conf"
 	ConfigFileType                  = "yaml"
-	OldEnvPrefix                    = "nms"
-	NewEnvPrefix                    = "nginx_agent"
+	LegacyEnvPrefix                 = "nms"
+	EnvPrefix                       = "nginx_agent"
 	ConfigPathKey                   = "path"
 	DynamicConfigPathKey            = "dynamic_config_path"
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/config.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/config.go
@@ -153,8 +153,8 @@ func RegisterFlags() {
 			return
 		}
 
-		oldKey := strings.ToUpper(fmt.Sprintf("%s%s%s", LegacyEnvPrefix, agent_config.KeyDelimiter, strings.ReplaceAll(flag.Name, "-", "_")))
-		newKey := strings.ToUpper(fmt.Sprintf("%s%s%s", EnvPrefix, agent_config.KeyDelimiter, strings.ReplaceAll(flag.Name, "-", "_")))
+		oldKey := strings.ToUpper(LegacyEnvPrefix + agent_config.KeyDelimiter + strings.ReplaceAll(flag.Name, "-", agent_config.KeyDelimiter))
+		newKey := strings.ToUpper(EnvPrefix + agent_config.KeyDelimiter + strings.ReplaceAll(flag.Name, "-", agent_config.KeyDelimiter))
 
 		if os.Getenv(oldKey) != "" && os.Getenv(newKey) == "" {
 			if err := os.Setenv(newKey, os.Getenv(oldKey)); err != nil {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/config.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/config.go
@@ -136,7 +136,7 @@ func deprecateFlags() {
 }
 
 func RegisterFlags() {
-	Viper.SetEnvPrefix(NewEnvPrefix)
+	Viper.SetEnvPrefix(EnvPrefix)
 	Viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	Viper.AutomaticEnv()
 
@@ -153,8 +153,8 @@ func RegisterFlags() {
 			return
 		}
 
-		oldKey := strings.ToUpper(OldEnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
-		newKey := strings.ToUpper(NewEnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
+		oldKey := strings.ToUpper(LegacyEnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
+		newKey := strings.ToUpper(EnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
 
 		if os.Getenv(oldKey) != "" && os.Getenv(newKey) == "" {
 			if err := os.Setenv(newKey, os.Getenv(oldKey)); err != nil {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/config.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/config.go
@@ -153,8 +153,8 @@ func RegisterFlags() {
 			return
 		}
 
-		oldKey := strings.ToUpper(LegacyEnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
-		newKey := strings.ToUpper(EnvPrefix + "_" + strings.ReplaceAll(flag.Name, "-", "_"))
+		oldKey := strings.ToUpper(fmt.Sprintf("%s%s%s", LegacyEnvPrefix, agent_config.KeyDelimiter, strings.ReplaceAll(flag.Name, "-", "_")))
+		newKey := strings.ToUpper(fmt.Sprintf("%s%s%s", EnvPrefix, agent_config.KeyDelimiter, strings.ReplaceAll(flag.Name, "-", "_")))
 
 		if os.Getenv(oldKey) != "" && os.Getenv(newKey) == "" {
 			if err := os.Setenv(newKey, os.Getenv(oldKey)); err != nil {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/defaults.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/defaults.go
@@ -103,7 +103,8 @@ const (
 	DynamicConfigFileAbsFreeBsdPath = "/var/db/nginx-agent/agent-dynamic.conf"
 	ConfigFileName                  = "nginx-agent.conf"
 	ConfigFileType                  = "yaml"
-	EnvPrefix                       = "nms"
+	OldEnvPrefix                    = "nms"
+	NewEnvPrefix                    = "nginx_agent"
 	ConfigPathKey                   = "path"
 	DynamicConfigPathKey            = "dynamic_config_path"
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/defaults.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/config/defaults.go
@@ -103,8 +103,8 @@ const (
 	DynamicConfigFileAbsFreeBsdPath = "/var/db/nginx-agent/agent-dynamic.conf"
 	ConfigFileName                  = "nginx-agent.conf"
 	ConfigFileType                  = "yaml"
-	OldEnvPrefix                    = "nms"
-	NewEnvPrefix                    = "nginx_agent"
+	LegacyEnvPrefix                 = "nms"
+	EnvPrefix                       = "nginx_agent"
 	ConfigPathKey                   = "path"
 	DynamicConfigPathKey            = "dynamic_config_path"
 


### PR DESCRIPTION
### Proposed changes

Agent now uses NGINX_AGENT as its environment prefix as opposed to NMS. If the old prefix is used, Agent migrates the value to the correct key and a message is logged warning the user to switch to the new prefix

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
