### PR TITLE
The letter v is now always prepended to output of -v

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -46,8 +46,9 @@ jobs:
           script: |
             const semver = require('semver');
             const ref = context.ref.split("/")[2]
-            const version = ref.split("-")[1]
-            console.log(`The release version is v${version}`)
+            const version_number = ref.split("-")[1]
+            const version = "v"+version_number
+            console.log(`The release version is ${version}`)
             
             const releases = (await github.rest.repos.listReleases({
               owner: context.payload.repository.owner.login,
@@ -62,10 +63,10 @@ jobs:
             
             console.log(`The latest release was ${latest_release}`)
 
-            if (latest_release === "v"+version) {
+            if (latest_release === version) {
                 core.setFailed(`A published release already exists for ${latest_release}`)
             } else {
-                const draft = releases.find((r) => r.draft && r.tag_name === "v"+version)
+                const draft = releases.find((r) => r.draft && r.tag_name === version)
                 const draft_found = !(draft === undefined)
                 
                 let release
@@ -81,7 +82,7 @@ jobs:
                 const release_notes = (await github.rest.repos.generateReleaseNotes({
                     owner: context.payload.repository.owner.login,
                     repo: context.payload.repository.name,
-                    tag_name: "v"+version,
+                    tag_name: version,
                     previous_tag_name: latest_release,
                     target_commitish: ref,
                 }))
@@ -94,9 +95,9 @@ jobs:
                 release = (await github.rest.repos.createRelease({
                     owner: context.payload.repository.owner.login,
                     repo: context.payload.repository.name,
-                    tag_name: "v"+version,
+                    tag_name: version,
                     target_commitish: ref,
-                    name: "v"+version,
+                    name: version,
                     body: release_notes.data.body + footer,
                     draft: true,
                 }))
@@ -107,7 +108,7 @@ jobs:
                 console.log(`Release Upload URL: ${release.data.upload_url}`)
                 
                 return {
-                    version: version,
+                    version: version_number,
                     release_id: release.data.id,
                     release_upload_url: release.data.upload_url,
                 }

--- a/Makefile.packaging
+++ b/Makefile.packaging
@@ -48,9 +48,9 @@ package: gpg-key $(PACKAGES_DIR) $(GITHUB_PACKAGES_DIR) $(AZURE_PACKAGES_DIR) ##
 		GOWORK=off CGO_ENABLED=0 GOARCH=$${arch} GOOS=linux go build -pgo=auto -ldflags=${LDFLAGS} -o ./build/nginx-agent; \
 		for distro in $(DEB_DISTROS); do \
 			deb_codename=`echo $$distro | cut -d- -f 2`; \
-			VERSION=$(shell echo ${VERSION} | tr -d 'v')~$${deb_codename} ARCH=$${arch} nfpm pkg --config .nfpm.yaml --packager deb --target ${PACKAGES_DIR}/deb/${PACKAGE_PREFIX}_$(shell echo ${VERSION} | tr -d 'v')~$${deb_codename}_$${arch}.deb; \
-			cp ${PACKAGES_DIR}/deb/${PACKAGE_PREFIX}_$(shell echo ${VERSION} | tr -d 'v')~$${deb_codename}_$${arch}.deb ${GITHUB_PACKAGES_DIR}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v')~$${deb_codename}_$${arch}.deb; \
-			cp ${PACKAGES_DIR}/deb/${PACKAGE_PREFIX}_$(shell echo ${VERSION} | tr -d 'v')~$${deb_codename}_$${arch}.deb ${AZURE_PACKAGES_DIR}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v')~$${deb_codename}_$${arch}.deb; \
+			VERSION=${VERSION}~$${deb_codename} ARCH=$${arch} nfpm pkg --config .nfpm.yaml --packager deb --target ${PACKAGES_DIR}/deb/${PACKAGE_PREFIX}_${VERSION}~$${deb_codename}_$${arch}.deb; \
+			cp ${PACKAGES_DIR}/deb/${PACKAGE_PREFIX}_${VERSION}~$${deb_codename}_$${arch}.deb ${GITHUB_PACKAGES_DIR}/${PACKAGE_PREFIX}-${VERSION}~$${deb_codename}_$${arch}.deb; \
+			cp ${PACKAGES_DIR}/deb/${PACKAGE_PREFIX}_${VERSION}~$${deb_codename}_$${arch}.deb ${AZURE_PACKAGES_DIR}/${PACKAGE_PREFIX}-${VERSION}~$${deb_codename}_$${arch}.deb; \
 		done; \
 		rm -rf ./build/nginx-agent; \
 	done; \
@@ -67,9 +67,9 @@ package: gpg-key $(PACKAGES_DIR) $(GITHUB_PACKAGES_DIR) $(AZURE_PACKAGES_DIR) ##
 			elif [ "$$rpm_distro" = "suse" ]; then rpm_codename="sles$$rpm_major"; \
 		fi; \
 		if [ "$$rpm_codename" != "na" ]; then \
-			VERSION=$(shell echo ${VERSION} | tr -d 'v') ARCH=amd64 nfpm pkg --config .nfpm.yaml --packager rpm --target $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.${RPM_ARCH}.rpm; \
-			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$(RPM_ARCH).rpm ${GITHUB_PACKAGES_DIR}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.${RPM_ARCH}.rpm; \
-			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$(RPM_ARCH).rpm ${AZURE_PACKAGES_DIR}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.${RPM_ARCH}.rpm; \
+			VERSION=${VERSION} ARCH=amd64 nfpm pkg --config .nfpm.yaml --packager rpm --target $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.${RPM_ARCH}.rpm; \
+			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$(RPM_ARCH).rpm ${GITHUB_PACKAGES_DIR}/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.${RPM_ARCH}.rpm; \
+			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$(RPM_ARCH).rpm ${AZURE_PACKAGES_DIR}/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.${RPM_ARCH}.rpm; \
 		fi; \
 	done; \
 	rm -rf ./build/nginx-agent
@@ -85,9 +85,9 @@ package: gpg-key $(PACKAGES_DIR) $(GITHUB_PACKAGES_DIR) $(AZURE_PACKAGES_DIR) ##
 			rpm_distro=`echo $$distro | cut -d- -f 1`; \
 			rpm_major=`echo $$distro | cut -d- -f 2`; \
 			rpm_codename="el$$rpm_major"; \
-			VERSION=$(shell echo ${VERSION} | tr -d 'v') ARCH=$${arch} nfpm pkg --config .nfpm.yaml --packager rpm --target $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm; \
-			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm ${GITHUB_PACKAGES_DIR}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm; \
-			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm ${AZURE_PACKAGES_DIR}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm; \
+			VERSION=${VERSION} ARCH=$${arch} nfpm pkg --config .nfpm.yaml --packager rpm --target $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm; \
+			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm ${GITHUB_PACKAGES_DIR}/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm; \
+			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm ${AZURE_PACKAGES_DIR}/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm; \
 		done; \
 		rm -rf ./build/nginx-agent; \
 	done; \
@@ -102,9 +102,9 @@ package: gpg-key $(PACKAGES_DIR) $(GITHUB_PACKAGES_DIR) $(AZURE_PACKAGES_DIR) ##
 			rpm_distro=`echo $$distro | cut -d- -f 1`; \
 			rpm_major=`echo $$distro | cut -d- -f 2`; \
 			rpm_codename="almalinux$$rpm_major"; \
-			VERSION=$(shell echo ${VERSION} | tr -d 'v') ARCH=$${arch} nfpm pkg --config .nfpm.yaml --packager rpm --target $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm; \
-			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm ${GITHUB_PACKAGES_DIR}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm; \
-			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm ${AZURE_PACKAGES_DIR}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm; \
+			VERSION=${VERSION} ARCH=$${arch} nfpm pkg --config .nfpm.yaml --packager rpm --target $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm; \
+			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm ${GITHUB_PACKAGES_DIR}/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm; \
+			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm ${AZURE_PACKAGES_DIR}/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm; \
 		done; \
 		rm -rf ./build/nginx-agent; \
 	done; \
@@ -121,9 +121,9 @@ package: gpg-key $(PACKAGES_DIR) $(GITHUB_PACKAGES_DIR) $(AZURE_PACKAGES_DIR) ##
 			rpm_codename='na'; \
 			if [ "$$rpm_distro" = "rocky" ]; then rpm_codename="rocky$$rpm_major"; fi; \
 			if [ "$$rpm_codename" != "na" ]; then \
-				VERSION=$(shell echo ${VERSION} | tr -d 'v') ARCH=$${arch} nfpm pkg --config .nfpm.yaml --packager rpm --target $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm; \
-				cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm ${GITHUB_PACKAGES_DIR}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm; \
-				cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm ${AZURE_PACKAGES_DIR}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm; \
+				VERSION=${VERSION} ARCH=$${arch} nfpm pkg --config .nfpm.yaml --packager rpm --target $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm; \
+				cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm ${GITHUB_PACKAGES_DIR}/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm; \
+				cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm ${AZURE_PACKAGES_DIR}/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm; \
 			fi; \
 		done; \
 		rm -rf ./build/nginx-agent; \
@@ -136,9 +136,9 @@ package: gpg-key $(PACKAGES_DIR) $(GITHUB_PACKAGES_DIR) $(AZURE_PACKAGES_DIR) ##
 		for version in $(AMAZON_VERSIONS); do \
 			rpm_major=`echo $$version | cut -d- -f 2`; \
 			rpm_codename="amzn$$rpm_major";\
-			VERSION=$(shell echo ${VERSION} | tr -d 'v') ARCH=$${arch} nfpm pkg --config .nfpm.yaml --packager rpm --target $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm; \
-			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm ${GITHUB_PACKAGES_DIR}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm; \
-			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm ${AZURE_PACKAGES_DIR}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').$${rpm_codename}.ngx.$${arch}.rpm; \
+			VERSION=${VERSION} ARCH=$${arch} nfpm pkg --config .nfpm.yaml --packager rpm --target $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm; \
+			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm ${GITHUB_PACKAGES_DIR}/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm; \
+			cp $(PACKAGES_DIR)/rpm/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm ${AZURE_PACKAGES_DIR}/${PACKAGE_PREFIX}-${VERSION}.$${rpm_codename}.ngx.$${arch}.rpm; \
 		done; \
 		rm -rf ./build/nginx-agent; \
 	done; \
@@ -151,9 +151,9 @@ package: gpg-key $(PACKAGES_DIR) $(GITHUB_PACKAGES_DIR) $(AZURE_PACKAGES_DIR) ##
 		GOWORK=off CGO_ENABLED=0 GOARCH=$${goarch} GOOS=linux go build -pgo=auto -ldflags=${LDFLAGS} -o ./build/nginx-agent; \
     	for version in $(APK_VERSIONS); do \
 			if [ ! -d "$(PACKAGES_DIR)/apk/v$${version}/$${arch}" ]; then mkdir -p $(PACKAGES_DIR)/apk/v$${version}/$${arch}; fi; \
-			VERSION=$(shell echo ${VERSION} | tr -d 'v') ARCH=$${arch} nfpm pkg --config .nfpm.yaml --packager apk --target $(PACKAGES_DIR)/apk/v$${version}/$${arch}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').apk; \
-			cp $(PACKAGES_DIR)/apk/v$${version}/$${arch}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').apk ${GITHUB_PACKAGES_DIR}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v')-v$${version}-$${arch}.apk; \
-			cp $(PACKAGES_DIR)/apk/v$${version}/$${arch}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v').apk ${AZURE_PACKAGES_DIR}/${PACKAGE_PREFIX}-$(shell echo ${VERSION} | tr -d 'v')-v$${version}-$${arch}.apk; \
+			VERSION=${VERSION} ARCH=$${arch} nfpm pkg --config .nfpm.yaml --packager apk --target $(PACKAGES_DIR)/apk/v$${version}/$${arch}/${PACKAGE_PREFIX}-${VERSION}.apk; \
+			cp $(PACKAGES_DIR)/apk/v$${version}/$${arch}/${PACKAGE_PREFIX}-${VERSION}.apk ${GITHUB_PACKAGES_DIR}/${PACKAGE_PREFIX}-${VERSION}-v$${version}-$${arch}.apk; \
+			cp $(PACKAGES_DIR)/apk/v$${version}/$${arch}/${PACKAGE_PREFIX}-${VERSION}.apk ${AZURE_PACKAGES_DIR}/${PACKAGE_PREFIX}-${VERSION}-v$${version}-$${arch}.apk; \
 		done; \
 		rm -rf ./build/nginx-agent; \
 	done; \

--- a/scripts/packages/packager/local-entrypoint.sh
+++ b/scripts/packages/packager/local-entrypoint.sh
@@ -27,7 +27,10 @@ chmod +x /staging/usr/local/etc/rc.d/nginx-agent
 
 # Temporary fix until the follow issue is resolved https://github.com/actions/checkout/issues/1169
 git config --global --add safe.directory /nginx-agent
-VERSION="$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')-SNAPSHOT-$(git rev-parse --short HEAD)" envsubst < scripts/packages/manifest > /staging/+MANIFEST
+VERSION_NUMBER="$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"
+COMMIT="$(git rev-parse --short HEAD)"
+
+VERSION="$VERSION_NUMBER-SNAPSHOT-$COMMIT" envsubst < scripts/packages/manifest > /staging/+MANIFEST
 
 mkdir -p ./build
 
@@ -41,7 +44,7 @@ pkg -o ABI="FreeBSD:13:${ABIARCH}" create --format txz \
 # but since version 1.17.0 pkg will now always create a file with the extesion pkg no matter what the format is.
 # See 1.17.0 release notes for more info: https://cgit.freebsd.org/ports/commit/?id=e497a16a286972bfcab908209b11ee6a13d99dc9
 cd build
-ln -s nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT-"$(git rev-parse --short HEAD)".pkg nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-SNAPSHOT-"$(git rev-parse --short HEAD)".txz
+ln -s "nginx-agent-$VERSION_NUMBER-SNAPSHOT-$COMMIT.pkg" "nginx-agent-$VERSION_NUMBER-SNAPSHOT-$COMMIT.txz"
 cd ../
 
 rm -rf /staging

--- a/scripts/packages/packager/signed-entrypoint.sh
+++ b/scripts/packages/packager/signed-entrypoint.sh
@@ -28,7 +28,8 @@ chmod +x staging/usr/local/etc/rc.d/nginx-agent
 
 # Temporary fix until the follow issue is resolved https://github.com/actions/checkout/issues/1169
 git config --global --add safe.directory /nginx-agent
-VERSION="$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')" envsubst < scripts/packages/manifest > staging/+MANIFEST
+VERSION_NUMBER="$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"
+VERSION="$VERSION_NUMBER" envsubst < scripts/packages/manifest > staging/+MANIFEST
 
 for freebsd_abi in $FREEBSD_DISTROS; do \
     mkdir -p ./build/packages/txz/"$freebsd_abi"; \
@@ -43,10 +44,10 @@ for freebsd_abi in $FREEBSD_DISTROS; do \
     # but since version 1.17.0 pkg will now always create a file with the extesion pkg no matter what the format is.
     # See 1.17.0 release notes for more info: https://cgit.freebsd.org/ports/commit/?id=e497a16a286972bfcab908209b11ee6a13d99dc9
     cd build/packages/txz/"$freebsd_abi"; \
-    ln -s nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')".pkg nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')".txz; \
+    ln -s "nginx-agent-$VERSION_NUMBER.pkg" "nginx-agent-$VERSION_NUMBER.txz"; \
     cd ../../../../; \
-    cp ./build/packages/txz/"$freebsd_abi"/nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')".pkg ./build/github/packages/nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-"$freebsd_abi".pkg; \
-    cp ./build/packages/txz/"$freebsd_abi"/nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')".pkg ./build/azure/packages/nginx-agent-"$(git describe --match 'v[0-9]*' --abbrev=0 | tr -d 'v')"-"${freebsd_abi//:}".pkg; \
+    cp "./build/packages/txz/$freebsd_abi/nginx-agent-$VERSION_NUMBER.pkg" "./build/github/packages/nginx-agent-$VERSION_NUMBER-$freebsd_abi.pkg"; \
+    cp "./build/packages/txz/$freebsd_abi/nginx-agent-$VERSION_NUMBER.pkg" "./build/azure/packages/nginx-agent-$VERSION_NUMBER-${freebsd_abi//:}.pkg"; \
 done; \
 
 rm -rf /staging


### PR DESCRIPTION
### Proposed changes

We encountered a bug where the output of
```bash
nginx-agent -v
nginx-agent version 2.36.0-cb1fc63a
```
produced a version without the letter 'v' prepended, which does not conform to correct formatting.

This PR ensures that we always prepend the letter 'v' to the output of the '-v' CLI flag.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
