### PR TITLE
Set log level to debug for inetegration tests

### DIFF
--- a/test/integration/api/nginx-agent.conf
+++ b/test/integration/api/nginx-agent.conf
@@ -29,7 +29,7 @@ tls:
   skip_verify: true
 log:
   # set log level (panic, fatal, error, info, debug, trace; default "info")
-  level: info
+  level: debug
   # set log path. if empty, don't log to file.
   path: /var/log/nginx-agent/
 # data plane status message / 'heartbeat'

--- a/test/integration/features/test_configs/nginx-agent-config.conf
+++ b/test/integration/features/test_configs/nginx-agent-config.conf
@@ -29,7 +29,7 @@ tls:
   skip_verify: true
 log:
   # set log level (panic, fatal, error, info, debug, trace; default "info")
-  level: info
+  level: debug
   # set log path. if empty, don't log to file.
   path: /var/log/nginx-agent/
 # data plane status message / 'heartbeat'

--- a/test/integration/features/test_configs/nginx-agent-counting.conf
+++ b/test/integration/features/test_configs/nginx-agent-counting.conf
@@ -29,7 +29,7 @@ tls:
   skip_verify: true
 log:
   # set log level (panic, fatal, error, info, debug, trace; default "info")
-  level: info
+  level: debug
   # set log path. if empty, don't log to file.
   path: /var/log/nginx-agent/
 # data plane status message / 'heartbeat'

--- a/test/integration/features/test_configs/nginx-agent-metrics.conf
+++ b/test/integration/features/test_configs/nginx-agent-metrics.conf
@@ -29,7 +29,7 @@ tls:
   skip_verify: true
 log:
   # set log level (panic, fatal, error, info, debug, trace; default "info")
-  level: info
+  level: debug
   # set log path. if empty, don't log to file.
   path: /var/log/nginx-agent/
 # data plane status message / 'heartbeat'

--- a/test/integration/grpc/grpc_config_apply_test.go
+++ b/test/integration/grpc/grpc_config_apply_test.go
@@ -42,7 +42,7 @@ tls:
     skip_verify: true
 
 log:
-    level: info
+    level: debug
     path: /var/log/nginx-agent/
 
 nginx:


### PR DESCRIPTION
### Proposed changes

If the integration tests fail we archive the container logs to help solve the failure, currenlty the agent log level is set to info for these tests which makes them hard to debug.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
