### PR TITLE
Add MaxRecvMsgSize and MaxSendMsgSize to client and server options

### DIFF
--- a/sdk/grpc/grpc.go
+++ b/sdk/grpc/grpc.go
@@ -12,6 +12,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"math"
 	"os"
 	"time"
 
@@ -42,6 +43,10 @@ var (
 			Timeout:             60 * time.Second,
 			PermitWithoutStream: true,
 		}),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(math.MaxInt),
+			grpc.MaxCallSendMsgSize(math.MaxInt),
+		),
 	}
 
 	DefaultServerDialOptions = []grpc.ServerOption{
@@ -51,6 +56,8 @@ var (
 			MinTime:             60 * time.Second,
 			PermitWithoutStream: true,
 		}),
+		grpc.MaxSendMsgSize(math.MaxInt),
+		grpc.MaxRecvMsgSize(math.MaxInt),
 	}
 )
 

--- a/test/integration/vendor/github.com/nginx/agent/sdk/v2/grpc/grpc.go
+++ b/test/integration/vendor/github.com/nginx/agent/sdk/v2/grpc/grpc.go
@@ -12,6 +12,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"math"
 	"os"
 	"time"
 
@@ -42,6 +43,10 @@ var (
 			Timeout:             60 * time.Second,
 			PermitWithoutStream: true,
 		}),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(math.MaxInt),
+			grpc.MaxCallSendMsgSize(math.MaxInt),
+		),
 	}
 
 	DefaultServerDialOptions = []grpc.ServerOption{
@@ -51,6 +56,8 @@ var (
 			MinTime:             60 * time.Second,
 			PermitWithoutStream: true,
 		}),
+		grpc.MaxSendMsgSize(math.MaxInt),
+		grpc.MaxRecvMsgSize(math.MaxInt),
 	}
 )
 

--- a/test/performance/vendor/github.com/nginx/agent/sdk/v2/grpc/grpc.go
+++ b/test/performance/vendor/github.com/nginx/agent/sdk/v2/grpc/grpc.go
@@ -12,6 +12,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"math"
 	"os"
 	"time"
 
@@ -42,6 +43,10 @@ var (
 			Timeout:             60 * time.Second,
 			PermitWithoutStream: true,
 		}),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(math.MaxInt),
+			grpc.MaxCallSendMsgSize(math.MaxInt),
+		),
 	}
 
 	DefaultServerDialOptions = []grpc.ServerOption{
@@ -51,6 +56,8 @@ var (
 			MinTime:             60 * time.Second,
 			PermitWithoutStream: true,
 		}),
+		grpc.MaxSendMsgSize(math.MaxInt),
+		grpc.MaxRecvMsgSize(math.MaxInt),
 	}
 )
 

--- a/vendor/github.com/nginx/agent/sdk/v2/grpc/grpc.go
+++ b/vendor/github.com/nginx/agent/sdk/v2/grpc/grpc.go
@@ -12,6 +12,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"math"
 	"os"
 	"time"
 
@@ -42,6 +43,10 @@ var (
 			Timeout:             60 * time.Second,
 			PermitWithoutStream: true,
 		}),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(math.MaxInt),
+			grpc.MaxCallSendMsgSize(math.MaxInt),
+		),
 	}
 
 	DefaultServerDialOptions = []grpc.ServerOption{
@@ -51,6 +56,8 @@ var (
 			MinTime:             60 * time.Second,
 			PermitWithoutStream: true,
 		}),
+		grpc.MaxSendMsgSize(math.MaxInt),
+		grpc.MaxRecvMsgSize(math.MaxInt),
 	}
 )
 


### PR DESCRIPTION
Update the Agent to take MaxSendMsgSize and MaxRecvMsgSize values in defaults for client and server options

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
