### PR TITLE
Avoid running config validation when file action fails

### DIFF
--- a/internal/file/file_plugin.go
+++ b/internal/file/file_plugin.go
@@ -205,25 +205,25 @@ func (fp *FilePlugin) handleConfigApplyRequest(ctx context.Context, msg *bus.Mes
 			ctx,
 			configApplyRequest.GetOverview().GetConfigVersion().GetInstanceId(),
 		)
-
 		if rollbackErr != nil {
 			rollbackResponse := fp.createDataPlaneResponse(
 				correlationID,
-				mpi.CommandResponse_COMMAND_STATUS_ERROR,
-				"Rollback failed",
+				mpi.CommandResponse_COMMAND_STATUS_FAILURE,
+				"Config apply failed, rollback failed",
 				configApplyRequest.GetOverview().GetConfigVersion().GetInstanceId(),
 				rollbackErr.Error())
-
 			fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: rollbackResponse})
+			fp.fileManagerService.ClearCache()
+
+			return
 		}
 
 		response = fp.createDataPlaneResponse(
 			correlationID,
 			mpi.CommandResponse_COMMAND_STATUS_FAILURE,
-			"Rollback failed",
+			"Config apply failed, rollback success",
 			configApplyRequest.GetOverview().GetConfigVersion().GetInstanceId(),
 			err.Error())
-
 		fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: response})
 		fp.fileManagerService.ClearCache()
 

--- a/internal/file/file_plugin.go
+++ b/internal/file/file_plugin.go
@@ -201,7 +201,11 @@ func (fp *FilePlugin) handleConfigApplyRequest(ctx context.Context, msg *bus.Mes
 		)
 		fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: response})
 
-		rollbackErr := fp.fileManagerService.Rollback(ctx, configApplyRequest.GetOverview().GetConfigVersion().GetInstanceId())
+		rollbackErr := fp.fileManagerService.Rollback(
+			ctx,
+			configApplyRequest.GetOverview().GetConfigVersion().GetInstanceId(),
+		)
+
 		if rollbackErr != nil {
 			rollbackResponse := fp.createDataPlaneResponse(
 				correlationID,

--- a/internal/file/file_plugin.go
+++ b/internal/file/file_plugin.go
@@ -200,7 +200,7 @@ func (fp *FilePlugin) handleConfigApplyRequest(ctx context.Context, msg *bus.Mes
 		)
 		fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: response})
 
-		err := fp.fileManagerService.Rollback(ctx, configApplyRequest.GetOverview().GetConfigVersion().GetInstanceId())
+		err = fp.fileManagerService.Rollback(ctx, configApplyRequest.GetOverview().GetConfigVersion().GetInstanceId())
 		if err != nil {
 			rollbackResponse := fp.createDataPlaneResponse(
 				correlationID,

--- a/internal/file/file_plugin.go
+++ b/internal/file/file_plugin.go
@@ -221,7 +221,7 @@ func (fp *FilePlugin) handleConfigApplyRequest(ctx context.Context, msg *bus.Mes
 		response = fp.createDataPlaneResponse(
 			correlationID,
 			mpi.CommandResponse_COMMAND_STATUS_FAILURE,
-			"Config apply failed, rollback success",
+			"Config apply failed, rollback successful",
 			configApplyRequest.GetOverview().GetConfigVersion().GetInstanceId(),
 			err.Error())
 		fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: response})

--- a/internal/file/file_plugin_test.go
+++ b/internal/file/file_plugin_test.go
@@ -169,9 +169,6 @@ func TestFilePlugin_Process_ConfigApplyRequestTopic(t *testing.T) {
 				_, ok := messages[0].Data.(*model.ConfigApplyMessage)
 				assert.True(t, ok)
 			case test.configApplyStatus == model.RollbackRequired:
-				for _, m := range messages {
-					fmt.Println(m)
-				}
 				assert.Equal(t, bus.DataPlaneResponseTopic, messages[0].Topic)
 				assert.Len(t, messages, 1)
 				dataPlaneResponse, ok := messages[0].Data.(*mpi.DataPlaneResponse)

--- a/internal/file/file_plugin_test.go
+++ b/internal/file/file_plugin_test.go
@@ -170,7 +170,7 @@ func TestFilePlugin_Process_ConfigApplyRequestTopic(t *testing.T) {
 				assert.True(t, ok)
 			case test.configApplyStatus == model.RollbackRequired:
 				assert.Equal(t, bus.DataPlaneResponseTopic, messages[0].Topic)
-				assert.Len(t, messages, 1)
+				assert.Len(t, messages, 2)
 				dataPlaneResponse, ok := messages[0].Data.(*mpi.DataPlaneResponse)
 				assert.True(t, ok)
 				assert.Equal(

--- a/internal/file/file_plugin_test.go
+++ b/internal/file/file_plugin_test.go
@@ -181,6 +181,12 @@ func TestFilePlugin_Process_ConfigApplyRequestTopic(t *testing.T) {
 				assert.Equal(t, "Config apply failed, rolling back config",
 					dataPlaneResponse.GetCommandResponse().GetMessage())
 				assert.Equal(t, test.configApplyReturnsErr.Error(), dataPlaneResponse.GetCommandResponse().GetError())
+				dataPlaneResponse, ok = messages[1].Data.(*mpi.DataPlaneResponse)
+				assert.True(t, ok)
+				assert.Equal(t, "Config apply failed, rollback successful",
+					dataPlaneResponse.GetCommandResponse().GetMessage())
+				assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_FAILURE,
+					dataPlaneResponse.GetCommandResponse().GetStatus())
 			case test.configApplyStatus == model.NoChange:
 				assert.Len(t, messages, 2)
 				dataPlaneResponse, ok := messages[0].Data.(*mpi.DataPlaneResponse)

--- a/internal/file/file_plugin_test.go
+++ b/internal/file/file_plugin_test.go
@@ -169,8 +169,11 @@ func TestFilePlugin_Process_ConfigApplyRequestTopic(t *testing.T) {
 				_, ok := messages[0].Data.(*model.ConfigApplyMessage)
 				assert.True(t, ok)
 			case test.configApplyStatus == model.RollbackRequired:
+				for _, m := range messages {
+					fmt.Println(m)
+				}
 				assert.Equal(t, bus.DataPlaneResponseTopic, messages[0].Topic)
-				assert.Len(t, messages, 2)
+				assert.Len(t, messages, 1)
 				dataPlaneResponse, ok := messages[0].Data.(*mpi.DataPlaneResponse)
 				assert.True(t, ok)
 				assert.Equal(


### PR DESCRIPTION
### Proposed changes

This change alters the handling of the `model.RollbackRequired` status in the file plugin to avoid running the validation step in cases where a config apply fails due to a file operation error.


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
