### PR TITLE
Fix data plane response messages and errors

### DIFF
--- a/internal/file/file_plugin.go
+++ b/internal/file/file_plugin.go
@@ -288,7 +288,7 @@ func (fp *FilePlugin) handleConfigUploadRequest(ctx context.Context, msg *bus.Me
 func (fp *FilePlugin) createDataPlaneResponse(correlationID string, status mpi.CommandResponse_CommandStatus,
 	message, instanceID, err string,
 ) *mpi.DataPlaneResponse {
-	response := &mpi.DataPlaneResponse{
+	return &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
 			MessageId:     uuid.NewString(),
 			CorrelationId: correlationID,
@@ -297,13 +297,8 @@ func (fp *FilePlugin) createDataPlaneResponse(correlationID string, status mpi.C
 		CommandResponse: &mpi.CommandResponse{
 			Status:  status,
 			Message: message,
+			Error:   err,
 		},
 		InstanceId: instanceID,
 	}
-
-	if err != "" {
-		response.GetCommandResponse().Error = err
-	}
-
-	return response
 }

--- a/internal/file/file_plugin.go
+++ b/internal/file/file_plugin.go
@@ -108,11 +108,11 @@ func (fp *FilePlugin) handleConfigApplyFailedRequest(ctx context.Context, msg *b
 	if err != nil {
 		rollbackResponse := fp.createDataPlaneResponse(data.CorrelationID,
 			mpi.CommandResponse_COMMAND_STATUS_ERROR,
-			fmt.Sprintf("Rollback failed for instanceId: %s", data.InstanceID), data.InstanceID, err.Error())
+			"Rollback failed", data.InstanceID, err.Error())
 
 		applyResponse := fp.createDataPlaneResponse(data.CorrelationID,
 			mpi.CommandResponse_COMMAND_STATUS_FAILURE,
-			fmt.Sprintf("Config apply failed for instanceId: %s", data.InstanceID), data.InstanceID, err.Error())
+			"Config apply failed, rollback failed", data.InstanceID, data.Error.Error())
 
 		fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: rollbackResponse})
 		fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: applyResponse})
@@ -152,9 +152,7 @@ func (fp *FilePlugin) handleConfigApplyRequest(ctx context.Context, msg *bus.Mes
 	switch writeStatus {
 	case model.NoChange:
 		response = fp.createDataPlaneResponse(correlationID, mpi.CommandResponse_COMMAND_STATUS_OK,
-			fmt.Sprintf("Successful config apply for instanceId: %s, no files to change",
-				configApplyRequest.GetConfigVersion().
-					GetInstanceId()), configApplyRequest.GetConfigVersion().GetInstanceId(), "")
+			"Config apply successful, no files to change", configApplyRequest.GetConfigVersion().GetInstanceId(), "")
 
 		fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: response})
 		fp.fileManagerService.ClearCache()
@@ -168,8 +166,7 @@ func (fp *FilePlugin) handleConfigApplyRequest(ctx context.Context, msg *bus.Mes
 			"error", err,
 		)
 		response = fp.createDataPlaneResponse(correlationID, mpi.CommandResponse_COMMAND_STATUS_FAILURE,
-			fmt.Sprintf("Config apply failed for instanceId: %s", configApplyRequest.
-				GetConfigVersion().GetInstanceId()), configApplyRequest.GetConfigVersion().GetInstanceId(), err.Error())
+			"Config apply failed", configApplyRequest.GetConfigVersion().GetInstanceId(), err.Error())
 
 		fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: response})
 		fp.fileManagerService.ClearCache()
@@ -183,8 +180,7 @@ func (fp *FilePlugin) handleConfigApplyRequest(ctx context.Context, msg *bus.Mes
 			"error", err,
 		)
 		response = fp.createDataPlaneResponse(correlationID, mpi.CommandResponse_COMMAND_STATUS_ERROR,
-			fmt.Sprintf("Config apply failed for instanceId: %s, rolling back config",
-				configApplyRequest.GetConfigVersion().GetInstanceId()), configApplyRequest.
+			"Config apply failed, rolling back config", configApplyRequest.
 				GetConfigVersion().GetInstanceId(), err.Error())
 
 		fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: response})
