### PR TITLE
Only send NGINX config context updates if there is a change

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -122,11 +122,15 @@ func GenerateCorrelationID() slog.Attr {
 }
 
 func GetCorrelationID(ctx context.Context) string {
+	return GetCorrelationIDAttr(ctx).Value.String()
+}
+
+func GetCorrelationIDAttr(ctx context.Context) slog.Attr {
 	value, ok := ctx.Value(CorrelationIDContextKey).(slog.Attr)
 	if !ok {
 		slog.Debug("Correlation ID not found in context")
-		return ""
+		return slog.Attr{}
 	}
 
-	return value.Value.String()
+	return value
 }

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -5,7 +5,11 @@
 
 package model
 
-import "github.com/nginx/agent/v3/api/grpc/mpi/v1"
+import (
+	"reflect"
+
+	"github.com/nginx/agent/v3/api/grpc/mpi/v1"
+)
 
 type NginxConfigContext struct {
 	StubStatus string
@@ -14,6 +18,34 @@ type NginxConfigContext struct {
 	Files      []*v1.File
 	AccessLogs []*AccessLog
 	ErrorLogs  []*ErrorLog
+}
+
+func (ncc *NginxConfigContext) Equal(otherNginxConfigContext *NginxConfigContext) bool {
+	if ncc.StubStatus != otherNginxConfigContext.StubStatus {
+		return false
+	}
+
+	if ncc.PlusAPI != otherNginxConfigContext.PlusAPI {
+		return false
+	}
+
+	if ncc.InstanceID != otherNginxConfigContext.InstanceID {
+		return false
+	}
+
+	if len(ncc.Files) != len(otherNginxConfigContext.Files) {
+		return false
+	}
+
+	if !reflect.DeepEqual(ncc.AccessLogs, otherNginxConfigContext.AccessLogs) {
+		return false
+	}
+
+	if !reflect.DeepEqual(ncc.ErrorLogs, otherNginxConfigContext.ErrorLogs) {
+		return false
+	}
+
+	return true
 }
 
 type ConfigApplyMessage struct {

--- a/internal/model/config_test.go
+++ b/internal/model/config_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) F5, Inc.
+//
+// This source code is licensed under the Apache License, Version 2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+
+package model
+
+import (
+	"testing"
+
+	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+var nginxConfigContext = &NginxConfigContext{
+	StubStatus: "",
+	PlusAPI:    "",
+	InstanceID: "12333",
+	Files: []*mpi.File{
+		{
+			FileMeta: &mpi.FileMeta{
+				Name:        "test2",
+				Hash:        "1323",
+				Permissions: "0644",
+				Size:        123,
+			},
+		}, {
+			FileMeta: &mpi.FileMeta{
+				Name:        "test",
+				Hash:        "1323",
+				Permissions: "0644",
+				Size:        123,
+			},
+		},
+	},
+	AccessLogs: []*AccessLog{
+		{
+			Name:   "access1",
+			Format: "something",
+		},
+	},
+	ErrorLogs: []*ErrorLog{
+		{
+			Name: "error",
+		},
+	},
+}
+
+func TestNginxConfigContext_Equal(t *testing.T) {
+	nginxConfigContextWithSameValues := *nginxConfigContext
+
+	nginxConfigContextWithDifferentStubStatus := *nginxConfigContext
+	nginxConfigContextWithDifferentStubStatus.StubStatus = "http://localhost:8080/stub_status"
+
+	nginxConfigContextWithDifferentPlusAPI := *nginxConfigContext
+	nginxConfigContextWithDifferentPlusAPI.PlusAPI = "http://localhost:8080/api"
+
+	nginxConfigContextWithDifferentInstanceID := *nginxConfigContext
+	nginxConfigContextWithDifferentInstanceID.InstanceID = "567"
+
+	nginxConfigContextWithDifferentNumberOfFiles := *nginxConfigContext
+	nginxConfigContextWithDifferentNumberOfFiles.Files = []*mpi.File{}
+
+	nginxConfigContextWithDifferentAccessLogs := *nginxConfigContext
+	nginxConfigContextWithDifferentAccessLogs.AccessLogs = []*AccessLog{}
+
+	nginxConfigContextWithDifferentErrorLogs := *nginxConfigContext
+	nginxConfigContextWithDifferentErrorLogs.ErrorLogs = []*ErrorLog{}
+
+	assert.True(t, nginxConfigContext.Equal(&nginxConfigContextWithSameValues))
+	assert.False(t, nginxConfigContext.Equal(&nginxConfigContextWithDifferentStubStatus))
+	assert.False(t, nginxConfigContext.Equal(&nginxConfigContextWithDifferentPlusAPI))
+	assert.False(t, nginxConfigContext.Equal(&nginxConfigContextWithDifferentInstanceID))
+	assert.False(t, nginxConfigContext.Equal(&nginxConfigContextWithDifferentNumberOfFiles))
+	assert.False(t, nginxConfigContext.Equal(&nginxConfigContextWithDifferentAccessLogs))
+	assert.False(t, nginxConfigContext.Equal(&nginxConfigContextWithDifferentErrorLogs))
+}

--- a/internal/model/config_test.go
+++ b/internal/model/config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
+	"github.com/nginx/agent/v3/test/protos"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,19 +19,10 @@ var nginxConfigContext = &NginxConfigContext{
 	InstanceID: "12333",
 	Files: []*mpi.File{
 		{
-			FileMeta: &mpi.FileMeta{
-				Name:        "test2",
-				Hash:        "1323",
-				Permissions: "0644",
-				Size:        123,
-			},
-		}, {
-			FileMeta: &mpi.FileMeta{
-				Name:        "test",
-				Hash:        "1323",
-				Permissions: "0644",
-				Size:        123,
-			},
+			FileMeta: protos.FileMeta("test1", "fef4e"),
+		},
+		{
+			FileMeta: protos.FileMeta("test2", "vre8e"),
 		},
 	},
 	AccessLogs: []*AccessLog{

--- a/internal/resource/resource_plugin.go
+++ b/internal/resource/resource_plugin.go
@@ -166,7 +166,7 @@ func (r *Resource) handleRollbackWrite(ctx context.Context, msg *bus.Message) {
 
 		r.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: applyResponse})
 		r.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: rollbackResponse})
-		r.messagePipe.Process(ctx, &bus.Message{Topic: bus.RollbackCompleteTopic})
+		r.messagePipe.Process(ctx, &bus.Message{Topic: bus.RollbackCompleteTopic, Data: data.InstanceID})
 
 		return
 	}
