### PR TITLE
feat: Add placeholder document for exporting metrics, update pages

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -1,4 +1,6 @@
 ---
 title: "NGINX Agent Documentation"
-description: "NGINX Agent is a companion daemon for your NGINX Open Source or NGINX Plus instance."
+weight: 900
 ---
+
+NGINX Agent is a companion daemon for your NGINX Open Source or NGINX Plus instance

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -1,6 +1,6 @@
 ---
 title: "Changelog"
-weight: 1200
+weight: 800
 toc: true
 ---
 

--- a/site/content/configuration/_index.md
+++ b/site/content/configuration/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuration"
-description: "Learn how to configure NGINX Agent."
 weight: 500
 ---
+
+Learn how to configure NGINX Agent

--- a/site/content/contribute/_index.md
+++ b/site/content/contribute/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Contribute"
-description: "Learn about the NGINX Agent community and contribute to the project."
-linkTitle: "Contribute"
-menu: docs
-weight: "500"
+weight: "700"
 ---
+
+Learn about the NGINX Agent community and how to contribute to the project.

--- a/site/content/export-metrics.md
+++ b/site/content/export-metrics.md
@@ -1,6 +1,6 @@
 ---
-title: Migrate from NGINX Agent v2 to v3
-weight: 900
+title: "Export metrics data"
+weight: 600
 docs: DOCS-000
 ---
 
@@ -26,9 +26,10 @@ To begin this task, you will require the following:
 -
 -
 
+
 ---
 
-## Migrate from NGINX Agent v2 to v3
+## Export metrics data
 
 
 ---
@@ -38,5 +39,5 @@ To begin this task, you will require the following:
 [//]: # "Examples of additional topics users might want to read include:"
 [//]: # "Relevant reference information, configuration options and more complex use cases."
 
--
+- [OpenTelemetry metrics]({{< ref "/metrics.md" >}})
 -

--- a/site/content/installation-upgrade/_index.md
+++ b/site/content/installation-upgrade/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Install and upgrade"
-description: "Learn how to install, upgrade, and uninstall NGINX Agent."
 weight: 400
 ---
+
+Learn how to install, upgrade, and uninstall NGINX Agent.

--- a/site/content/installation-upgrade/container-environments/_index.md
+++ b/site/content/installation-upgrade/container-environments/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Container environments"
-description: "Learn how to build and run NGINX Agent docker images."
-menu: docs
-weight: 900
+weight: 700
 ---
+
+Learn how to build and run NGINX Agent docker images.

--- a/site/content/installation-upgrade/uninstall.md
+++ b/site/content/installation-upgrade/uninstall.md
@@ -1,7 +1,7 @@
 ---
 title: "Uninstall NGINX Agent package"
 toc: true
-weight: 700
+weight: 600
 docs: DOCS-000
 ---
 

--- a/site/content/v2/_index.md
+++ b/site/content/v2/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "NGINX Agent v2"
 description: "NGINX Agent is a companion daemon for your NGINX Open Source or NGINX Plus instance."
+weight: 900
 cascade:
     type: agent-v2-migration
 ---

--- a/site/content/v2/configuration/_index.md
+++ b/site/content/v2/configuration/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Configuration"
-description: "Learn how to configure NGINX Agent."
-linkTitle: "Configuration"
 weight: "400"
-menu: docs
 ---
+
+Learn how to configure NGINX Agent.

--- a/site/content/v2/installation-upgrade/_index.md
+++ b/site/content/v2/installation-upgrade/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Installation and Upgrade"
-description: "Learn how to install, upgrade, and uninstall NGINX Agent."
 menu: docs
 weight: 300
 ---
+
+Learn how to install, upgrade, and uninstall NGINX Agent.

--- a/site/content/v2/installation-upgrade/container-environments/_index.md
+++ b/site/content/v2/installation-upgrade/container-environments/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Container Environments"
-description: "Learn how to build and run NGINX Agent docker images."
-menu: docs
 weight: 800
 ---
+
+Learn how to build and run NGINX Agent docker images.


### PR DESCRIPTION
### Proposed changes

This commit adds a placeholder document for exporting metrics, and adds the key template information for how-to documents to the exporting metrics and migrating from v2 to v3 pages.

It also cleans up metadata description instances on the folder index pages.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
