### PR TITLE
Fix post install script for when no nginx instance is installed

### DIFF
--- a/scripts/packages/postinstall.sh
+++ b/scripts/packages/postinstall.sh
@@ -24,7 +24,7 @@ WORKER_USER=""
 AGENT_GROUP="nginx-agent"
 
 detect_nginx_users() {
-    if command -V systemctl >/dev/null 2>&1 && [ "$(cat /proc/1/comm)" = "systemd" ]; then
+    if command -V systemctl >/dev/null 2>&1 && systemctl status nginx >/dev/null 2>&1 && [ "$(cat /proc/1/comm)" = "systemd" ]; then
         printf "PostInstall: Reading NGINX systemctl unit file for user information\n"
         nginx_unit_file=$(systemctl status nginx | grep -Po "\(\K\/.*service")
         pid_file=$(grep -Po "PIDFile=\K.*$" "${nginx_unit_file}")


### PR DESCRIPTION
### Proposed changes

Fix post install script for when no nginx instance is installed.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
