### PR TITLE
Fix docs docker failing without git context

### DIFF
--- a/site/config/docker/config.toml
+++ b/site/config/docker/config.toml
@@ -1,0 +1,1 @@
+enableGitInfo = false

--- a/site/go.mod
+++ b/site/go.mod
@@ -2,4 +2,4 @@ module github.com/nginx/agent/site
 
 go 1.23
 
-require github.com/nginxinc/nginx-hugo-theme v0.41.19 // indirect
+require github.com/nginxinc/nginx-hugo-theme v0.41.20 // indirect

--- a/site/go.sum
+++ b/site/go.sum
@@ -1,2 +1,4 @@
 github.com/nginxinc/nginx-hugo-theme v0.41.19 h1:CyZOhU8q0p3nQ+ZTFRx7c/Dq9rxV1mShADIHz0vDoHo=
 github.com/nginxinc/nginx-hugo-theme v0.41.19/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
+github.com/nginxinc/nginx-hugo-theme v0.41.20 h1:6BJGRGdHW17OpkC4qbcHARo9TRrJPFrALBjFltwedf8=
+github.com/nginxinc/nginx-hugo-theme v0.41.20/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=

--- a/site/hugo-entrypoint.sh
+++ b/site/hugo-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 hugo mod get -u github.com/nginxinc/nginx-hugo-theme
-hugo $*
+hugo --environment docker $*


### PR DESCRIPTION
### Proposed changes
Fix docs docker failing without git context. Since adding `LastMod`, a proper git history is required during hugo build time. The mount point in docker doesn't pull in the `.git` directory, so it would always fail.


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
