### PR TITLE
Fix collector extensions config

### DIFF
--- a/internal/collector/otelcol.tmpl
+++ b/internal/collector/otelcol.tmpl
@@ -138,8 +138,13 @@ service:
       output_paths: ["{{ .Log.Path -}}"]
       error_output_paths: ["{{ .Log.Path -}}"]
   {{- end}}
+  
+  {{- if ne .Extensions nil }}
   extensions:
+    {{- if ne .Extensions.Health nil }}
     - health_check
+    {{- end}}
+  {{- end}}
   pipelines:
     metrics:
       receivers:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -366,7 +366,7 @@ func getAgentConfig() *Config {
 				},
 			},
 			Extensions: Extensions{
-				Health: Health{
+				Health: &Health{
 					Server: &ServerConfig{
 						Host: "localhost",
 						Port: 1337,

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -95,7 +95,7 @@ type (
 	}
 
 	Extensions struct {
-		Health Health `yaml:"-" mapstructure:"health"`
+		Health *Health `yaml:"-" mapstructure:"health"`
 	}
 
 	Health struct {

--- a/test/mock/collector/nginx-agent.conf
+++ b/test/mock/collector/nginx-agent.conf
@@ -51,7 +51,7 @@ collector:
           key: /tmp/key.pem
           generate_self_signed_cert: true
   processors:
-    batch:
+    batch: {}
   exporters:
     otlp_exporters:
       - server:

--- a/test/types/config.go
+++ b/test/types/config.go
@@ -84,7 +84,7 @@ func AgentConfig() *config.Config {
 				},
 			},
 			Extensions: config.Extensions{
-				Health: config.Health{
+				Health: &config.Health{
 					Server: &config.ServerConfig{
 						Host: "localhost",
 						Port: randomPort3,


### PR DESCRIPTION
### Proposed changes

If the health extension configuration is missing in the `nginx-agent.conf` then the collector will fail to start.
This PR fixes that issue by allowing the collector to start with no extensions configured.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