@@ -292,7 +288,7 @@ func (fp *FilePlugin) handleConfigUploadRequest(ctx context.Context, msg *bus.Me
 func (fp *FilePlugin) createDataPlaneResponse(correlationID string, status mpi.CommandResponse_CommandStatus,
 	message, instanceID, err string,
 ) *mpi.DataPlaneResponse {
-	return &mpi.DataPlaneResponse{
+	response := &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
 			MessageId:     uuid.NewString(),
 			CorrelationId: correlationID,
@@ -301,8 +297,13 @@ func (fp *FilePlugin) createDataPlaneResponse(correlationID string, status mpi.C
 		CommandResponse: &mpi.CommandResponse{
 			Status:  status,
 			Message: message,
-			Error:   err,
 		},
 		InstanceId: instanceID,
 	}
+
+	if err != "" {
+		response.GetCommandResponse().Error = err
+	}
+
+	return response
 }

--- a/internal/file/file_plugin_test.go
+++ b/internal/file/file_plugin_test.go
@@ -380,7 +380,7 @@ func TestFilePlugin_Process_ConfigApplyFailedTopic(t *testing.T) {
 			data := &model.ConfigApplyMessage{
 				CorrelationID: "dfsbhj6-bc92-30c1-a9c9-85591422068e",
 				InstanceID:    test.instanceID,
-				Error:         nil,
+				Error:         fmt.Errorf("something went wrong with config apply"),
 			}
 
 			filePlugin.Process(ctx, &bus.Message{Topic: bus.ConfigApplyFailedTopic, Data: data})

--- a/internal/resource/resource_plugin.go
+++ b/internal/resource/resource_plugin.go
@@ -171,8 +171,6 @@ func (r *Resource) handleRollbackWrite(ctx context.Context, msg *bus.Message) {
 		return
 	}
 
-	slog.InfoContext(ctx, "--------->>>>", "data", data)
-
 	applyResponse := r.createDataPlaneResponse(data.CorrelationID,
 		mpi.CommandResponse_COMMAND_STATUS_FAILURE,
 		"Config apply failed, rollback successful", data.InstanceID, data.Error.Error())

--- a/internal/resource/resource_plugin.go
+++ b/internal/resource/resource_plugin.go
@@ -182,7 +182,7 @@ func (r *Resource) handleRollbackWrite(ctx context.Context, msg *bus.Message) {
 func (*Resource) createDataPlaneResponse(correlationID string, status mpi.CommandResponse_CommandStatus,
 	message, instanceID, err string,
 ) *mpi.DataPlaneResponse {
-	response := &mpi.DataPlaneResponse{
+	return &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
 			MessageId:     uuid.NewString(),
 			CorrelationId: correlationID,
@@ -191,13 +191,8 @@ func (*Resource) createDataPlaneResponse(correlationID string, status mpi.Comman
 		CommandResponse: &mpi.CommandResponse{
 			Status:  status,
 			Message: message,
+			Error:   err,
 		},
 		InstanceId: instanceID,
 	}
-
-	if err != "" {
-		response.GetCommandResponse().Error = err
-	}
-
-	return response
 }

--- a/internal/resource/resource_plugin.go
+++ b/internal/resource/resource_plugin.go
@@ -127,6 +127,7 @@ func (r *Resource) handleWriteConfigSuccessful(ctx context.Context, msg *bus.Mes
 	}
 	err := r.resourceService.ApplyConfig(ctx, data.InstanceID)
 	if err != nil {
+		data.Error = err
 		slog.Error("errors found during config apply, sending error status, rolling back config", "err", err)
 		response := r.createDataPlaneResponse(data.CorrelationID, mpi.CommandResponse_COMMAND_STATUS_ERROR,
 			"Config apply failed, rolling back config", data.InstanceID, err.Error())
@@ -169,6 +170,8 @@ func (r *Resource) handleRollbackWrite(ctx context.Context, msg *bus.Message) {
 
 		return
 	}
+
+	slog.InfoContext(ctx, "--------->>>>", "data", data)
 
 	applyResponse := r.createDataPlaneResponse(data.CorrelationID,
 		mpi.CommandResponse_COMMAND_STATUS_FAILURE,

--- a/internal/resource/resource_plugin.go
+++ b/internal/resource/resource_plugin.go
@@ -7,7 +7,6 @@ package resource
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 
 	"github.com/google/uuid"
@@ -128,10 +127,9 @@ func (r *Resource) handleWriteConfigSuccessful(ctx context.Context, msg *bus.Mes
 	}
 	err := r.resourceService.ApplyConfig(ctx, data.InstanceID)
 	if err != nil {
-		slog.Error("errors found during config apply, sending failure status", "err", err)
+		slog.Error("errors found during config apply, sending error status, rolling back config", "err", err)
 		response := r.createDataPlaneResponse(data.CorrelationID, mpi.CommandResponse_COMMAND_STATUS_ERROR,
-			fmt.Sprintf("Config apply failed for instanceId: %s, "+
-				"rolling back config", data.InstanceID), data.InstanceID, err.Error())
+			"Config apply failed, rolling back config", data.InstanceID, err.Error())
 		r.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: response})
 
 		r.messagePipe.Process(ctx, &bus.Message{Topic: bus.ConfigApplyFailedTopic, Data: data})
@@ -139,7 +137,7 @@ func (r *Resource) handleWriteConfigSuccessful(ctx context.Context, msg *bus.Mes
 		return
 	}
 	response := r.createDataPlaneResponse(data.CorrelationID, mpi.CommandResponse_COMMAND_STATUS_OK,
-		fmt.Sprintf("Successful config apply for instanceId: %s", data.InstanceID), data.InstanceID, "")
+		"Config apply successful", data.InstanceID, "")
 
 	instance := r.resourceService.Instance(data.InstanceID)
 
@@ -158,13 +156,12 @@ func (r *Resource) handleRollbackWrite(ctx context.Context, msg *bus.Message) {
 	if err != nil {
 		slog.Error("errors found during rollback, sending failure status", "err", err)
 
-		applyResponse := r.createDataPlaneResponse(data.CorrelationID,
-			mpi.CommandResponse_COMMAND_STATUS_ERROR, fmt.Sprintf("Rollback failed for instanceId: %s",
-				data.InstanceID), data.InstanceID, err.Error())
-
 		rollbackResponse := r.createDataPlaneResponse(data.CorrelationID,
-			mpi.CommandResponse_COMMAND_STATUS_FAILURE, fmt.Sprintf("Config apply failed for instanceId: %s",
-				data.InstanceID), data.InstanceID, err.Error())
+			mpi.CommandResponse_COMMAND_STATUS_ERROR, "Rollback failed", data.InstanceID, err.Error())
+
+		applyResponse := r.createDataPlaneResponse(data.CorrelationID,
+			mpi.CommandResponse_COMMAND_STATUS_FAILURE, "Config apply failed, rollback failed",
+			data.InstanceID, data.Error.Error())
 
 		r.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: applyResponse})
 		r.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: rollbackResponse})
@@ -175,8 +172,7 @@ func (r *Resource) handleRollbackWrite(ctx context.Context, msg *bus.Message) {
 
 	applyResponse := r.createDataPlaneResponse(data.CorrelationID,
 		mpi.CommandResponse_COMMAND_STATUS_FAILURE,
-		"config apply failed", data.InstanceID, fmt.Sprintf("Config apply failed for instanceId: %s, "+
-			"rollback successful", data.InstanceID))
+		"Config apply failed, rollback successful", data.InstanceID, data.Error.Error())
 
 	r.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: applyResponse})
 	r.messagePipe.Process(ctx, &bus.Message{Topic: bus.RollbackCompleteTopic})
