### PR TITLE
docs: enableGitInfo config and docs-action bump

### DIFF
--- a/.github/workflows/docs-build-push.yml
+++ b/.github/workflows/docs-build-push.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   call-docs-build-push:
-    uses: nginxinc/docs-actions/.github/workflows/docs-build-push.yml@f88844356d32c94be057b60033b3a933bebabf77 # v1.0.5
+    uses: nginxinc/docs-actions/.github/workflows/docs-build-push.yml@69843fb5d009e99750e50c23e90c23a899e4637e # v1.0.6
     permissions:
       pull-requests: write # needed to write preview url comment to PR
       contents: read

--- a/site/config/_default/config.toml
+++ b/site/config/_default/config.toml
@@ -1,5 +1,5 @@
 title = "NGINX Agent"
-enableGitInfo = false
+enableGitInfo = true
 baseURL = "/"
 publishDir = "public/nginx-agent"
 staticDir = ["static"]


### PR DESCRIPTION
### Proposed changes

This enables `enableGitInfo` config and bumps docs-action version to fix incorrect `last-modified` docs values
### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
