### PR TITLE
Add DetermineFileAction Function 

### DIFF
--- a/pkg/files/file_helpers.go
+++ b/pkg/files/file_helpers.go
@@ -159,30 +159,24 @@ func DetermineFileAction(currentFiles, modifiedFiles []*mpi.File) []*mpi.File {
 		if !ok {
 			currentFile.Action = &deleteAction
 			filesWithActions = append(filesWithActions, currentFile)
-			delete(modifiedFilesMap, currentFile.GetFileMeta().GetName())
 
 			continue
 		}
 	}
 
 	for _, file := range modifiedFilesMap {
-		_, ok := currentFilesMap[file.GetFileMeta().GetName()]
+		currentFile, ok := currentFilesMap[file.GetFileMeta().GetName()]
+
+		// default to unchanged action
+		file.Action = &unchangedAction
 		// if file doesn't exist in the current files, file has been added
 		if !ok {
 			file.Action = &addAction
-			filesWithActions = append(filesWithActions, file)
-
-			continue
 			// if file currently exists and file hash is different, file has been updated
-		} else if file.GetFileMeta().GetHash() != currentFilesMap[file.GetFileMeta().GetName()].
-			GetFileMeta().GetHash() {
+		} else if file.GetFileMeta().GetHash() != currentFile.GetFileMeta().GetHash() {
 			file.Action = &updateAction
-			filesWithActions = append(filesWithActions, file)
-
-			continue
 		}
 		// if file exists and file hash matches, file is unchanged
-		file.Action = &unchangedAction
 		filesWithActions = append(filesWithActions, file)
 	}
 

--- a/pkg/files/file_helpers_test.go
+++ b/pkg/files/file_helpers_test.go
@@ -315,7 +315,7 @@ func TestDetermineFileAction(t *testing.T) {
 	}
 
 	result := DetermineFileAction(currentFiles, modifiedFiles)
-	assert.Equal(t, expectedResult, result)
+	assert.Len(t, result, len(expectedResult))
 
 	slices.SortFunc(result, func(a, b *mpi.File) int {
 		return cmp.Compare(a.GetFileMeta().GetName(), b.GetFileMeta().GetName())

--- a/pkg/files/file_helpers_test.go
+++ b/pkg/files/file_helpers_test.go
@@ -315,6 +315,7 @@ func TestDetermineFileAction(t *testing.T) {
 	}
 
 	result := DetermineFileAction(currentFiles, modifiedFiles)
+	assert.Equal(t, expectedResult, result)
 
 	slices.SortFunc(result, func(a, b *mpi.File) int {
 		return cmp.Compare(a.GetFileMeta().GetName(), b.GetFileMeta().GetName())


### PR DESCRIPTION
### Proposed changes

Added DetermineFileAction to pkg/files/file_helpers.go which compares two lists of files, determines the action needed for each file and then returns a list of files with the file action set for each file

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
