### PR TITLE
Handle errors correctly when NGINX config can't be parsed

### DIFF
--- a/internal/watcher/instance/nginx_config_parser.go
+++ b/internal/watcher/instance/nginx_config_parser.go
@@ -64,13 +64,7 @@ func (ncp *NginxConfigParser) Parse(ctx context.Context, instance *mpi.Instance)
 		},
 	)
 	if err != nil {
-		slog.ErrorContext(
-			ctx,
-			"Parsing instance config",
-			"config_path", instance.GetInstanceRuntime().GetConfigPath(),
-			"instance_id", instance.GetInstanceMeta().GetInstanceId(),
-			"error", err,
-		)
+		return nil, err
 	}
 
 	return ncp.createNginxConfigContext(ctx, instance, payload)


### PR DESCRIPTION
### Proposed changes

Handle errors correctly when NGINX config can't be parsed

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
