### PR TITLE
Add check for expired GPG key

### DIFF
--- a/Makefile.packaging
+++ b/Makefile.packaging
@@ -195,6 +195,13 @@ build-signed-packager:
 gpg-key: ## Generate GPG public key
 	$$(gpg --import $(NFPM_SIGNING_KEY_FILE)); \
 	keyid=$$(gpg --list-keys NGINX | egrep -A1 "^pub" | egrep -v "^pub" | tr -d '[:space:]'); \
+	if [ -z "$$keyid" ]; then echo "Error: GPG key not found."; exit 1; fi; \
+	# Check if the key is expired \
+	# Look for the 'e' (expired) flag in the 'pub' or 'uid' lines \
+	if gpg --list-keys --with-colons "$$keyid" | grep -E '^pub:e:|^uid:e:'; then \
+		echo "Error: GPG key has expired."; \
+		exit 1; \
+	fi; \
 	expiry=1y; \
 	$$(gpg --quick-set-expire $$keyid $$expiry '*'); \
 	# we need to convert the private gpg key to rsa pem format for pkg signing \


### PR DESCRIPTION
### Proposed changes

Currently if the GPG private key used for package signing is invalid or expired the pipelines still pass. This adds a check that will fail the pipeline if there's a problem with the key.
### Checklist

```
$ make package
$(gpg --import $AGENT_GPG_KEY); \
keyid=$(gpg --list-keys NGINX | egrep -A1 "^pub" | egrep -v "^pub" | tr -d '[:space:]'); \
if [ -z "$keyid" ]; then echo "Error: GPG key not found."; exit 1; fi; \
        # Check if the key is expired \
# Look for the 'e' (expired) flag in the 'pub' or 'uid' lines \
if gpg --list-keys --with-colons "$keyid" | grep -E '^pub:e:|^uid:e:'; then \
	echo "Error: GPG key has expired."; \
	exit 1; \
fi; \
$(gpg --output .key --armor --export $keyid)
gpg: key <redacted>: public key "NGINX NIM (Signing key) <support@nginx.com>" imported
gpg: key <redacted>: secret key imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg:       secret keys read: 1
gpg:   secret keys imported: 1
pub:e:<redacted>::-:::sc::::::23::0:
uid:e::::<redacted>::NGINX NIM (Signing key) <support@nginx.com>::::::::::0:
Error: GPG key has expired.
make: *** [Makefile.packaging:183: gpg-key] Error 1
```
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
