### PR TITLE
Fix make image targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ OS_VERSION  ?= 24.04
 BASE_IMAGE  = "${CONTAINER_REGISTRY}/${OS_RELEASE}:${OS_VERSION}"
 IMAGE_TAG   = "agent_${OS_RELEASE}_${OS_VERSION}"
 IMAGE_PATH ?= "/nginx/agent"
+IMAGE_BUILD_TARGET ?= install-agent-local
+NGINX_AGENT_VERSION ?= ""
 
 VERSION_WITH_V := v${VERSION}
 LDFLAGS = "-w -X main.version=${VERSION_WITH_V} -X main.commit=${COMMIT} -X main.date=${DATE}"
@@ -287,21 +289,24 @@ image: ## Build agent container image for NGINX Plus, need nginx-repo.crt and ng
 		--no-cache -f ./scripts/docker/nginx-plus/${OS_RELEASE}/Dockerfile \
 		--secret id=nginx-crt,src=${CERTS_DIR}/nginx-repo.crt \
 		--secret id=nginx-key,src=${CERTS_DIR}/nginx-repo.key \
+		--build-arg CONTAINER_REGISTRY=${CONTAINER_REGISTRY} \
 		--build-arg BASE_IMAGE=${BASE_IMAGE} \
 		--build-arg PACKAGES_REPO=${PLUS_PACKAGES_REPO} \
 		--build-arg OS_RELEASE=${OS_RELEASE} \
 		--build-arg OS_VERSION=${OS_VERSION} \
+		--build-arg NGINX_AGENT_VERSION=${NGINX_AGENT_VERSION}
 
 oss-image: ## Build agent container image for NGINX OSS
 	@echo Building image with $(CONTAINER_CLITOOL); \
 	$(CONTAINER_BUILDENV) $(CONTAINER_CLITOOL) build -t ${IMAGE_TAG} . \
 		--no-cache -f ./scripts/docker/nginx-oss/${CONTAINER_OS_TYPE}/Dockerfile \
-		--target install-agent-local \
+		--target ${IMAGE_BUILD_TARGET} \
 		--build-arg PACKAGE_NAME=${PACKAGE_NAME} \
 		--build-arg PACKAGES_REPO=${OSS_PACKAGES_REPO} \
 		--build-arg BASE_IMAGE=${BASE_IMAGE} \
 		--build-arg OS_RELEASE=${OS_RELEASE} \
 		--build-arg OS_VERSION=${OS_VERSION} \
+		--build-arg NGINX_AGENT_VERSION=${NGINX_AGENT_VERSION} \
 		--build-arg ENTRY_POINT=./scripts/docker/entrypoint.sh
 
 run-container: ## Run container from specified IMAGE_TAG

--- a/scripts/docker/nginx-oss/apk/Dockerfile
+++ b/scripts/docker/nginx-oss/apk/Dockerfile
@@ -43,5 +43,6 @@ RUN apk add --allow-untrusted /agent/build/${PACKAGE_NAME}.apk
 
 FROM install-nginx as install-agent-repo
 
-RUN apk add nginx-agent@nginx-agent
+ARG NGINX_AGENT_VERSION
 
+RUN if [ -z "$NGINX_AGENT_VERSION" ]; then apk add nginx-agent; else apk add "nginx-agent=${NGINX_AGENT_VERSION}"; fi

--- a/scripts/docker/nginx-oss/deb/Dockerfile
+++ b/scripts/docker/nginx-oss/deb/Dockerfile
@@ -43,4 +43,7 @@ RUN apt install -y /agent/build/$PACKAGE_NAME.deb
 
 FROM install-nginx as install-agent-repo
 
-RUN apt-get update && apt-get install -y nginx-agent
+ARG NGINX_AGENT_VERSION
+
+RUN apt-get update
+RUN if [ -z "$NGINX_AGENT_VERSION" ]; then apt-get install -y nginx-agent; else apt-get install -y nginx-agent=${NGINX_AGENT_VERSION}; fi

--- a/scripts/docker/nginx-oss/rpm/Dockerfile
+++ b/scripts/docker/nginx-oss/rpm/Dockerfile
@@ -92,6 +92,9 @@ RUN yum localinstall -y /agent/build/${PACKAGE_NAME}.rpm
 
 FROM install-nginx as install-agent-repo
 