@@ -176,7 +176,7 @@ func (r *Resource) handleRollbackWrite(ctx context.Context, msg *bus.Message) {
 		"Config apply failed, rollback successful", data.InstanceID, data.Error.Error())
 
 	r.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: applyResponse})
-	r.messagePipe.Process(ctx, &bus.Message{Topic: bus.RollbackCompleteTopic})
+	r.messagePipe.Process(ctx, &bus.Message{Topic: bus.RollbackCompleteTopic, Data: data.InstanceID})
 }
 
 func (*Resource) createDataPlaneResponse(correlationID string, status mpi.CommandResponse_CommandStatus,

--- a/internal/watcher/instance/nginx_config_parser.go
+++ b/internal/watcher/instance/nginx_config_parser.go
@@ -63,6 +63,13 @@ func (ncp *NginxConfigParser) Parse(ctx context.Context, instance *mpi.Instance)
 		return nil, fmt.Errorf("config path %s is not in allowed directories", configPath)
 	}
 
+	slog.DebugContext(
+		ctx,
+		"Parsing NGINX config",
+		"file_path", configPath,
+		"instance_id", instance.GetInstanceMeta().GetInstanceId(),
+	)
+
 	payload, err := crossplane.Parse(configPath,
 		&crossplane.ParseOptions{
 			SingleFile:         false,
@@ -368,6 +375,9 @@ func (ncp *NginxConfigParser) hasAdditionArguments(args []string) bool {
 
 func (ncp *NginxConfigParser) stubStatusAPICallback(ctx context.Context, parent, current *crossplane.Directive) string {
 	urls := ncp.urlsForLocationDirective(parent, current, stubStatusAPIDirective)
+	if len(urls) > 0 {
+		slog.DebugContext(ctx, "Potential stub_status urls", "urls", urls)
+	}
 
 	for _, url := range urls {
 		if ncp.pingStubStatusAPIEndpoint(ctx, url) {
@@ -421,6 +431,9 @@ func (ncp *NginxConfigParser) pingStubStatusAPIEndpoint(ctx context.Context, sta
 
 func (ncp *NginxConfigParser) plusAPICallback(ctx context.Context, parent, current *crossplane.Directive) string {
 	urls := ncp.urlsForLocationDirective(parent, current, plusAPIDirective)
+	if len(urls) > 0 {
+		slog.DebugContext(ctx, "Potential Plus API urls", "urls", urls)
+	}
 
 	for _, url := range urls {
 		if ncp.pingPlusAPIEndpoint(ctx, url) {

--- a/internal/watcher/watcher_plugin.go
+++ b/internal/watcher/watcher_plugin.go
@@ -140,6 +140,8 @@ func (w *Watcher) handleConfigApplySuccess(ctx context.Context, msg *bus.Message
 	data, ok := msg.Data.(*mpi.Instance)
 	if !ok {
 		slog.ErrorContext(ctx, "Unable to cast message payload to Instance", "payload", msg.Data)
+
+		return
 	}
 
 	w.instancesWithConfigApplyInProgress = slices.DeleteFunc(
@@ -156,6 +158,8 @@ func (w *Watcher) handleRollbackComplete(ctx context.Context, msg *bus.Message) 
 	instanceID, ok := msg.Data.(string)
 	if !ok {
 		slog.ErrorContext(ctx, "Unable to cast message payload to string", "payload", msg.Data)
+
+		return
 	}
 
 	w.instancesWithConfigApplyInProgress = slices.DeleteFunc(

--- a/internal/watcher/watcher_plugin.go
+++ b/internal/watcher/watcher_plugin.go
@@ -8,6 +8,7 @@ package watcher
 import (
 	"context"
 	"log/slog"
+	"slices"
 
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
 
@@ -25,14 +26,15 @@ import (
 // nolint
 type (
 	Watcher struct {
-		messagePipe               bus.MessagePipeInterface
-		agentConfig               *config.Config
-		instanceWatcherService    instanceWatcherServiceInterface
-		healthWatcherService      *health.HealthWatcherService
-		instanceUpdatesChannel    chan instance.InstanceUpdatesMessage
-		nginxConfigContextChannel chan instance.NginxConfigContextMessage
-		instanceHealthChannel     chan health.InstanceHealthMessage
-		cancel                    context.CancelFunc
+		messagePipe                        bus.MessagePipeInterface
+		agentConfig                        *config.Config
+		instanceWatcherService             instanceWatcherServiceInterface
+		healthWatcherService               *health.HealthWatcherService
+		instanceUpdatesChannel             chan instance.InstanceUpdatesMessage
+		nginxConfigContextChannel          chan instance.NginxConfigContextMessage
+		instanceHealthChannel              chan health.InstanceHealthMessage
+		cancel                             context.CancelFunc
+		instancesWithConfigApplyInProgress []string
 	}
 
 	instanceWatcherServiceInterface interface {
@@ -49,12 +51,13 @@ var _ bus.Plugin = (*Watcher)(nil)
 
 func NewWatcher(agentConfig *config.Config) *Watcher {
 	return &Watcher{
-		agentConfig:               agentConfig,
-		instanceWatcherService:    instance.NewInstanceWatcherService(agentConfig),
-		healthWatcherService:      health.NewHealthWatcherService(agentConfig),
-		instanceUpdatesChannel:    make(chan instance.InstanceUpdatesMessage),
-		nginxConfigContextChannel: make(chan instance.NginxConfigContextMessage),
-		instanceHealthChannel:     make(chan health.InstanceHealthMessage),
+		agentConfig:                        agentConfig,
+		instanceWatcherService:             instance.NewInstanceWatcherService(agentConfig),
+		healthWatcherService:               health.NewHealthWatcherService(agentConfig),
+		instanceUpdatesChannel:             make(chan instance.InstanceUpdatesMessage),
+		nginxConfigContextChannel:          make(chan instance.NginxConfigContextMessage),
+		instanceHealthChannel:              make(chan health.InstanceHealthMessage),
+		instancesWithConfigApplyInProgress: []string{},
 	}
 }
 
@@ -92,14 +95,12 @@ func (*Watcher) Info() *bus.Info {
 
 func (w *Watcher) Process(ctx context.Context, msg *bus.Message) {
 	switch msg.Topic {
+	case bus.ConfigApplyRequestTopic:
+		w.handleConfigApplyRequest(ctx, msg)
 	case bus.ConfigApplySuccessfulTopic:
-		data, ok := msg.Data.(*mpi.Instance)
-		if !ok {
-			slog.ErrorContext(ctx, "Unable to cast message payload to Instance", "payload", msg.Data)
-
-			return
-		}
-		w.instanceWatcherService.ReparseConfig(ctx, data)
+		w.handleConfigApplySuccess(ctx, msg)
+	case bus.RollbackCompleteTopic:
+		w.handleRollbackComplete(ctx, msg)
 	default:
 		slog.DebugContext(ctx, "Watcher plugin unknown topic", "topic", msg.Topic)
 	}
@@ -107,8 +108,62 @@ func (w *Watcher) Process(ctx context.Context, msg *bus.Message) {
 
 func (*Watcher) Subscriptions() []string {
 	return []string{
+		bus.ConfigApplyRequestTopic,
 		bus.ConfigApplySuccessfulTopic,
+		bus.RollbackCompleteTopic,
 	}
+}
+
+func (w *Watcher) handleConfigApplyRequest(ctx context.Context, msg *bus.Message) {
+	managementPlaneRequest, ok := msg.Data.(*mpi.ManagementPlaneRequest)
+	if !ok {
+		slog.ErrorContext(ctx, "Unable to cast message payload to *mpi.ManagementPlaneRequest",
+			"payload", msg.Data)
+
+		return
+	}
+
+	request, requestOk := managementPlaneRequest.GetRequest().(*mpi.ManagementPlaneRequest_ConfigApplyRequest)
+	if !requestOk {
+		slog.ErrorContext(ctx, "Unable to cast message payload to *mpi.ManagementPlaneRequest_ConfigApplyRequest",
+			"payload", msg.Data)
+
+		return
+	}
+
+	instanceID := request.ConfigApplyRequest.GetOverview().GetConfigVersion().GetInstanceId()
+
+	w.instancesWithConfigApplyInProgress = append(w.instancesWithConfigApplyInProgress, instanceID)
+}
+
+func (w *Watcher) handleConfigApplySuccess(ctx context.Context, msg *bus.Message) {
+	data, ok := msg.Data.(*mpi.Instance)
+	if !ok {
+		slog.ErrorContext(ctx, "Unable to cast message payload to Instance", "payload", msg.Data)
+	}
+
+	w.instancesWithConfigApplyInProgress = slices.DeleteFunc(
+		w.instancesWithConfigApplyInProgress,
+		func(element string) bool {
+			return element == data.GetInstanceMeta().GetInstanceId()
+		},
+	)
+
+	w.instanceWatcherService.ReparseConfig(ctx, data)
+}
+
+func (w *Watcher) handleRollbackComplete(ctx context.Context, msg *bus.Message) {
+	instanceID, ok := msg.Data.(string)
+	if !ok {
+		slog.ErrorContext(ctx, "Unable to cast message payload to string", "payload", msg.Data)
+	}
+
+	w.instancesWithConfigApplyInProgress = slices.DeleteFunc(
+		w.instancesWithConfigApplyInProgress,
+		func(element string) bool {
+			return element == instanceID
+		},
+	)
 }
 
 func (w *Watcher) monitorWatchers(ctx context.Context) {
@@ -120,16 +175,18 @@ func (w *Watcher) monitorWatchers(ctx context.Context) {
 			newCtx := context.WithValue(ctx, logger.CorrelationIDContextKey, message.CorrelationID)
 			w.handleInstanceUpdates(newCtx, message)
 		case message := <-w.nginxConfigContextChannel:
-			newCtx := context.WithValue(ctx, logger.CorrelationIDContextKey, message.CorrelationID)
-			slog.DebugContext(
-				newCtx,
-				"Updated NGINX config context",
-				"nginx_config_context", message.NginxConfigContext,
-			)
-			w.messagePipe.Process(
-				newCtx,
-				&bus.Message{Topic: bus.NginxConfigUpdateTopic, Data: message.NginxConfigContext},
-			)
+			if !slices.Contains(w.instancesWithConfigApplyInProgress, message.NginxConfigContext.InstanceID) {
+				newCtx := context.WithValue(ctx, logger.CorrelationIDContextKey, message.CorrelationID)
+				slog.DebugContext(
+					newCtx,
+					"Updated NGINX config context",
+					"nginx_config_context", message.NginxConfigContext,
+				)
+				w.messagePipe.Process(
+					newCtx,
+					&bus.Message{Topic: bus.NginxConfigUpdateTopic, Data: message.NginxConfigContext},
+				)
+			}
 		case message := <-w.instanceHealthChannel:
 			newCtx := context.WithValue(ctx, logger.CorrelationIDContextKey, message.CorrelationID)
 			w.messagePipe.Process(newCtx, &bus.Message{


### PR DESCRIPTION
### Proposed changes

- Added checks to ensure that we only send NGINX config context updates if there is a change to the NGINX config
- Added checks to prevent NGINX config context updates from being sent while a config apply is in progress
- Added extra debug logging

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
