### PR TITLE
Update host metrics receiver

### DIFF
--- a/internal/collector/otel_collector_plugin_test.go
+++ b/internal/collector/otel_collector_plugin_test.go
@@ -86,6 +86,12 @@ func TestCollector_Process(t *testing.T) {
 				HostMetrics: config.HostMetrics{
 					CollectionInterval: time.Minute,
 					InitialDelay:       time.Second,
+					Scrapers: map[string]struct{}{
+						"cpu":     {},
+						"disk":    {},
+						"memory":  {},
+						"network": {},
+					},
 				},
 				OtlpReceivers: types.OtlpReceivers(),
 				NginxPlusReceivers: []config.NginxPlusReceiver{
@@ -115,6 +121,12 @@ func TestCollector_Process(t *testing.T) {
 				HostMetrics: config.HostMetrics{
 					CollectionInterval: time.Minute,
 					InitialDelay:       time.Second,
+					Scrapers: map[string]struct{}{
+						"cpu":     {},
+						"disk":    {},
+						"memory":  {},
+						"network": {},
+					},
 				},
 				OtlpReceivers: types.OtlpReceivers(),
 				NginxReceivers: []config.NginxReceiver{

--- a/internal/collector/otel_collector_plugin_test.go
+++ b/internal/collector/otel_collector_plugin_test.go
@@ -86,11 +86,12 @@ func TestCollector_Process(t *testing.T) {
 				HostMetrics: config.HostMetrics{
 					CollectionInterval: time.Minute,
 					InitialDelay:       time.Second,
-					Scrapers: map[string]struct{}{
-						"cpu":     {},
-						"disk":    {},
-						"memory":  {},
-						"network": {},
+					Scrapers: &config.HostMetricsScrapers{
+						CPU:        &config.CpuScraper{},
+						Disk:       &config.DiskScraper{},
+						Filesystem: &config.FilesystemScraper{},
+						Memory:     &config.MemoryScraper{},
+						Network:    &config.NetworkScraper{},
 					},
 				},
 				OtlpReceivers: types.OtlpReceivers(),
@@ -121,11 +122,12 @@ func TestCollector_Process(t *testing.T) {
 				HostMetrics: config.HostMetrics{
 					CollectionInterval: time.Minute,
 					InitialDelay:       time.Second,
-					Scrapers: map[string]struct{}{
-						"cpu":     {},
-						"disk":    {},
-						"memory":  {},
-						"network": {},
+					Scrapers: &config.HostMetricsScrapers{
+						CPU:        &config.CpuScraper{},
+						Disk:       &config.DiskScraper{},
+						Filesystem: &config.FilesystemScraper{},
+						Memory:     &config.MemoryScraper{},
+						Network:    &config.NetworkScraper{},
 					},
 				},
 				OtlpReceivers: types.OtlpReceivers(),

--- a/internal/collector/otel_collector_plugin_test.go
+++ b/internal/collector/otel_collector_plugin_test.go
@@ -87,7 +87,7 @@ func TestCollector_Process(t *testing.T) {
 					CollectionInterval: time.Minute,
 					InitialDelay:       time.Second,
 					Scrapers: &config.HostMetricsScrapers{
-						CPU:        &config.CpuScraper{},
+						CPU:        &config.CPUScraper{},
 						Disk:       &config.DiskScraper{},
 						Filesystem: &config.FilesystemScraper{},
 						Memory:     &config.MemoryScraper{},
@@ -123,7 +123,7 @@ func TestCollector_Process(t *testing.T) {
 					CollectionInterval: time.Minute,
 					InitialDelay:       time.Second,
 					Scrapers: &config.HostMetricsScrapers{
-						CPU:        &config.CpuScraper{},
+						CPU:        &config.CPUScraper{},
 						Disk:       &config.DiskScraper{},
 						Filesystem: &config.FilesystemScraper{},
 						Memory:     &config.MemoryScraper{},

--- a/internal/collector/otelcol.tmpl
+++ b/internal/collector/otelcol.tmpl
@@ -21,7 +21,7 @@ receivers:
       network:
       {{- end }}
       {{- end }}
-    {{- end }}  
+{{- end }}  
 {{- range $index, $otlpReceiver := .Receivers.OtlpReceivers }}
   otlp/{{$index}}:
     protocols:

--- a/internal/collector/otelcol.tmpl
+++ b/internal/collector/otelcol.tmpl
@@ -3,14 +3,10 @@ receivers:
   hostmetrics:
     collection_interval: {{ .Receivers.HostMetrics.CollectionInterval }}
     initial_delay: {{ .Receivers.HostMetrics.InitialDelay }}
-    scrapers:
-      cpu:
-      disk:
-      load:
-      filesystem:
-      memory:
-      network:
-      paging:
+    scrapers: 
+    {{- range $key, $value := .Receivers.HostMetrics.Scrapers }}
+      {{ $key }}:
+    {{- end }}
 {{- end }}
 {{- range $index, $otlpReceiver := .Receivers.OtlpReceivers }}
   otlp/{{$index}}:

--- a/internal/collector/otelcol.tmpl
+++ b/internal/collector/otelcol.tmpl
@@ -3,11 +3,25 @@ receivers:
   hostmetrics:
     collection_interval: {{ .Receivers.HostMetrics.CollectionInterval }}
     initial_delay: {{ .Receivers.HostMetrics.InitialDelay }}
-    scrapers: 
-    {{- range $key, $value := .Receivers.HostMetrics.Scrapers }}
-      {{ $key }}:
-    {{- end }}
-{{- end }}
+    scrapers:
+      {{- if .Receivers.HostMetrics.Scrapers }}
+      {{- if .Receivers.HostMetrics.Scrapers.CPU }}
+      cpu:
+      {{- end }}
+      {{- if .Receivers.HostMetrics.Scrapers.Disk }}
+      disk:
+      {{- end }}
+      {{- if .Receivers.HostMetrics.Scrapers.Filesystem }}
+      filesystem:
+      {{- end }}
+      {{- if .Receivers.HostMetrics.Scrapers.Memory }}
+      memory:
+      {{- end }}
+      {{- if .Receivers.HostMetrics.Scrapers.Network }}
+      network:
+      {{- end }}
+      {{- end }}
+    {{- end }}  
 {{- range $index, $otlpReceiver := .Receivers.OtlpReceivers }}
   otlp/{{$index}}:
     protocols:

--- a/internal/collector/settings_test.go
+++ b/internal/collector/settings_test.go
@@ -73,10 +73,11 @@ func TestTemplateWrite(t *testing.T) {
 		CollectionInterval: time.Minute,
 		InitialDelay:       time.Second,
 		Scrapers: map[string]struct{}{
-			"cpu":     {},
-			"disk":    {},
-			"memory":  {},
-			"network": {},
+			"cpu":        {},
+			"disk":       {},
+			"filesystem": {},
+			"memory":     {},
+			"network":    {},
 		},
 	}
 	cfg.Collector.Receivers.NginxReceivers = append(cfg.Collector.Receivers.NginxReceivers, config.NginxReceiver{

--- a/internal/collector/settings_test.go
+++ b/internal/collector/settings_test.go
@@ -72,12 +72,12 @@ func TestTemplateWrite(t *testing.T) {
 	cfg.Collector.Receivers.HostMetrics = config.HostMetrics{
 		CollectionInterval: time.Minute,
 		InitialDelay:       time.Second,
-		Scrapers: map[string]struct{}{
-			"cpu":        {},
-			"disk":       {},
-			"filesystem": {},
-			"memory":     {},
-			"network":    {},
+		Scrapers: &config.HostMetricsScrapers{
+			CPU:        &config.CpuScraper{},
+			Disk:       &config.DiskScraper{},
+			Filesystem: &config.FilesystemScraper{},
+			Memory:     &config.MemoryScraper{},
+			Network:    &config.NetworkScraper{},
 		},
 	}
 	cfg.Collector.Receivers.NginxReceivers = append(cfg.Collector.Receivers.NginxReceivers, config.NginxReceiver{

--- a/internal/collector/settings_test.go
+++ b/internal/collector/settings_test.go
@@ -72,6 +72,12 @@ func TestTemplateWrite(t *testing.T) {
 	cfg.Collector.Receivers.HostMetrics = config.HostMetrics{
 		CollectionInterval: time.Minute,
 		InitialDelay:       time.Second,
+		Scrapers: map[string]struct{}{
+			"cpu":     {},
+			"disk":    {},
+			"memory":  {},
+			"network": {},
+		},
 	}
 	cfg.Collector.Receivers.NginxReceivers = append(cfg.Collector.Receivers.NginxReceivers, config.NginxReceiver{
 		InstanceID: "123",

--- a/internal/collector/settings_test.go
+++ b/internal/collector/settings_test.go
@@ -73,7 +73,7 @@ func TestTemplateWrite(t *testing.T) {
 		CollectionInterval: time.Minute,
 		InitialDelay:       time.Second,
 		Scrapers: &config.HostMetricsScrapers{
-			CPU:        &config.CpuScraper{},
+			CPU:        &config.CPUScraper{},
 			Disk:       &config.DiskScraper{},
 			Filesystem: &config.FilesystemScraper{},
 			Memory:     &config.MemoryScraper{},

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -136,9 +136,9 @@ type (
 	}
 
 	HostMetrics struct {
+		Scrapers           map[string]struct{} `yaml:"-" mapstructure:"scrapers"`
 		CollectionInterval time.Duration       `yaml:"-" mapstructure:"collection_interval"`
 		InitialDelay       time.Duration       `yaml:"-" mapstructure:"initial_delay"`
-		Scrapers           map[string]struct{} `yaml:"-" mapstructure:"scrapers"`
 	}
 
 	GRPC struct {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -136,8 +136,9 @@ type (
 	}
 
 	HostMetrics struct {
-		CollectionInterval time.Duration `yaml:"-" mapstructure:"collection_interval"`
-		InitialDelay       time.Duration `yaml:"-" mapstructure:"initial_delay"`
+		CollectionInterval time.Duration       `yaml:"-" mapstructure:"collection_interval"`
+		InitialDelay       time.Duration       `yaml:"-" mapstructure:"initial_delay"`
+		Scrapers           map[string]struct{} `yaml:"-" mapstructure:"scrapers"`
 	}
 
 	GRPC struct {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -142,13 +142,13 @@ type (
 	}
 
 	HostMetricsScrapers struct {
-		CPU        *CpuScraper        `yaml:"-" mapstructure:"cpu"`
+		CPU        *CPUScraper        `yaml:"-" mapstructure:"cpu"`
 		Disk       *DiskScraper       `yaml:"-" mapstructure:"disk"`
 		Filesystem *FilesystemScraper `yaml:"-" mapstructure:"filesystem"`
 		Memory     *MemoryScraper     `yaml:"-" mapstructure:"memory"`
 		Network    *NetworkScraper    `yaml:"-" mapstructure:"network"`
 	}
-	CpuScraper        struct{}
+	CPUScraper        struct{}
 	DiskScraper       struct{}
 	FilesystemScraper struct{}
 	MemoryScraper     struct{}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -136,10 +136,23 @@ type (
 	}
 
 	HostMetrics struct {
-		Scrapers           map[string]struct{} `yaml:"-" mapstructure:"scrapers"`
-		CollectionInterval time.Duration       `yaml:"-" mapstructure:"collection_interval"`
-		InitialDelay       time.Duration       `yaml:"-" mapstructure:"initial_delay"`
+		Scrapers           *HostMetricsScrapers `yaml:"-" mapstructure:"scrapers"`
+		CollectionInterval time.Duration        `yaml:"-" mapstructure:"collection_interval"`
+		InitialDelay       time.Duration        `yaml:"-" mapstructure:"initial_delay"`
 	}
+
+	HostMetricsScrapers struct {
+		CPU        *CpuScraper        `yaml:"-" mapstructure:"cpu"`
+		Disk       *DiskScraper       `yaml:"-" mapstructure:"disk"`
+		Filesystem *FilesystemScraper `yaml:"-" mapstructure:"filesystem"`
+		Memory     *MemoryScraper     `yaml:"-" mapstructure:"memory"`
+		Network    *NetworkScraper    `yaml:"-" mapstructure:"network"`
+	}
+	CpuScraper        struct{}
+	DiskScraper       struct{}
+	FilesystemScraper struct{}
+	MemoryScraper     struct{}
+	NetworkScraper    struct{}
 
 	GRPC struct {
 		Target         string        `yaml:"-" mapstructure:"target"`

--- a/test/config/collector/test-opentelemetry-collector-agent.yaml
+++ b/test/config/collector/test-opentelemetry-collector-agent.yaml
@@ -5,6 +5,7 @@ receivers:
     scrapers:
       cpu:
       disk:
+      filesystem:
       memory:
       network:
   otlp/0:

--- a/test/config/collector/test-opentelemetry-collector-agent.yaml
+++ b/test/config/collector/test-opentelemetry-collector-agent.yaml
@@ -5,11 +5,8 @@ receivers:
     scrapers:
       cpu:
       disk:
-      load:
-      filesystem:
       memory:
       network:
-      paging:
   otlp/0:
     protocols:
       grpc:

--- a/test/mock/collector/grafana/provisioning/dashboards/host-metrics.json
+++ b/test/mock/collector/grafana/provisioning/dashboards/host-metrics.json
@@ -1,0 +1,436 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            }
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "links": [],
+    "panels": [
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "otel-prometheus-scraper"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 0
+            },
+            "id": 2,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "otel-prometheus-scraper"
+                    },
+                    "disableTextWrap": false,
+                    "editorMode": "builder",
+                    "expr": "system_cpu_time",
+                    "fullMetaSearch": false,
+                    "includeNullMetadata": false,
+                    "instant": false,
+                    "legendFormat": "{{nginx_conn_outcome}}",
+                    "range": true,
+                    "refId": "A",
+                    "useBackend": false
+                }
+            ],
+            "title": "System CPU Time",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "otel-prometheus-scraper"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 0
+            },
+            "id": 3,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "otel-prometheus-scraper"
+                    },
+                    "disableTextWrap": false,
+                    "editorMode": "builder",
+                    "expr": "system_filesystem_usage",
+                    "fullMetaSearch": false,
+                    "includeNullMetadata": true,
+                    "instant": false,
+                    "legendFormat": "{{nginx_conn_outcome}}",
+                    "range": true,
+                    "refId": "A",
+                    "useBackend": false
+                }
+            ],
+            "title": "System Filesystem Usage",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "otel-prometheus-scraper"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 8
+            },
+            "id": 4,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "otel-prometheus-scraper"
+                    },
+                    "disableTextWrap": false,
+                    "editorMode": "builder",
+                    "expr": "system_memory_usage",
+                    "fullMetaSearch": false,
+                    "includeNullMetadata": true,
+                    "instant": false,
+                    "legendFormat": "Requests",
+                    "range": true,
+                    "refId": "A",
+                    "useBackend": false
+                }
+            ],
+            "title": "System Memory Usage",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "otel-prometheus-scraper"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 8
+            },
+            "id": 5,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "otel-prometheus-scraper"
+                    },
+                    "disableTextWrap": false,
+                    "editorMode": "builder",
+                    "expr": "system_network_io",
+                    "fullMetaSearch": false,
+                    "includeNullMetadata": false,
+                    "instant": false,
+                    "legendFormat": "__auto",
+                    "range": true,
+                    "refId": "A",
+                    "useBackend": false
+                }
+            ],
+            "title": "System Network IO",
+            "type": "timeseries"
+        }
+    ],
+    "refresh": "",
+    "schemaVersion": 39,
+    "tags": [],
+    "templating": {
+        "list": []
+    },
+    "time": {
+        "from": "now-5m",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "Host Metrics",
+    "uid": "jbsjbjfjnfjdnf",
+    "version": 1,
+    "weekStart": ""
+}

--- a/test/mock/collector/nginx-agent.conf
+++ b/test/mock/collector/nginx-agent.conf
@@ -31,12 +31,12 @@ collector:
     host_metrics:
       collection_interval: 1m0s
       initial_delay: 1s
-      scrapers: 
-        cpu:
-        disk:
-        filesystem:
-        memory:
-        network:
+      scrapers:
+        cpu: {}
+        memory: {}
+        disk: {}
+        network: {}
+        filesystem: {}
   processors:
     - type: batch
   exporters:

--- a/test/mock/collector/nginx-agent.conf
+++ b/test/mock/collector/nginx-agent.conf
@@ -31,6 +31,11 @@ collector:
     host_metrics:
       collection_interval: 1m0s
       initial_delay: 1s
+      scrapers: 
+        cpu:
+        disk:
+        memory:
+        network:
   processors:
     - type: batch
   exporters:

--- a/test/mock/collector/nginx-agent.conf
+++ b/test/mock/collector/nginx-agent.conf
@@ -34,6 +34,7 @@ collector:
       scrapers: 
         cpu:
         disk:
+        filesystem:
         memory:
         network:
   processors:

--- a/test/types/config.go
+++ b/test/types/config.go
@@ -74,6 +74,12 @@ func AgentConfig() *config.Config {
 				HostMetrics: config.HostMetrics{
 					CollectionInterval: time.Minute,
 					InitialDelay:       time.Second,
+					Scrapers: map[string]struct{}{
+						"cpu":     {},
+						"disk":    {},
+						"memory":  {},
+						"network": {},
+					},
 				},
 			},
 			Health: &config.ServerConfig{

--- a/test/types/config.go
+++ b/test/types/config.go
@@ -75,7 +75,7 @@ func AgentConfig() *config.Config {
 					CollectionInterval: time.Minute,
 					InitialDelay:       time.Second,
 					Scrapers: &config.HostMetricsScrapers{
-						CPU:        &config.CpuScraper{},
+						CPU:        &config.CPUScraper{},
 						Disk:       &config.DiskScraper{},
 						Filesystem: &config.FilesystemScraper{},
 						Memory:     &config.MemoryScraper{},

--- a/test/types/config.go
+++ b/test/types/config.go
@@ -74,11 +74,12 @@ func AgentConfig() *config.Config {
 				HostMetrics: config.HostMetrics{
 					CollectionInterval: time.Minute,
 					InitialDelay:       time.Second,
-					Scrapers: map[string]struct{}{
-						"cpu":     {},
-						"disk":    {},
-						"memory":  {},
-						"network": {},
+					Scrapers: &config.HostMetricsScrapers{
+						CPU:        &config.CpuScraper{},
+						Disk:       &config.DiskScraper{},
+						Filesystem: &config.FilesystemScraper{},
+						Memory:     &config.MemoryScraper{},
+						Network:    &config.NetworkScraper{},
 					},
 				},
 			},


### PR DESCRIPTION
### Proposed changes

Introduced the option for the users to set the scraper for the Host metrics receiver from the nginx agent conf. 

![image](https://github.com/user-attachments/assets/c939c0d3-7e8b-451d-9baf-9d7a41aac7b3)


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
