### PR TITLE
Publish package for agent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,16 +332,30 @@ jobs:
       - name: Push load test result
         if:  ${{ success() && github.ref_name == 'v3'}}
         run: git push 'https://github-actions:${{ secrets.GITHUB_TOKEN }}@github.com/nginx/agent.git' benchmark-results:benchmark-results
+  publish-packages-vars:
+    name: Set workflow variables
+    if: ${{ github.event_name == 'pull_request' &&
+      github.base_ref == 'v3' &&
+      github.event.pull_request.merged == true &&
+      !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-22.04
+    outputs:
+      package_build_num: ${{ steps.get_build_num.outputs.build_num }}
+    steps:
+      - name: Get the build number
+        id: get_build_num
+        run: echo "build_num=${{ github.run_number }}-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+
   publish-packages:
     name: Publish NGINX Agent v3 packages
-    if: ${{ github.event_name =='pull_request' &&
+    if: ${{ github.event_name == 'pull_request' &&
             github.base_ref == 'v3' &&
             github.event.pull_request.merged == true &&
             !github.event.pull_request.head.repo.fork }}
     needs: [ lint, unit-test, performance-tests,
              load-tests, official-oss-image-integration-tests,
              official-plus-image-integration-tests,
-             race-condition-test ]
+             race-condition-test, publish-packages-vars ]
     uses: ./.github/workflows/release-branch.yml
     secrets: inherit
     permissions:
@@ -349,8 +363,7 @@ jobs:
       contents: read
     with:
       packageVersion: "3.0.0"
-      packageBuildNo: "${{ github.run_number }}-${{ github.sha.substring(0,7) }}"
+      packageBuildNo: "${{ needs.publish-packages-vars.outputs.package_build_num }}"
       uploadAzure: true
       publishPackages: true
       releaseBranch: "v3"
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,7 @@ jobs:
             github.event.pull_request.merged == true &&
             !github.event.pull_request.head.repo.fork }}
     needs: [ lint, unit-test, performance-tests,
-             loads-tests, official-oss-image-integration-tests,
+             load-tests, official-oss-image-integration-tests,
              official-plus-image-integration-tests,
              race-condition-test ]
     uses: ./.github/workflows/release-branch.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,7 +349,7 @@ jobs:
       contents: read
     with:
       packageVersion: "3.0.0"
-      packageBuildNo: "${{ github.run_number }}"
+      packageBuildNo: "${{ github.run_number }}-${{ github.sha.substring(0,7) }}"
       uploadAzure: true
       publishPackages: true
       releaseBranch: "v3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,9 +338,9 @@ jobs:
             github.base_ref == 'v3' &&
             github.event.pull_request.merged == true &&
             !github.event.pull_request.head.repo.fork }}
-    needs: [ lint, unit-test, component-test, performance-test,
+    needs: [ lint, unit-test, performance-test,
              loads-tests, official-oss-image-integration-tests,
-             official-oss-image-integration-tests,
+             official-plus-image-integration-tests,
              race-condition-test ]
     uses: ./.github/workflows/release-branch.yml
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,9 +343,14 @@ jobs:
              official-plus-image-integration-tests,
              race-condition-test ]
     uses: ./.github/workflows/release-branch.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
     with:
       packageVersion: "3.0.0"
       packageBuildNo: "${{ github.run_number }}"
       uploadAzure: true
       publishPackages: true
       releaseBranch: "v3"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
               name: nginx-agent-unsigned-snapshots
               path: build
               retention-days: 1
-
   generate-pgo-profile:
     name: Generate Profile
     needs: build-unsigned-snapshot
@@ -261,7 +260,6 @@ jobs:
       - name: Push benchmark result
         if:  ${{ success() && github.ref_name == 'v3'}}
         run: git push 'https://github-actions:${{ secrets.GITHUB_TOKEN }}@github.com/nginx/agent.git' benchmark-results:benchmark-results
-
   load-tests:
     name: Load Tests
     if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.ref_name, 'dependabot/') }}
@@ -334,3 +332,19 @@ jobs:
       - name: Push load test result
         if:  ${{ success() && github.ref_name == 'v3'}}
         run: git push 'https://github-actions:${{ secrets.GITHUB_TOKEN }}@github.com/nginx/agent.git' benchmark-results:benchmark-results