-RUN yum install -y nginx-agent \
-    && yum clean all \
+ARG NGINX_AGENT_VERSION
+
+RUN if [ -z "$NGINX_AGENT_VERSION" ]; then yum install -y nginx-agent; else yum install -y nginx-agent-${NGINX_AGENT_VERSION}; fi
+
+RUN yum clean all \
     && rm -rf /var/cache/yum /etc/yum.repos.d/* /etc/ssl/nginx

--- a/scripts/docker/nginx-plus/almalinux/Dockerfile
+++ b/scripts/docker/nginx-plus/almalinux/Dockerfile
@@ -6,6 +6,7 @@ ARG BASE_IMAGE
 ARG PACKAGES_REPO
 ARG OS_RELEASE
 ARG OS_VERSION
+ARG NGINX_AGENT_VERSION
 
 WORKDIR /agent
 COPY ./scripts/docker/entrypoint.sh /agent/entrypoint.sh
@@ -41,11 +42,14 @@ enabled=1 \n\
 sslverify=true \n\
 gpgkey=https://nginx.org/keys/nginx_signing.key" > /etc/yum.repos.d/nginx-agent.repo \
     && nginxPackages=" \
-        nginx-agent \
         nginx-plus \
        " \
-    && yum install -y $nginxPackages \
-    && yum clean all \
+    && yum install -y $nginxPackages 
+
+
+RUN if [ -z "$NGINX_AGENT_VERSION" ]; then yum install -y nginx-agent; else yum install -y nginx-agent-${NGINX_AGENT_VERSION}; fi
+
+RUN yum clean all \
     && rm -rf /var/cache/yum /etc/yum.repos.d/* /etc/ssl/nginx
 
 FROM install as runtime

--- a/scripts/docker/nginx-plus/alpine/Dockerfile
+++ b/scripts/docker/nginx-plus/alpine/Dockerfile
@@ -3,6 +3,7 @@ FROM ${BASE_IMAGE} as install
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG PACKAGES_REPO
+ARG NGINX_AGENT_VERSION
 
 WORKDIR /agent
 COPY ./scripts/docker/entrypoint.sh /agent/entrypoint.sh
@@ -58,10 +59,11 @@ RUN --mount=type=secret,id=nginx-crt,dst=/etc/apk/cert.pem \
     && printf "https://$PACKAGES_REPO/nginx-agent/alpine/v`egrep -o '^[0-9]+\.[0-9]+' /etc/alpine-release`/main/\n" | tee -a /etc/apk/repositories \
     && nginxPackages=" \
         nginx-plus \
-        nginx-agent \
     " \
     && apk update \
     && apk add $nginxPackages
+
+RUN if [ -z "$NGINX_AGENT_VERSION" ]; then apk add nginx-agent; else apk add "nginx-agent=${NGINX_AGENT_VERSION}"; fi
 
 # run the nginx and agent
 FROM install as runtime

--- a/scripts/docker/nginx-plus/amazonlinux/Dockerfile
+++ b/scripts/docker/nginx-plus/amazonlinux/Dockerfile
@@ -6,6 +6,7 @@ ARG BASE_IMAGE
 ARG PACKAGES_REPO
 # note if OS_VERSION is 1, there will be an issues in the yum.repos.d folder
 ARG OS_VERSION
+ARG NGINX_AGENT_VERSION
 
 WORKDIR /agent
 COPY ./scripts/docker/entrypoint.sh /agent/entrypoint.sh
@@ -22,7 +23,6 @@ RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt \
     && adduser -g nginx --system --no-create-home --home /nonexistent --shell /bin/false --uid 101 nginx \
     && nginxPackages=" \
         nginx-plus \
-        nginx-agent \
        " \
     && printf "[nginx-plus] \n\
 name=nginx-plus repo \n\
@@ -42,8 +42,11 @@ gpgcheck=1 \n\
 enabled=1 \n\
 sslverify=true \n\
 gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-agent.repo \
-    && yum install -y $nginxPackages \
-    && yum clean all \
+    && yum install -y $nginxPackages 
+
+RUN if [ -z "$NGINX_AGENT_VERSION" ]; then yum install -y nginx-agent; else yum install -y nginx-agent-${NGINX_AGENT_VERSION}; fi
+
+RUN yum clean all \
     && rm -rf /var/cache/yum /etc/yum.repos.d/* /etc/ssl/nginx
 
 FROM install as runtime

--- a/scripts/docker/nginx-plus/centos/Dockerfile
+++ b/scripts/docker/nginx-plus/centos/Dockerfile
@@ -6,6 +6,7 @@ ARG BASE_IMAGE
 ARG PACKAGES_REPO
 ARG OS_RELEASE
 ARG OS_VERSION
+ARG NGINX_AGENT_VERSION
 
 WORKDIR /agent
 COPY ./scripts/docker/entrypoint.sh /agent/entrypoint.sh
@@ -41,11 +42,13 @@ enabled=1 \n\
 sslverify=true \n\
 gpgkey=https://nginx.org/keys/nginx_signing.key">> /etc/yum.repos.d/nginx-agent.repo \
     && nginxPackages=" \
-        nginx-agent \
         nginx-plus \
        " \
-    && yum install -y $nginxPackages \
-    && yum clean all \
+    && yum install -y $nginxPackages 
+
+RUN if [ -z "$NGINX_AGENT_VERSION" ]; then yum install -y nginx-agent; else yum install -y nginx-agent-${NGINX_AGENT_VERSION}; fi
+
+RUN yum clean all \
     && rm -rf /var/cache/yum /etc/yum.repos.d/* /etc/ssl/nginx
 
 FROM install as runtime

--- a/scripts/docker/nginx-plus/debian/Dockerfile
+++ b/scripts/docker/nginx-plus/debian/Dockerfile
@@ -3,6 +3,7 @@ FROM ${BASE_IMAGE} as install
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG PACKAGES_REPO
+ARG NGINX_AGENT_VERSION
 
 WORKDIR /agent
 COPY ./scripts/docker/entrypoint.sh /agent/entrypoint.sh
@@ -36,7 +37,6 @@ RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt \
 # Use versioned packages over defaults to specify a release
     && nginxPackages=" \
         nginx-plus \
-        nginx-agent \
        " \
     && echo "Acquire::https::$PACKAGES_REPO::Verify-Peer \"true\";" > /etc/apt/apt.conf.d/90nginx \
     && echo "Acquire::https::$PACKAGES_REPO::Verify-Host \"true\";" >> /etc/apt/apt.conf.d/90nginx \
@@ -51,10 +51,13 @@ RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt \
     && apt-get install --no-install-recommends --no-install-suggests -y \
                         $nginxPackages \
                         curl \
-                        gettext-base \
-    && apt-get autoremove --purge -y \
-       gnupg \
-       lsb-release \
+                        gettext-base 
+
+RUN if [ -z "$NGINX_AGENT_VERSION" ]; then apt-get install -y nginx-agent; else apt-get install -y nginx-agent=${NGINX_AGENT_VERSION}; fi
+
+RUN apt-get autoremove --purge -y \
+        gnupg \
+        lsb-release \
     && rm -rf /root/.gnupg \
     && apt-get remove --purge --auto-remove -y && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/nginx-plus.list \
     && rm -rf /etc/apt/apt.conf.d/90nginx /etc/ssl/nginx

--- a/scripts/docker/nginx-plus/oraclelinux/Dockerfile
+++ b/scripts/docker/nginx-plus/oraclelinux/Dockerfile
@@ -6,6 +6,7 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 ARG BASE_IMAGE
 ARG PACKAGES_REPO
 ARG OS_VERSION
+ARG NGINX_AGENT_VERSION
 
 WORKDIR /agent
 COPY ./scripts/docker/entrypoint.sh /agent/entrypoint.sh
@@ -24,7 +25,6 @@ RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt \
     && usermod -L nginx \
     && nginxPackages=" \
         nginx-plus \
-        nginx-agent \
        " \
     && printf "[nginx-plus] \n\
 name=nginx-plus repo \n\
@@ -44,8 +44,11 @@ gpgcheck=1 \n\
 enabled=1 \n\
 sslverify=true \n\
 gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-agent.repo \
-    && yum install -y $nginxPackages \
-    && yum clean all \
+    && yum install -y $nginxPackages
+
+RUN if [ -z "$NGINX_AGENT_VERSION" ]; then yum install -y nginx-agent; else yum install -y nginx-agent-${NGINX_AGENT_VERSION}; fi
+
+RUN yum clean all \
     && rm -rf /var/cache/yum /etc/yum.repos.d/* /etc/ssl/nginx
 
 FROM install as runtime

--- a/scripts/docker/nginx-plus/redhatenterprise/Dockerfile
+++ b/scripts/docker/nginx-plus/redhatenterprise/Dockerfile
@@ -7,6 +7,7 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG PACKAGES_REPO
 ARG OS_VERSION
+ARG NGINX_AGENT_VERSION
 
 WORKDIR /agent
 COPY ./scripts/docker/entrypoint.sh /agent/entrypoint.sh
@@ -24,7 +25,6 @@ RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt \
     && usermod -s /sbin/nologin nginx \
     && usermod -L nginx \
     && nginxPackages=" \
-        nginx-agent \
         nginx-plus \
        " \
     && printf "[nginx-plus] \n\
@@ -45,8 +45,11 @@ gpgcheck=1 \n\
 enabled=1 \n\
 sslverify=true \n\
 gpgkey=https://nginx.org/keys/nginx_signing.key" >> /etc/yum.repos.d/nginx-agent.repo \
-    && yum install -y $nginxPackages \
-    && yum clean all \
+    && yum install -y $nginxPackages
+
+RUN if [ -z "$NGINX_AGENT_VERSION" ]; then yum install -y nginx-agent; else yum install -y nginx-agent-${NGINX_AGENT_VERSION}; fi
+
+RUN yum clean all \
     && rm -rf /var/cache/yum /etc/yum.repos.d/* /etc/ssl/nginx
 
 FROM install as runtime

--- a/scripts/docker/nginx-plus/rockylinux/Dockerfile
+++ b/scripts/docker/nginx-plus/rockylinux/Dockerfile
@@ -6,6 +6,7 @@ ARG BASE_IMAGE
 ARG PACKAGES_REPO
 ARG OS_RELEASE
 ARG OS_VERSION
+ARG NGINX_AGENT_VERSION
 
 WORKDIR /agent
 COPY ./scripts/docker/entrypoint.sh /agent/entrypoint.sh
@@ -41,11 +42,13 @@ enabled=1 \n\
 sslverify=true \n\
 gpgkey=https://nginx.org/keys/nginx_signing.key">> /etc/yum.repos.d/nginx-agent.repo \
     && nginxPackages=" \
-        nginx-agent \
         nginx-plus \
        " \
-    && yum install -y $nginxPackages \
-    && yum clean all \
+    && yum install -y $nginxPackages
+
+RUN if [ -z "$NGINX_AGENT_VERSION" ]; then yum install -y nginx-agent; else yum install -y nginx-agent-${NGINX_AGENT_VERSION}; fi
+
+RUN yum clean all \
     && rm -rf /var/cache/yum /etc/yum.repos.d/* /etc/ssl/nginx
 
 FROM install as runtime

--- a/scripts/docker/nginx-plus/suse/Dockerfile
+++ b/scripts/docker/nginx-plus/suse/Dockerfile
@@ -7,6 +7,7 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG OS_VERSION
 ARG PACKAGES_REPO
+ARG NGINX_AGENT_VERSION
 
 WORKDIR /agent
 COPY ./scripts/docker/entrypoint.sh /agent/entrypoint.sh
@@ -22,7 +23,6 @@ RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt \
     && zypper install ca-certificates \
     && nginxPackages=" \
         nginx-plus \
-        nginx-agent \
        " \
     &&  if [ "$OS_VERSION" = "sles12sp5" ]; then \
             zypper addrepo -G -c "https://$PACKAGES_REPO/plus/sles/12?ssl_clientcert=/etc/ssl/nginx/nginx-repo-bundle.crt&ssl_verify=peer" nginx-plus \
@@ -32,8 +32,10 @@ RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt \
             && zypper addrepo -G -c "https://$PACKAGES_REPO/nginx-agent/sles/15?ssl_clientcert=/etc/ssl/nginx/nginx-repo-bundle.crt&ssl_verify=peer" nginx-agent; \
         fi \
     && zypper refresh \
-    && zypper install -y $nginxPackages \
-    && rm -rf /etc/ssl/nginx/nginx-repo-bundle.crt /etc/ssl/nginx
+    && zypper install -y $nginxPackages 
+
+RUN if [ -z "$NGINX_AGENT_VERSION" ]; then zypper install -y nginx-agent; else zypper install -y nginx-agent=${NGINX_AGENT_VERSION}; fi
+RUN rm -rf /etc/ssl/nginx/nginx-repo-bundle.crt /etc/ssl/nginx
 
 FROM install as runtime
 

--- a/scripts/docker/nginx-plus/ubuntu/Dockerfile
+++ b/scripts/docker/nginx-plus/ubuntu/Dockerfile
@@ -3,6 +3,7 @@ FROM ${BASE_IMAGE} as install
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG PACKAGES_REPO
+ARG NGINX_AGENT_VERSION
 
 RUN echo $PACKAGES_REPO
 WORKDIR /agent
@@ -37,7 +38,6 @@ RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt \
     # Install the latest release of NGINX Plus and/or NGINX Plus modules and NGINX Agent
     && nginxPackages=" \
         nginx-plus \
-        nginx-agent \
     " \
     && echo "Acquire::https::$PACKAGES_REPO::Verify-Peer \"true\";" > /etc/apt/apt.conf.d/90nginx \
     && echo "Acquire::https::$PACKAGES_REPO::Verify-Host \"true\";" >> /etc/apt/apt.conf.d/90nginx \
@@ -51,8 +51,10 @@ RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt \
     && cat /nginx-repo.crt >> /etc/ssl/nginx/nginx-repo.crt \
     && cat /nginx-repo.key >> /etc/ssl/nginx/nginx-repo.key \
     && apt-get update \
-    && apt-get install $nginxPackages -y  \
-    && rm /etc/ssl/nginx/nginx-repo.crt /etc/ssl/nginx/nginx-repo.key
+    && apt-get install $nginxPackages -y 
+    
+RUN if [ -z "$NGINX_AGENT_VERSION" ]; then apt-get install -y nginx-agent; else apt-get install -y nginx-agent=${NGINX_AGENT_VERSION}; fi
+RUN rm /etc/ssl/nginx/nginx-repo.crt /etc/ssl/nginx/nginx-repo.key
 
 # run the nginx and agent
 FROM install as runtime

--- a/scripts/packages/postinstall.sh
+++ b/scripts/packages/postinstall.sh
@@ -46,7 +46,7 @@ detect_nginx_users() {
         if [ "$ID" = "alpine" ]; then
             nginx_user=$(ps aux | grep "nginx: master process" | grep -v grep | head -1 | awk '{print $2}')
         else
-            nginx_user=$(ps aux | grep "nginx: master process" | grep -v grep | head -1 | awk '{print $1}')
+            nginx_user=$(ps aux | grep "nginx: master process" | grep -v grep | head -1 | cut -f1 -d " ")
         fi
 
         if [ -z "${nginx_user}" ]; then
@@ -87,7 +87,7 @@ detect_nginx_users() {
         if [ "$ID" = "alpine" ]; then
             worker_user=$(ps aux | grep "nginx: worker process" | grep -v grep | head -1 | awk '{print $2}')
         else
-            worker_user=$(ps aux | grep "nginx: worker process" | grep -v grep | head -1 | awk '{print $1}')
+            worker_user=$(ps aux | grep "nginx: worker process" | grep -v grep | head -1 | cut -f1 -d " ")
         fi
 
         if [ -z "${worker_user}" ]; then


### PR DESCRIPTION
### Proposed changes

* Update `make image` & `make oss-image` to take a `NGINX_AGENT_VERSION` argument
* Update `make oss-image` to take a `IMAGE_BUILD_TARGET` argument
* Fix postinstall script error when running on SUSE OS (`awk` wasn't installed so I used `cut` instead)

Can now call make targets like this now:
```
IMAGE_BUILD_TARGET=install-agent-repo NGINX_AGENT_VERSION=2.37.0 OS_RELEASE=alpine OS_VERSION=3.20 make oss-image
```

```
NGINX_AGENT_VERSION=2.37.0 OS_RELEASE=alpine OS_VERSION=3.20 make image
```
### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