@@ -185,7 +181,7 @@ func (r *Resource) handleRollbackWrite(ctx context.Context, msg *bus.Message) {
 func (*Resource) createDataPlaneResponse(correlationID string, status mpi.CommandResponse_CommandStatus,
 	message, instanceID, err string,
 ) *mpi.DataPlaneResponse {
-	return &mpi.DataPlaneResponse{
+	response := &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
 			MessageId:     uuid.NewString(),
 			CorrelationId: correlationID,
@@ -194,8 +190,13 @@ func (*Resource) createDataPlaneResponse(correlationID string, status mpi.Comman
 		CommandResponse: &mpi.CommandResponse{
 			Status:  status,
 			Message: message,
-			Error:   err,
 		},
 		InstanceId: instanceID,
 	}
+
+	if err != "" {
+		response.GetCommandResponse().Error = err
+	}
+
+	return response
 }

--- a/internal/resource/resource_plugin_test.go
+++ b/internal/resource/resource_plugin_test.go
@@ -174,7 +174,6 @@ func TestResource_Process_Apply(t *testing.T) {
 				assert.True(tt, ok)
 				assert.Equal(tt, test.applyErr.Error(), response.GetCommandResponse().GetError())
 			}
-
 		})
 	}
 }
@@ -247,7 +246,6 @@ func TestResource_Process_Rollback(t *testing.T) {
 				assert.Equal(t, test.topic[2], messagePipe.GetMessages()[2].Topic)
 				assert.Equal(tt, test.rollbackErr.Error(), rollbackResponse.GetCommandResponse().GetError())
 			}
