### PR TITLE
Fix Post Install Script Issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,6 @@ jobs:
               --account-name ${{ secrets.AZURE_ACCOUNT_NAME }} --overwrite -n nginx-agent/${GIT_BRANCH}/${i##*/}
             done
 
-
   build-example:
     name: Build Grafana Dashboard Example
     runs-on: ubuntu-22.04

--- a/Makefile.containers
+++ b/Makefile.containers
@@ -31,7 +31,7 @@ else
 CONTAINER_VOLUME_FLAGS =
 endif
 else
-CONTAINER_COMPOSETOOL = $(error Neither docker-compose, docker c0mpose or podman-compose were found)
+CONTAINER_COMPOSETOOL = $(error Neither docker-compose, docker compose or podman-compose were found)
 endif
 
 ifeq ($(OS_RELEASE), ubuntu)

--- a/Makefile.containers
+++ b/Makefile.containers
@@ -12,6 +12,8 @@ ifeq ($(CONTAINER_CLITOOL), docker)
 CONTAINER_BUILDENV ?= DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain
 ifeq ($(shell docker-compose -v >/dev/null 2>&1 || echo FAIL),)
 CONTAINER_COMPOSE = docker-compose
+else ifeq ($(shell docker compose -v >/dev/null 2>&1 || echo FAIL),)
+CONTAINER_COMPOSE = "docker compose"
 endif
 else ifeq ($(CONTAINER_CLITOOL), podman)
 ifeq ($(shell podman-compose -v >/dev/null 2>&1 || echo FAIL),)
@@ -29,7 +31,7 @@ else
 CONTAINER_VOLUME_FLAGS =
 endif
 else
-CONTAINER_COMPOSETOOL = $(error Neither docker-compose nor podman-compose found)
+CONTAINER_COMPOSETOOL = $(error Neither docker-compose, docker c0mpose or podman-compose were found)
 endif
 
 ifeq ($(OS_RELEASE), ubuntu)

--- a/Makefile.containers
+++ b/Makefile.containers
@@ -13,7 +13,7 @@ CONTAINER_BUILDENV ?= DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain
 ifeq ($(shell docker-compose -v >/dev/null 2>&1 || echo FAIL),)
 CONTAINER_COMPOSE = docker-compose
 else ifeq ($(shell docker compose -v >/dev/null 2>&1 || echo FAIL),)
-CONTAINER_COMPOSE = "docker compose"
+CONTAINER_COMPOSE = docker compose
 endif
 else ifeq ($(CONTAINER_CLITOOL), podman)
 ifeq ($(shell podman-compose -v >/dev/null 2>&1 || echo FAIL),)

--- a/scripts/packages/nginx-agent.service
+++ b/scripts/packages/nginx-agent.service
@@ -23,8 +23,8 @@ PermissionsStartOnly=true
 PIDFile=${AGENT_RUN_DIR}/nginx-agent.pid
 Environment=
 
-StandardOutput=syslog
-StandardError=syslog
+StandardOutput=journal
+StandardError=journal
 SyslogIdentifier=nginx-agent
 
 ExecStop=/bin/kill -2 $MAINPID

--- a/scripts/packages/postinstall.sh
+++ b/scripts/packages/postinstall.sh
@@ -21,7 +21,7 @@ WORKER_USER=""
 AGENT_GROUP="nginx-agent"
 
 detect_nginx_users() {
-    if command -V systemctl >/dev/null 2>&1; then
+    if command -V systemctl; then
         printf "PostInstall: Reading NGINX systemctl unit file for user information\n"
         nginx_unit_file=$(systemctl status nginx | grep -Po "\(\K\/.*service")
         pid_file=$(grep -Po "PIDFile=\K.*$" "${nginx_unit_file}")
@@ -122,7 +122,7 @@ ensure_agent_path() {
 create_agent_group() {
     printf "PostInstall: Adding nginx-agent group %s\n" "${AGENT_GROUP}"
 
-    if command -V groupadd >/dev/null 2>&1; then
+    if command -V groupadd; then
         if [ ! "$(getent group $AGENT_GROUP)" ]; then
             groupadd "${AGENT_GROUP}"
         fi
@@ -168,7 +168,7 @@ create_run_dir() {
 
 update_unit_file() {
     # Fill in data to unit file that's acquired post install
-    if command -V systemctl >/dev/null 2>&1; then
+    if command -V systemctl; then
         printf "PostInstall: Modifying NGINX Agent unit file with correct locations and user information\n"
         EXE_CMD="s|\${AGENT_EXE}|${AGENT_EXE}|g"
         sed -i -e $EXE_CMD ${AGENT_UNIT_LOCATION}/${AGENT_UNIT_FILE}
@@ -303,7 +303,7 @@ restart_agent_if_required() {
         # https://github.com/freebsd/pkg/pull/2128
         return
     fi
-    if service nginx-agent status >/dev/null 2>&1; then
+    if service nginx-agent status; then
         printf "PostInstall: Restarting nginx agent\n"
         service nginx-agent restart || true
     fi

--- a/scripts/packages/postinstall.sh
+++ b/scripts/packages/postinstall.sh
@@ -41,16 +41,17 @@ detect_nginx_users() {
     if [ -z "${nginx_user}" ]; then
         printf "PostInstall: Reading NGINX process information to determine NGINX user\n"
         nginx_pid=""
-        for pid in $(ls /proc | grep -E '^[0-9]+$'); do
-            if [ -r /proc/$pid/cmdline ]; then
-                if grep -q "nginx: master process" /proc/$pid/cmdline 2>/dev/null; then
+        for pid in /proc/[0-9]*; do
+            pid=${pid##*/}
+            if [ -r /proc/"$pid"/cmdline ]; then
+                if grep -q "nginx: master process" /proc/"$pid"/cmdline 2>/dev/null; then
                     nginx_pid=$pid
                     break
                 fi
             fi
         done 
         if [ "${nginx_pid}" ]; then
-            nginx_user=$(awk '/^Uid:/ {print $2}' /proc/$nginx_pid/status | xargs -I {} getent passwd {} | cut -d: -f1)
+            nginx_user=$(awk '/^Uid:/ {print $2}' /proc/"$nginx_pid"/status | xargs -I {} getent passwd {} | cut -d: -f1)
         fi
 
         if [ -z "${nginx_user}" ]; then
@@ -68,16 +69,17 @@ detect_nginx_users() {
     if [ -z "${worker_user}" ]; then
         printf "PostInstall: Reading NGINX process information to determine NGINX user\n"
         worker_pid=""
-        for pid in $(ls /proc | grep -E '^[0-9]+$'); do
-            if [ -r /proc/$pid/cmdline ]; then
-                if grep -q "nginx: worker process" /proc/$pid/cmdline 2>/dev/null; then
+        for pid in /proc/[0-9]*; do
+            pid=${pid##*/}
+            if [ -r /proc/"$pid"/cmdline ]; then
+                if grep -q "nginx: worker process" /proc/"$pid"/cmdline 2>/dev/null; then
                     worker_pid=$pid
                     break
                 fi
             fi
         done
         if [ "${worker_pid}" ]; then
-            worker_user=$(awk '/^Uid:/ {print $2}' /proc/$worker_pid/status | xargs -I {} getent passwd {} | cut -d: -f1)
+            worker_user=$(awk '/^Uid:/ {print $2}' /proc/"$worker_pid"/status | xargs -I {} getent passwd {} | cut -d: -f1)
         fi
 
         if [ -z "${worker_user}" ]; then
@@ -121,7 +123,7 @@ create_agent_group() {
     printf "PostInstall: Adding nginx-agent group %s\n" "${AGENT_GROUP}"
 
     if command -V groupadd >/dev/null 2>&1; then
-        if [ ! $(getent group $AGENT_GROUP) ]; then
+        if [ ! "$(getent group $AGENT_GROUP)" ]; then
             groupadd "${AGENT_GROUP}"
         fi
 

--- a/scripts/packages/postinstall.sh
+++ b/scripts/packages/postinstall.sh
@@ -21,7 +21,7 @@ WORKER_USER=""
 AGENT_GROUP="nginx-agent"
 
 detect_nginx_users() {
-    if command -v systemctl && [ "$(cat /proc/1/comm)" == "systemd" ]; then
+    if command -V systemctl && [ "$(cat /proc/1/comm)" == "systemd" ]; then
         printf "PostInstall: Reading NGINX systemctl unit file for user information\n"
         nginx_unit_file=$(systemctl status nginx | grep -Po "\(\K\/.*service")
         pid_file=$(grep -Po "PIDFile=\K.*$" "${nginx_unit_file}")
@@ -168,7 +168,7 @@ create_run_dir() {
 
 update_unit_file() {
     # Fill in data to unit file that's acquired post install
-    if command -v systemctl && [ "$(cat /proc/1/comm)" == "systemd" ]; then
+    if command -V systemctl && [ "$(cat /proc/1/comm)" == "systemd" ]; then
         printf "PostInstall: Modifying NGINX Agent unit file with correct locations and user information\n"
         EXE_CMD="s|\${AGENT_EXE}|${AGENT_EXE}|g"
         sed -i -e $EXE_CMD ${AGENT_UNIT_LOCATION}/${AGENT_UNIT_FILE}
@@ -303,7 +303,7 @@ restart_agent_if_required() {
         # https://github.com/freebsd/pkg/pull/2128
         return
     fi
-    if command -v service; then
+    if command -V service; then
         if service nginx-agent status; then
             printf "PostInstall: Restarting nginx agent\n"
             service nginx-agent restart || true

--- a/scripts/packages/postinstall.sh
+++ b/scripts/packages/postinstall.sh
@@ -43,7 +43,11 @@ detect_nginx_users() {
 
     if command -V ps >/dev/null 2>&1 && [ -z "${nginx_user}" ]; then
         printf "PostInstall: Reading NGINX process information to determine NGINX user\n"
-        nginx_user=$(ps aux | grep "nginx: master process" | grep -v grep | head -1 | awk '{print $1}')
+        if [ "$ID" = "alpine" ]; then
+            nginx_user=$(ps aux | grep "nginx: master process" | grep -v grep | head -1 | awk '{print $2}')
+        else
+            nginx_user=$(ps aux | grep "nginx: master process" | grep -v grep | head -1 | awk '{print $1}')
+        fi
 
         if [ -z "${nginx_user}" ]; then
             printf "No NGINX user found\n"
@@ -80,7 +84,11 @@ detect_nginx_users() {
 
     if command -V ps >/dev/null 2>&1 && [ -z "${worker_user}" ]; then
         printf "PostInstall: Reading NGINX process information to determine NGINX worker user\n"
-        worker_user=$(ps aux | grep "nginx: worker process" | grep -v grep | head -1 | awk '{print $1}')
+        if [ "$ID" = "alpine" ]; then
+            worker_user=$(ps aux | grep "nginx: worker process" | grep -v grep | head -1 | awk '{print $2}')
+        else
+            worker_user=$(ps aux | grep "nginx: worker process" | grep -v grep | head -1 | awk '{print $1}')
+        fi
 
         if [ -z "${worker_user}" ]; then
             printf "No NGINX worker user found\n"

--- a/scripts/packages/postinstall.sh
+++ b/scripts/packages/postinstall.sh
@@ -21,7 +21,7 @@ WORKER_USER=""
 AGENT_GROUP="nginx-agent"
 
 detect_nginx_users() {
-    if command -V systemctl; then
+    if command -v systemctl && [ "$(cat /proc/1/comm)" == "systemd" ]; then
         printf "PostInstall: Reading NGINX systemctl unit file for user information\n"
         nginx_unit_file=$(systemctl status nginx | grep -Po "\(\K\/.*service")
         pid_file=$(grep -Po "PIDFile=\K.*$" "${nginx_unit_file}")
@@ -168,7 +168,7 @@ create_run_dir() {
 
 update_unit_file() {
     # Fill in data to unit file that's acquired post install
-    if command -V systemctl; then
+    if command -v systemctl && [ "$(cat /proc/1/comm)" == "systemd" ]; then
         printf "PostInstall: Modifying NGINX Agent unit file with correct locations and user information\n"
         EXE_CMD="s|\${AGENT_EXE}|${AGENT_EXE}|g"
         sed -i -e $EXE_CMD ${AGENT_UNIT_LOCATION}/${AGENT_UNIT_FILE}

--- a/scripts/packages/postremove.sh
+++ b/scripts/packages/postremove.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # Determine OS platform
 # shellcheck source=/dev/null

--- a/scripts/packages/postremove.sh
+++ b/scripts/packages/postremove.sh
@@ -2,27 +2,27 @@
 set -e
 
 # Determine OS platform
-# shellcheck source=/dev/null
+
 . /etc/os-release
 
 stop_agent_freebsd() {
     echo "Stopping nginx-agent service"
-    service nginx-agent onestop >/dev/null 2>&1 || true
+    service nginx-agent onestop || true
 }
 
 disable_agent_freebsd() {
     echo "Disabling nginx-agent service"
-    sysrc -x nginx_agent_enable >/dev/null 2>&1 || true
+    sysrc -x nginx_agent_enable || true
 }
 
 stop_agent_systemd() {
     echo "Stopping nginx-agent service"
-    systemctl stop nginx-agent >/dev/null 2>&1 || true
+    systemctl stop nginx-agent || true
 }
 
 disable_agent_systemd() {
     echo "Disabling nginx-agent service"
-    systemctl disable nginx-agent >/dev/null 2>&1 || true
+    systemctl disable nginx-agent || true
 }
 
 systemd_daemon_reload() {

--- a/scripts/packages/postupgrade.sh
+++ b/scripts/packages/postupgrade.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 NEWVER="$1"
 OLDVER="$2"

--- a/scripts/packages/postupgrade.sh
+++ b/scripts/packages/postupgrade.sh
@@ -5,14 +5,14 @@ NEWVER="$1"
 OLDVER="$2"
 
 restart_agent_if_required() {
-    if service nginx-agent status >/dev/null 2>&1; then
+    if service nginx-agent status; then
         printf "PostUpgrade: Restarting nginx agent (upgraded to %s from %s)\n" "$NEWVER" "$OLDVER"
         service nginx-agent restart || true
     fi
 }
 
 # Determine OS platform
-# shellcheck source=/dev/null
+
 . /etc/os-release
 
 case "$ID" in

--- a/scripts/packages/postupgrade.sh
+++ b/scripts/packages/postupgrade.sh
@@ -1,11 +1,14 @@
 #!/bin/sh
 set -e
 
+# Note: >/dev/null 2>&1 is used in multiple if statements in this file. 
+# This is to hide expected error messages from being outputted.
+
 NEWVER="$1"
 OLDVER="$2"
 
 restart_agent_if_required() {
-    if service nginx-agent status; then
+    if service nginx-agent status >/dev/null 2>&1; then
         printf "PostUpgrade: Restarting nginx agent (upgraded to %s from %s)\n" "$NEWVER" "$OLDVER"
         service nginx-agent restart || true
     fi

--- a/scripts/packages/preremove.sh
+++ b/scripts/packages/preremove.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
+
 # Pre Remove Steps
 
 # Determine OS platform

--- a/scripts/packages/preremove.sh
+++ b/scripts/packages/preremove.sh
@@ -4,7 +4,7 @@ set -e
 # Pre Remove Steps
 
 # Determine OS platform
-# shellcheck source=/dev/null
+
 . /etc/os-release
 
 stop_agent_openrc() {


### PR DESCRIPTION
### Proposed changes

This PR aims to prevent silent fails when agent is installed in a Debian docker image. PostInstall.sh no longer uses the ps command to detect nginx users.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
