### PR TITLE
More flexible container images for the official images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,17 @@ official-oss-image: ## Build official NGINX OSS with NGINX Agent container image
 	@echo Building image nginx-oss-with-nginx-agent with $(CONTAINER_CLITOOL); \
 	cd scripts/docker/official/nginx-oss-with-nginx-agent/alpine/ \
 	&& $(CONTAINER_BUILDENV) $(CONTAINER_CLITOOL) build -t nginx-oss-with-nginx-agent . \
+	    --build-arg NGINX_AGENT_VERSION=$(shell echo ${VERSION} | tr -d 'v') \
 		--no-cache -f ./Dockerfile.mainline
+
+official-oss-stable-image: ## Build official NGINX OSS with NGINX Agent container stable image
+	@echo Building image nginx-oss-with-nginx-agent with $(CONTAINER_CLITOOL); \
+	cd scripts/docker/official/nginx-oss-with-nginx-agent/alpine/ \
+	&& $(CONTAINER_BUILDENV) $(CONTAINER_CLITOOL) build -t nginx-oss-with-nginx-agent . \
+	    --build-arg NGINX_AGENT_VERSION=$(shell echo ${VERSION} | tr -d 'v') \
+		--no-cache -f ./Dockerfile.stable
+
+official-oss-mainline-image: official-oss-image ## Build official NGINX OSS with NGINX Agent container mainline image
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Grafana Example Dashboard Targets                                                                               #

--- a/README.md
+++ b/README.md
@@ -163,9 +163,16 @@ If you need to make changes to the default configuration you can update the file
 For more detail on logrotate configuration see [Logrotate Configuration Options](https://linux.die.net/man/8/logrotate)
 
 ## Building Docker Image
-To build an image that contains the latest NGINX Agent and the latest mainline version of NGINX OSS run the following command:
-```
+To build an image that contains the latest NGINX Agent, the latest mainline version of NGINX OSS on latest Alpine run the following command:
+
+```make
 make official-oss-image
+```
+
+To build an image that contains the latest NGINX Agent, the latest stable version of NGINX OSS on latest Alpine run the following command:
+
+```make
+make official-oss-stable-image
 ```
 
 For more information on how to run NGINX Agent containers and how build an image that uses NGINX Plus instead of NGINX OSS see [Docker Images](https://docs.nginx.com/nginx-agent/installation-upgrade/container-environments/docker-images/)

--- a/scripts/docker/official/nginx-oss-with-nginx-agent/alpine/Dockerfile.mainline
+++ b/scripts/docker/official/nginx-oss-with-nginx-agent/alpine/Dockerfile.mainline
@@ -1,9 +1,9 @@
-ARG NGINX_VERSION=1.25.1-alpine
+ARG NGINX_VERSION=mainline-alpine-slim
 
 FROM nginx:${NGINX_VERSION}
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ARG NGINX_AGENT_VERSION=2.27.0
+ARG NGINX_AGENT_VERSION
 
 # Unlink symbolic links for access and error logs as the NGINX Agent 
 # requires both files to be able to monitor NGINX and provide metrics.

--- a/scripts/docker/official/nginx-oss-with-nginx-agent/alpine/Dockerfile.stable
+++ b/scripts/docker/official/nginx-oss-with-nginx-agent/alpine/Dockerfile.stable
@@ -1,9 +1,9 @@
-ARG NGINX_VERSION=1.24.0-alpine
+ARG NGINX_VERSION=stable-alpine-slim
 
 FROM nginx:${NGINX_VERSION}
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ARG NGINX_AGENT_VERSION=2.27.0
+ARG NGINX_AGENT_VERSION
 
 # Unlink symbolic links for access and error logs as the NGINX Agent 
 # requires both files to be able to monitor NGINX and provide metrics.


### PR DESCRIPTION
### Proposed changes

* Added build args `NGINX_AGENT_VERSION` to take different Agent versions in the official docker images.
* Added new make target to run stable images `make official-oss-stable-image` and aliased `make official-oss-image` with `make official-oss-mainline-image`
* Updated base images to use slim images

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
