### PR TITLE
Improve chunking benchmarks

### DIFF
--- a/internal/file/file_manager_service.go
+++ b/internal/file/file_manager_service.go
@@ -290,15 +290,14 @@ func (fms *FileManagerService) UpdateMultipleFiles(
 	backOffCtx, backoffCancel := context.WithTimeout(ctx, fms.agentConfig.Common.MaxElapsedTime)
 	defer backoffCancel()
 
+	if fms.fileServiceClient == nil {
+		return errors.New("file service client is not initialized")
+	}
+
+	if !fms.isConnected.Load() {
+		return errors.New("CreateConnection rpc has not being called yet")
+	}
 	sendUpdateFile := func() (*mpi.UpdateFileResponse, error) {
-		if fms.fileServiceClient == nil {
-			return nil, errors.New("file service client is not initialized")
-		}
-
-		if !fms.isConnected.Load() {
-			return nil, errors.New("CreateConnection rpc has not being called yet")
-		}
-
 		g := errgroup.Group{}
 
 		for _, fileToUpdate := range filesToUpdate {
@@ -345,15 +344,14 @@ func (fms *FileManagerService) UploadMultipleFiles(
 	backOffCtx, backoffCancel := context.WithTimeout(ctx, fms.agentConfig.Common.MaxElapsedTime)
 	defer backoffCancel()
 
+	if fms.fileServiceClient == nil {
+		errors.New("file service client is not initialized")
+	}
+
+	if !fms.isConnected.Load() {
+		errors.New("CreateConnection rpc has not being called yet")
+	}
 	sendUpdateFile := func() (*mpi.UpdateFileResponse, error) {
-		if fms.fileServiceClient == nil {
-			return nil, errors.New("file service client is not initialized")
-		}
-
-		if !fms.isConnected.Load() {
-			return nil, errors.New("CreateConnection rpc has not being called yet")
-		}
-
 		client, uploadFileError := fms.fileServiceClient.UploadFile(ctx)
 		if uploadFileError != nil {
 			return nil, uploadFileError

--- a/internal/file/file_manager_service_benchmark_test.go
+++ b/internal/file/file_manager_service_benchmark_test.go
@@ -7,6 +7,7 @@ package file
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"path/filepath"
 	"testing"
@@ -21,48 +22,78 @@ import (
 
 var configFilePaths = []string{
 	"../../test/config/nginx/nginx.conf",
-	"../../test/config/nginx/nginx-with-1k-lines.conf",
-	"../../test/config/nginx/nginx-with-2k-lines.conf",
+	// "../../test/config/nginx/nginx-with-1k-lines.conf",
+	//"../../test/config/nginx/nginx-with-2k-lines.conf",
 	"../../test/config/nginx/nginx-with-3k-lines.conf",
-	"../../test/config/nginx/nginx-with-10k-lines.conf",
+	//"../../test/config/nginx/nginx-with-10k-lines.conf",
 	"../../test/config/nginx/nginx-10MB.conf",
 	"../../test/config/nginx/nginx-100MB.conf",
+	// "../../test/config/nginx/nginx-200MB.conf",
+}
+
+var chunksizes = []int{
+	0,           // no chunking
+	4 * 1024,    // the only thing tested so far
+	1024 * 1024, // a larger chunk size to be a bit closer to (1/4) the default gRPC message size
+}
+
+// runAllFilePaths will run the given test function foreach configFilePaths.
+// This checks the file exists and builds the FileMeta
+func runAllFilePaths(b *testing.B, tester func(b *testing.B, fileMeta *mpi.FileMeta)) {
+	b.Helper()
+	for _, configFilePath := range configFilePaths {
+		configFilePath := configFilePath
+		absFilePath, err := filepath.Abs(configFilePath)
+		require.NoError(b, err)
+
+		fileMeta, err := files.GetFileMeta(absFilePath)
+		require.NoError(b, err)
+		name := filepath.Base(configFilePath)
+		b.Run(name, func(b *testing.B) {
+			tester(b, fileMeta)
+		})
+	}
+}
+
+// runAllChunkSizes runs the given test function foreach chunksize
+func runAllChunkSizes(b *testing.B, tester func(b *testing.B, chunksize int)) {
+	b.Helper()
+	for _, chunksize := range chunksizes {
+		chunksize := chunksize
+		chunking := "chunk:off "
+		if chunksize > 0 {
+			chunking = fmt.Sprintf("chunk:%v ", chunksize)
+		}
+		b.Run(chunking, func(b *testing.B) {
+			tester(b, chunksize)
+		})
+	}
 }
 
 func BenchmarkFileManagerService_UpdateFile_RPC(b *testing.B) {
 	slog.SetLogLoggerLevel(slog.LevelError)
-	
+
 	ctx := context.Background()
 	agentConfig := types.AgentConfig()
 
 	grpcConnection, err := grpc.NewGrpcConnection(ctx, agentConfig)
 	require.NoError(b, err)
-	
+
 	fileManagerService := NewFileManagerService(grpcConnection.FileServiceClient(), agentConfig)
 	fileManagerService.isConnected.Store(true)
 
-	for _, configFilePath := range configFilePaths {
-		func(configFilePath string) {
-			absFilePath, err := filepath.Abs(configFilePath)
+	runAllFilePaths(b, func(b *testing.B, fileMeta *mpi.FileMeta) {
+		for i := 0; i < b.N; i++ {
+			err := fileManagerService.UpdateFile(
+				ctx,
+				"123",
+				&mpi.File{
+					FileMeta: fileMeta,
+				},
+			)
 			require.NoError(b, err)
-
-			fileMeta, err := files.GetFileMeta(absFilePath)
-			require.NoError(b, err)
-			 
-			b.Run(configFilePath, func(bb *testing.B) {
-				for i := 0; i < bb.N; i++ {
-					err := fileManagerService.UpdateFile(
-						ctx,
-						"123",
-						&mpi.File{
-							FileMeta: fileMeta,
-						},
-					)
-					require.NoError(bb, err)
-				}
-			})
-		}(configFilePath)
-	}
+		}
+	})
 }
 
 func BenchmarkFileManagerService_UploadFile_Stream(b *testing.B) {
@@ -74,269 +105,142 @@ func BenchmarkFileManagerService_UploadFile_Stream(b *testing.B) {
 
 	grpcConnection, err := grpc.NewGrpcConnection(ctx, agentConfig)
 	require.NoError(b, err)
-	
+
 	fileManagerService := NewFileManagerService(grpcConnection.FileServiceClient(), agentConfig)
 	fileManagerService.isConnected.Store(true)
 
-	for _, configFilePath := range configFilePaths {
-		func(configFilePath string) {
-			absFilePath, err := filepath.Abs(configFilePath)
-			require.NoError(b, err)
-
-			fileMeta, err := files.GetFileMeta(absFilePath)
-			require.NoError(b, err)
-			 
-			b.Run(configFilePath, func(bb *testing.B) {
-				for i := 0; i < bb.N; i++ {
-					err := fileManagerService.UploadFile(
-						ctx,
-						"123",
-						&mpi.File{
-							FileMeta: fileMeta,
-						},
-						false,
-					)
-					require.NoError(bb, err)
-				}
-			})
-		}(configFilePath)
-	}
-}
-
-
-func BenchmarkFileManagerService_UploadFile_chunked_Stream(b *testing.B) {
-	slog.SetLogLoggerLevel(slog.LevelError)
-	
-	ctx := context.Background()
-	agentConfig := types.AgentConfig()
-
-	grpcConnection, err := grpc.NewGrpcConnection(ctx, agentConfig)
-	require.NoError(b, err)
-	
-	fileManagerService := NewFileManagerService(grpcConnection.FileServiceClient(), agentConfig)
-	fileManagerService.isConnected.Store(true)
-
-	for _, configFilePath := range configFilePaths {
-		func(configFilePath string) {
-			absFilePath, err := filepath.Abs(configFilePath)
-			require.NoError(b, err)
-
-			fileMeta, err := files.GetFileMeta(absFilePath)
-			require.NoError(b, err)
-			 
-			b.Run(configFilePath, func(bb *testing.B) {
-				for i := 0; i < bb.N; i++ {
-					err := fileManagerService.UploadFile(
-						ctx,
-						"123",
-						&mpi.File{
-							FileMeta: fileMeta,
-						},
-						true,
-					)
-					require.NoError(bb, err)
-				}
-			})
-		}(configFilePath)
-	}
+	runAllFilePaths(b, func(b *testing.B, fileMeta *mpi.FileMeta) {
+		runAllChunkSizes(b, func(b *testing.B, chunksize int) {
+			for i := 0; i < b.N; i++ {
+				err := fileManagerService.UploadFile(
+					ctx,
+					"123",
+					&mpi.File{
+						FileMeta: fileMeta,
+					},
+					chunksize,
+				)
+				require.NoError(b, err)
+			}
+		})
+	})
 }
 
 func BenchmarkFileManagerService_UpdateMultipleFiles_1000_files_RPC(b *testing.B) {
 	slog.SetLogLoggerLevel(slog.LevelError)
-	
+
 	ctx := context.Background()
 	agentConfig := types.AgentConfig()
 
 	grpcConnection, err := grpc.NewGrpcConnection(ctx, agentConfig)
 	require.NoError(b, err)
-	
+
 	fileManagerService := NewFileManagerService(grpcConnection.FileServiceClient(), agentConfig)
 	fileManagerService.isConnected.Store(true)
 
-	for _, configFilePath := range configFilePaths {
-		func(configFilePath string) {
-			absFilePath, err := filepath.Abs(configFilePath)
-			require.NoError(b, err)
-
-			fileMeta, err := files.GetFileMeta(absFilePath)
-			require.NoError(b, err)
-
-			files := []*mpi.File{}
-			for range 1000 {
-				files = append(files, &mpi.File{
-					FileMeta: fileMeta,
-				})
-			}
-			 
-			b.Run(configFilePath, func(bb *testing.B) {
-				for i := 0; i < bb.N; i++ {
-					err := fileManagerService.UpdateMultipleFiles(
-						ctx,
-						"123",
-						files,
-					)
-					require.NoError(bb, err)
-				}
+	runAllFilePaths(b, func(b *testing.B, fileMeta *mpi.FileMeta) {
+		fileList := []*mpi.File{}
+		for range 1000 {
+			fileList = append(fileList, &mpi.File{
+				FileMeta: fileMeta,
 			})
-		}(configFilePath)
-	}
+		}
+		// our other test has the "build the 1000 list outside the body, so replicate that here"
+		b.Run("body", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				err := fileManagerService.UpdateMultipleFiles(
+					ctx,
+					"123",
+					fileList,
+				)
+				require.NoError(b, err)
+			}
+		})
+	})
 }
 
 func BenchmarkFileManagerService_UploadMultipleFiles_1000_files_Stream(b *testing.B) {
 	slog.SetLogLoggerLevel(slog.LevelError)
-	
+
 	ctx := context.Background()
 	agentConfig := types.AgentConfig()
 
 	grpcConnection, err := grpc.NewGrpcConnection(ctx, agentConfig)
 	require.NoError(b, err)
-	
+
 	fileManagerService := NewFileManagerService(grpcConnection.FileServiceClient(), agentConfig)
 	fileManagerService.isConnected.Store(true)
 
-	for _, configFilePath := range configFilePaths {
-		func(configFilePath string) {
-			absFilePath, err := filepath.Abs(configFilePath)
-			require.NoError(b, err)
-
-			fileMeta, err := files.GetFileMeta(absFilePath)
-			require.NoError(b, err)
-
-			files := []*mpi.File{}
-			for range 1000 {
-				files = append(files, &mpi.File{
-					FileMeta: fileMeta,
-				})
-			}
-			 
-			b.Run(configFilePath, func(bb *testing.B) {
-				for i := 0; i < bb.N; i++ {
-					err := fileManagerService.UploadMultipleFiles(
-						ctx,
-						"123",
-						files,
-						false,
-					)
-					require.NoError(bb, err)
-				}
+	runAllFilePaths(b, func(b *testing.B, fileMeta *mpi.FileMeta) {
+		files := []*mpi.File{}
+		for range 1000 {
+			files = append(files, &mpi.File{
+				FileMeta: fileMeta,
 			})
-		}(configFilePath)
-	}
-}
-
-func BenchmarkFileManagerService_UploadMultipleFiles_1000_files_chunked_Stream(b *testing.B) {
-	slog.SetLogLoggerLevel(slog.LevelError)
-	
-	ctx := context.Background()
-	agentConfig := types.AgentConfig()
-
-	grpcConnection, err := grpc.NewGrpcConnection(ctx, agentConfig)
-	require.NoError(b, err)
-	
-	fileManagerService := NewFileManagerService(grpcConnection.FileServiceClient(), agentConfig)
-	fileManagerService.isConnected.Store(true)
-
-	for _, configFilePath := range configFilePaths {
-		func(configFilePath string) {
-			absFilePath, err := filepath.Abs(configFilePath)
-			require.NoError(b, err)
-
-			fileMeta, err := files.GetFileMeta(absFilePath)
-			require.NoError(b, err)
-
-			files := []*mpi.File{}
-			for range 1000 {
-				files = append(files, &mpi.File{
-					FileMeta: fileMeta,
-				})
+		}
+		runAllChunkSizes(b, func(b *testing.B, chunksize int) {
+			for i := 0; i < b.N; i++ {
+				err := fileManagerService.UploadMultipleFiles(
+					ctx,
+					"123",
+					files,
+					chunksize,
+				)
+				require.NoError(b, err)
 			}
-			 
-			b.Run(configFilePath, func(bb *testing.B) {
-				for i := 0; i < bb.N; i++ {
-					err := fileManagerService.UploadMultipleFiles(
-						ctx,
-						"123",
-						files,
-						true,
-					)
-					require.NoError(bb, err)
-				}
-			})
-		}(configFilePath)
-	}
+		})
+	})
 }
 
 func BenchmarkFileManagerService_GetFile_RPC(b *testing.B) {
 	slog.SetLogLoggerLevel(slog.LevelError)
-	
+
 	ctx := context.Background()
 	agentConfig := types.AgentConfig()
 
 	grpcConnection, err := grpc.NewGrpcConnection(ctx, agentConfig)
 	require.NoError(b, err)
-	
+
 	fileManagerService := NewFileManagerService(grpcConnection.FileServiceClient(), agentConfig)
 	fileManagerService.isConnected.Store(true)
 
-	for _, configFilePath := range configFilePaths {
-		func(configFilePath string) {
-			absFilePath, err := filepath.Abs(configFilePath)
+	runAllFilePaths(b, func(b *testing.B, fileMeta *mpi.FileMeta) {
+		for i := 0; i < b.N; i++ {
+			err := fileManagerService.GetFile(
+				ctx,
+				"123",
+				&mpi.File{
+					FileMeta: fileMeta,
+				},
+			)
 			require.NoError(b, err)
-
-			fileMeta, err := files.GetFileMeta(absFilePath)
-			fileMeta.Name = filepath.Join("/", filepath.Base(configFilePath))
-			require.NoError(b, err)
-			 
-			b.Run(configFilePath, func(bb *testing.B) {
-				for i := 0; i < bb.N; i++ {
-					err := fileManagerService.GetFile(
-						ctx,
-						"123",
-						&mpi.File{
-							FileMeta: fileMeta,
-						},
-					)
-					require.NoError(bb, err)
-				}
-			})
-		}(configFilePath)
-	}
+		}
+	})
 }
 
 func BenchmarkFileManagerService_DownloadFile_Stream(b *testing.B) {
 	slog.SetLogLoggerLevel(slog.LevelError)
-	
+
 	ctx := context.Background()
 	agentConfig := types.AgentConfig()
 	agentConfig.Common.MaxElapsedTime = time.Hour
 
 	grpcConnection, err := grpc.NewGrpcConnection(ctx, agentConfig)
 	require.NoError(b, err)
-	
+
 	fileManagerService := NewFileManagerService(grpcConnection.FileServiceClient(), agentConfig)
 	fileManagerService.isConnected.Store(true)
 
-	for _, configFilePath := range configFilePaths {
-		func(configFilePath string) {
-			absFilePath, err := filepath.Abs(configFilePath)
+	runAllFilePaths(b, func(b *testing.B, fileMeta *mpi.FileMeta) {
+		for i := 0; i < b.N; i++ {
+			err := fileManagerService.DownloadFile(
+				ctx,
+				"123",
+				&mpi.File{
+					FileMeta: fileMeta,
+				},
+			)
 			require.NoError(b, err)
-
-			fileMeta, err := files.GetFileMeta(absFilePath)
-			fileMeta.Name = filepath.Join("/", filepath.Base(configFilePath))
-			require.NoError(b, err)
-			 
-			b.Run(configFilePath, func(bb *testing.B) {
-				for i := 0; i < bb.N; i++ {
-					err := fileManagerService.DownloadFile(
-						ctx,
-						"123",
-						&mpi.File{
-							FileMeta: fileMeta,
-						},
-					)
-					require.NoError(bb, err)
-				}
-			})
-		}(configFilePath)
-	}
+		}
+	})
 }


### PR DESCRIPTION
- When building chunks read them from disk in chunks rather than reading the entire file and chunk in memory
- test a few chunksizes

I also refactored the test setup a bit to make it easier to run foreach fof these.

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
