### PR TITLE
Log error from integration test

### DIFF
--- a/test/integration/grpc_management_plane_api_test.go
+++ b/test/integration/grpc_management_plane_api_test.go
@@ -77,7 +77,9 @@ func setupConnectionTest(tb testing.TB, expectNoErrorsInLogs bool) func(tb testi
 		)
 		require.NoError(tb, err)
 		tb.Cleanup(func() {
-			require.NoError(tb, containerNetwork.Remove(ctx))
+			networkErr := containerNetwork.Remove(ctx)
+			tb.Logf("Error removing container network: %v", networkErr)
+			require.NoError(tb, networkErr)
 		})
 
 		mockManagementPlaneGrpcContainer = helpers.StartMockManagementPlaneGrpcContainer(


### PR DESCRIPTION
### Proposed changes

The integration tests in the pipelines are failing as there is an error removing the network, adding a log to find the exact error. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
