### PR TITLE
docs: Fix NGINX install link and dockerfile section

### DIFF
--- a/site/content/installation-upgrade/container-environments/docker-images.md
+++ b/site/content/installation-upgrade/container-environments/docker-images.md
@@ -186,14 +186,6 @@ You can pass the following arguments when running the **make** command to build 
 
 {{</bootstrap-table>}}
 
-Refer to the [Supported distributions]({{< relref "/technical-specifications.md#supported-distributions" >}}) table to find out which base images you can use.
-You can find the official images and versions for each distribution on [Docker Hub](https://hub.docker.com/search?image_filter=official&q=&type=image).
-
-Keep the following information in mind when using the NGINX Agent [Dockerfiles](https://github.com/nginx/agent/tree/main/scripts/docker) to build container images:
-
-- On some operating systems, you need root privileges (**sudo**) to run **make** commands.
-- If you choose to run the **docker build** or **podman build** command instead of using the **make** commands provided, you must do so from the nginx-agent repository's root directory.
-
 ### Build NGINX open source images
 
 Run the following `make` command to build the default image, which uses Alpine as the base image:
@@ -207,7 +199,6 @@ To build an image with Debian and an older version of NGINX Agent you can run th
 ```shell
 IMAGE_BUILD_TARGET=install-agent-repo NGINX_AGENT_VERSION=2.37.0~bullseye OS_RELEASE=debian OS_VERSION=bullseye-slim make oss-image
 ```
-
 
 ### Build NGINX Plus images
 

--- a/site/content/installation-upgrade/getting-started.md
+++ b/site/content/installation-upgrade/getting-started.md
@@ -15,7 +15,7 @@ Follow these steps to configure and run NGINX Agent and a mock interface ("contr
 
 ## Install NGINX
 
-Follow the steps in the [Installation]({{< relref "https://docs.nginx.com/nginx/admin-guide/installing-nginx/" >}}) section to download, install, and run NGINX.
+Follow the steps in the [Installation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/) section to download, install, and run NGINX.
 
 ## Clone the NGINX Agent Repository
 

--- a/site/content/installation-upgrade/getting-started.md
+++ b/site/content/installation-upgrade/getting-started.md
@@ -15,7 +15,7 @@ Follow these steps to configure and run NGINX Agent and a mock interface ("contr
 
 ## Install NGINX
 
-Follow the steps in the [Installation]({{< relref "/installation-upgrade/" >}}) section to download, install, and run NGINX.
+Follow the steps in the [Installation]({{< relref "https://docs.nginx.com/nginx/admin-guide/installing-nginx/" >}}) section to download, install, and run NGINX.
 
 ## Clone the NGINX Agent Repository
 

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,5 +1,5 @@
 module github.com/nginx/agent/site
 
-go 1.23
+go 1.19
 
-require github.com/nginxinc/nginx-hugo-theme v0.41.20 // indirect
+require github.com/nginxinc/nginx-hugo-theme v0.41.22 // indirect

--- a/site/go.sum
+++ b/site/go.sum
@@ -1,4 +1,2 @@
-github.com/nginxinc/nginx-hugo-theme v0.41.19 h1:CyZOhU8q0p3nQ+ZTFRx7c/Dq9rxV1mShADIHz0vDoHo=
-github.com/nginxinc/nginx-hugo-theme v0.41.19/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
-github.com/nginxinc/nginx-hugo-theme v0.41.20 h1:6BJGRGdHW17OpkC4qbcHARo9TRrJPFrALBjFltwedf8=
-github.com/nginxinc/nginx-hugo-theme v0.41.20/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
+github.com/nginxinc/nginx-hugo-theme v0.41.22 h1:Gb/OLbpumNqp8vOPkZzO2GmgPDRd1yr2tWHWUBHg8BA=
+github.com/nginxinc/nginx-hugo-theme v0.41.22/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=


### PR DESCRIPTION
### Proposed changes

- Fixes a link to the wrong guide
- Removes section referencing dockerfiles that are not available any more

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