-
 		})
 	}
 }

--- a/internal/resource/resource_plugin_test.go
+++ b/internal/resource/resource_plugin_test.go
@@ -8,6 +8,7 @@ package resource
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"testing"
 
@@ -187,7 +188,7 @@ func TestResource_Process_Rollback(t *testing.T) {
 				Data: &model.ConfigApplyMessage{
 					CorrelationID: "dfsbhj6-bc92-30c1-a9c9-85591422068e",
 					InstanceID:    protos.GetNginxOssInstance([]string{}).GetInstanceMeta().GetInstanceId(),
-					Error:         nil,
+					Error:         fmt.Errorf("something went wrong with config apply"),
 				},
 			},
 			applyErr: nil,
@@ -200,6 +201,7 @@ func TestResource_Process_Rollback(t *testing.T) {
 				Data: &model.ConfigApplyMessage{
 					CorrelationID: "",
 					InstanceID:    protos.GetNginxOssInstance([]string{}).GetInstanceMeta().GetInstanceId(),
+					Error:         fmt.Errorf("something went wrong with config apply"),
 				},
 			},
 			applyErr: errors.New("error reloading"),

--- a/test/mock/grpc/mock_management_file_service.go
+++ b/test/mock/grpc/mock_management_file_service.go
@@ -182,7 +182,7 @@ func getMapOfVersionedFiles(configDirectory string) (map[string][]*v1.File, erro
 			return err
 		}
 
-		if !info.IsDir() {
+		if isValidFile(info, path) {
 			slog.Debug("Found file", "path", path)
 
 			splitPath := strings.SplitN(strings.Split(path, configDirectory)[1], string(filepath.Separator), 3)
@@ -209,6 +209,10 @@ func getMapOfVersionedFiles(configDirectory string) (map[string][]*v1.File, erro
 	})
 
 	return files, err
+}
+
+func isValidFile(info os.FileInfo, path string) bool {
+	return !info.IsDir() && !strings.HasSuffix(path, ".DS_Store")
 }
 
 func performFileAction(fileAction v1.File_FileAction, fileContents []byte, fullFilePath, filePermissions string) error {


### PR DESCRIPTION
### Proposed changes

- Cleaned up data plane response messages so they are consistent and no longer contain the instanceID
- Errors are cleaned up so Config apply original error is sent with failure status instead of the rollback error, rollbacks status is also included in the message for a config apply failure if rollback has occurred 
- Added additional checks to the unit tests to check the errors being sent in the data plane responses instead of just checking the topic

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
