### PR TITLE
agent log to standard out as well as a file

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -88,8 +88,11 @@ func getLogWriter(logFile string) io.Writer {
 
 			return os.Stderr
 		}
-
-		return logFileHandle
+    
+		// Use io.MultiWriter to log to both Stdout and the file
+    	multiWriter := io.MultiWriter(os.Stdout, logFileHandle)
+		
+		return multiWriter
 	}
 
 	return os.Stderr


### PR DESCRIPTION
### Proposed changes

Get the Agent to log to standard out

```
sudo nginx-agent --command-server-host "foo.com"
time=2024-09-23T12:01:26.183Z level=INFO msg="Starting NGINX Agent" version=v3.0.0 commit=f8f44430
time=2024-09-23T12:01:26.183Z level=INFO msg="Finished registering plugins" plugins="[resource watcher]"
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
