### PR TITLE
docs: fix github links in changelog

### DIFF
--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -10,7 +10,7 @@ docs: "DOCS-1093"
 See the list of supported Operating Systems and architectures in the [Technical Specifications]({{< relref "./technical-specifications.md" >}}).
 
 ---
-## Release [v2.36.1](https//github.com/nginx/agent/releases/tag/v2.36.1)
+## Release [v2.36.1](https://github.com/nginx/agent/releases/tag/v2.36.1)
 
 ### 🌟 Highlights
 
@@ -23,7 +23,7 @@ We have made the following maintenance-related minor changes:
 - Added version regex to parse the logs to see if matches vsemvar format by [@oliveromahony](https://github.com/oliveromahony) in [#747](https://github.com/nginx/agent/pull/747)
 
 ---
-## Release [v2.36.0](https//github.com/nginx/agent/releases/tag/v2.36.0)
+## Release [v2.36.0](https://github.com/nginx/agent/releases/tag/v2.36.0)
 
 ### 🐛 Bug Fixes
 
@@ -44,7 +44,7 @@ We have made the following updates to the documentation:
 - Upgrade crossplane by [@oliveromahony](https://github.com/oliveromahony) in [#737](https://github.com/nginx/agent/pull/737)
 
 ---
-## Release [v2.35.1](https//github.com/nginx/agent/releases/tag/v2.35.1)
+## Release [v2.35.1](https://github.com/nginx/agent/releases/tag/v2.35.1)
 
 ### 🐛 Bug Fixes
 
@@ -68,7 +68,7 @@ We have made the following maintenance-related minor changes:
 - More detailed test for env variables migration by [@oliveromahony](https://github.com/oliveromahony) in [#709](https://github.com/nginx/agent/pull/709)
 
 ---
-## Release [v2.35.0](https//github.com/nginx/agent/releases/tag/v2.35.0)
+## Release [v2.35.0](https://github.com/nginx/agent/releases/tag/v2.35.0)
 
 ### 🌟 Highlights
 
@@ -88,7 +88,7 @@ We have made the following updates to the documentation:
 - Add Ubuntu Noble 24.04 LTS support by [@Dean-Coakley](https://github.com/Dean-Coakley) in [#682](https://github.com/nginx/agent/pull/682)
 
 ---
-## Release [v2.34.1](https//github.com/nginx/agent/releases/tag/v2.34.1)
+## Release [v2.34.1](https://github.com/nginx/agent/releases/tag/v2.34.1)
 
 ### 🐛 Bug Fixes
 
@@ -103,7 +103,7 @@ We have made the following updates to the documentation:
 - Update changelog for release 2.34 by [@ADubhlaoich](https://github.com/ADubhlaoich) in [#693](https://github.com/nginx/agent/pull/693)
 
 ---
-## Release [v2.34.0](https//github.com/nginx/agent/releases/tag/v2.34.0)
+## Release [v2.34.0](https://github.com/nginx/agent/releases/tag/v2.34.0)
 
 ### 🌟 Highlights
 
@@ -139,7 +139,7 @@ We have made the following maintenance-related minor changes:
 - Add additional checks in chunking functionality by [@dhurley](https://github.com/dhurley) in [#671](https://github.com/nginx/agent/pull/671)
 
 ---
-## Release [v2.33.0](https//github.com/nginx/agent/releases/tag/v2.33.0)
+## Release [v2.33.0](https://github.com/nginx/agent/releases/tag/v2.33.0)
 
 ### 🌟 Highlights
 
@@ -175,7 +175,7 @@ We have made the following maintenance-related minor changes:
 - Add logging to NGINX API http requests by [@dhurley](https://github.com/dhurley) in [#605](https://github.com/nginx/agent/pull/605)
 
 ---
-## Release [v2.32.2](https//github.com/nginx/agent/releases/tag/v2.32.2)
+## Release [v2.32.2](https://github.com/nginx/agent/releases/tag/v2.32.2)
 
 ### 🌟 Highlights
 
@@ -202,7 +202,7 @@ We have made the following updates to the documentation:
 - fix: add additional container checks during instance registration by [@mattdesmarais](https://github.com/mattdesmarais) in [#592](https://github.com/nginx/agent/pull/592)
 
 ---
-## Release [v2.32.1](https//github.com/nginx/agent/releases/tag/v2.32.1)
+## Release [v2.32.1](https://github.com/nginx/agent/releases/tag/v2.32.1)
 
 ### 🚀 Features
 
@@ -233,7 +233,7 @@ We have made the following maintenance-related minor changes:
 - bump vulnerable version of buildkit by [@oliveromahony](https://github.com/oliveromahony) in [#564](https://github.com/nginx/agent/pull/564)
 
 ---
-## Release [v2.32.0](https//github.com/nginx/agent/releases/tag/v2.32.0)
+## Release [v2.32.0](https://github.com/nginx/agent/releases/tag/v2.32.0)
 
 ### 🚀 Features
 

--- a/site/go.mod
+++ b/site/go.mod
@@ -2,4 +2,4 @@ module github.com/nginx/agent/site
 
 go 1.18
 
-require github.com/nginxinc/nginx-hugo-theme v0.40.8 // indirect
+require github.com/nginxinc/nginx-hugo-theme v0.41.9 // indirect

--- a/site/go.sum
+++ b/site/go.sum
@@ -10,3 +10,5 @@ github.com/nginxinc/nginx-hugo-theme v0.35.0 h1:7XB2GMy6qeJgKEJy9wOS3SYKYpfvLW3/
 github.com/nginxinc/nginx-hugo-theme v0.35.0/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
 github.com/nginxinc/nginx-hugo-theme v0.40.8 h1:VtoSAtf9k67tI2jzbLRo0oFBAMHZBUPRh/xV4MYullI=
 github.com/nginxinc/nginx-hugo-theme v0.40.8/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
+github.com/nginxinc/nginx-hugo-theme v0.41.9 h1:8TKgjocF95ZSRP0PHkyvk9TyJvwPrdz1k0FB5RfKT3I=
+github.com/nginxinc/nginx-hugo-theme v0.41.9/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=


### PR DESCRIPTION
### Proposed changes

Links to releases in the changelog are missing a `:` after https.

(This is an issue in the template for the changelog script that has been fixed separately)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