+  publish-packages:
+    name: Publish NGINX Agent v3 packages
+    if: ${{ github.event_name =='pull_request' &&
+      github.base_ref == 'v3' &&
+      github.event.pull_request.merged == true && !github.event.pull_request.head.repo.fork }}
+    needs: [ lint, unit-test, component-test, performance-test,
+             loads-tests, official-oss-image-integration-tests,
+             official-oss-image-integration-tests,
+             race-condition-test ]
+    uses: ./.github/workflows/release-branch.yml
+    with:
+      packageVersion: "3.0.0"
+      packageBuildNo: "${{ env.PACKAGE_BUILD_NO }}"
+      uploadAzure: true
+      publishPackages: true
+      releaseBranch: "v3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,22 +335,17 @@ jobs:
   publish-packages:
     name: Publish NGINX Agent v3 packages
     if: ${{ github.event_name =='pull_request' &&
-      github.base_ref == 'v3' &&
-      github.event.pull_request.merged == true && !github.event.pull_request.head.repo.fork }}
+            github.base_ref == 'v3' &&
+            github.event.pull_request.merged == true &&
+            !github.event.pull_request.head.repo.fork }}
     needs: [ lint, unit-test, component-test, performance-test,
              loads-tests, official-oss-image-integration-tests,
              official-oss-image-integration-tests,
              race-condition-test ]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Set Package Build Number
-        run: echo "PACKAGE_BUILD_NO=${{ github.run_number }}" >> $GITHUB_ENV
-
-      - name: Call the Release Workflow
-        uses: ./.github/workflows/release-branch.yml
-        with:
-          packageVersion: "3.0.0"
-          packageBuildNo: "${{ env.PACKAGE_BUILD_NO }}"
-          uploadAzure: true
-          publishPackages: true
-          releaseBranch: "v3"
+    uses: ./.github/workflows/release-branch.yml
+    with:
+      packageVersion: "3.0.0"
+      packageBuildNo: "${{ github.run_number }}"
+      uploadAzure: true
+      publishPackages: true
+      releaseBranch: "v3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,7 @@ jobs:
             github.base_ref == 'v3' &&
             github.event.pull_request.merged == true &&
             !github.event.pull_request.head.repo.fork }}
-    needs: [ lint, unit-test, performance-test,
+    needs: [ lint, unit-test, performance-tests,
              loads-tests, official-oss-image-integration-tests,
              official-plus-image-integration-tests,
              race-condition-test ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,10 +341,16 @@ jobs:
              loads-tests, official-oss-image-integration-tests,
              official-oss-image-integration-tests,
              race-condition-test ]
-    uses: ./.github/workflows/release-branch.yml
-    with:
-      packageVersion: "3.0.0"
-      packageBuildNo: "${{ env.PACKAGE_BUILD_NO }}"
-      uploadAzure: true
-      publishPackages: true
-      releaseBranch: "v3"
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Set Package Build Number
+        run: echo "PACKAGE_BUILD_NO=${{ github.run_number }}" >> $GITHUB_ENV
+
+      - name: Call the Release Workflow
+        uses: ./.github/workflows/release-branch.yml
+        with:
+          packageVersion: "3.0.0"
+          packageBuildNo: "${{ env.PACKAGE_BUILD_NO }}"
+          uploadAzure: true
+          publishPackages: true
+          releaseBranch: "v3"

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -35,6 +35,32 @@ on:
         description: 'Release branch to build & publish from'
         required: true
         type: string
+  workflow_call:
+    inputs:
+      githubRelease:
+        type: boolean
+        default: false
+      packageVersion:
+        type: string
+        default: "3.0.0"
+      packageBuildNo:
+        type: string
+        default: "1"
+      uploadAzure:
+        type: boolean
+        default: true
+      publishPackages:
+        type: boolean
+        default: true
+      tagRelease:
+        type: boolean
+        default: false
+      createPullRequest:
+        type: boolean
+        default: false
+      releaseBranch:
+        type: string
+        required: true
 
 env:
   NFPM_VERSION: 'v2.35.3'

--- a/internal/collector/nginxossreceiver/internal/metadata/generated_status.go
+++ b/internal/collector/nginxossreceiver/internal/metadata/generated_status.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("nginx")
+	Type      = component.MustNewType("nginx")
+	ScopeName = "otelcol/nginxreceiver"
 )
 
 const (

--- a/internal/collector/nginxplusreceiver/internal/metadata/generated_status.go
+++ b/internal/collector/nginxplusreceiver/internal/metadata/generated_status.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Type = component.MustNewType("nginxplus")
+	Type      = component.MustNewType("nginxplus")
+	ScopeName = "otelcol/nginxplusreceiver"
 )
 
 const (


### PR DESCRIPTION
### Proposed changes

With this change a package will be published every time a commit is merged in the `v3` branch. 

The value of the build number is dynamic which increments each time the workflow is run.

GITHUB_RUN_NUMBER : It's part of the default environment variables that GitHub sets are available to every step in a workflow. A unique number for each run of a particular workflow in a repository. This number begins at 1 for the workflow's first run, and increments with each new run. This number does not change if you re-run the workflow run. For example, 3.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
