### PR TITLE
Set the message identifiers as UUIDv7

### DIFF
--- a/internal/collector/otel_collector_plugin_test.go
+++ b/internal/collector/otel_collector_plugin_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/nginx/agent/v3/test/protos"
@@ -119,20 +118,10 @@ func TestCollector_Init(t *testing.T) {
 			initError := collector.Init(context.Background(), nil)
 			require.NoError(t, initError)
 
-			validateLog(t, tt.expectedLog, logBuf)
+			helpers.ValidateLog(t, tt.expectedLog, logBuf)
 
 			require.NoError(t, collector.Close(context.TODO()))
 		})
-	}
-}
-
-func validateLog(t *testing.T, expectedLog string, logBuf *bytes.Buffer) {
-	t.Helper()
-
-	if expectedLog != "" {
-		if !strings.Contains(logBuf.String(), expectedLog) {
-			t.Errorf("Expected log to contain %q, but got %q", expectedLog, logBuf.String())
-		}
 	}
 }
 

--- a/internal/command/command_plugin.go
+++ b/internal/command/command_plugin.go
@@ -14,10 +14,10 @@ import (
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
 	"github.com/nginx/agent/v3/internal/bus"
 	"github.com/nginx/agent/v3/internal/config"
+	"github.com/nginx/agent/v3/internal/datasource/proto"
 	"github.com/nginx/agent/v3/internal/grpc"
 	"github.com/nginx/agent/v3/internal/logger"
 	pkgConfig "github.com/nginx/agent/v3/pkg/config"
-	"github.com/nginx/agent/v3/pkg/uuid"
 )
 
 var _ bus.Plugin = (*CommandPlugin)(nil)
@@ -248,7 +248,7 @@ func (cp *CommandPlugin) createDataPlaneResponse(correlationID string, status mp
 ) *mpi.DataPlaneResponse {
 	return &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.GenerateUUIDV7(),
+			MessageId:     proto.GenerateMessageID(),
 			CorrelationId: correlationID,
 			Timestamp:     timestamppb.Now(),
 		},

--- a/internal/command/command_plugin.go
+++ b/internal/command/command_plugin.go
@@ -11,14 +11,13 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/google/uuid"
-
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
 	"github.com/nginx/agent/v3/internal/bus"
 	"github.com/nginx/agent/v3/internal/config"
 	"github.com/nginx/agent/v3/internal/grpc"
 	"github.com/nginx/agent/v3/internal/logger"
 	pkgConfig "github.com/nginx/agent/v3/pkg/config"
+	"github.com/nginx/agent/v3/pkg/uuid"
 )
 
 var _ bus.Plugin = (*CommandPlugin)(nil)
@@ -249,7 +248,7 @@ func (cp *CommandPlugin) createDataPlaneResponse(correlationID string, status mp
 ) *mpi.DataPlaneResponse {
 	return &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.NewString(),
+			MessageId:     uuid.GenerateUUIDV7(),
 			CorrelationId: correlationID,
 			Timestamp:     timestamppb.Now(),
 		},

--- a/internal/command/command_plugin_test.go
+++ b/internal/command/command_plugin_test.go
@@ -8,7 +8,6 @@ package command
 import (
 	"bytes"
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/nginx/agent/v3/internal/bus"
 	"github.com/nginx/agent/v3/internal/command/commandfakes"
 	"github.com/nginx/agent/v3/internal/grpc/grpcfakes"
+	"github.com/nginx/agent/v3/test/helpers"
 	"github.com/nginx/agent/v3/test/protos"
 	"github.com/nginx/agent/v3/test/stub"
 	"github.com/nginx/agent/v3/test/types"
@@ -211,10 +211,7 @@ func TestMonitorSubscribeChannel(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	// Verify the logger was called
-	if s := logBuf.String(); !strings.Contains(s, "Received management plane request") {
-		t.Errorf("Unexpected log %s", s)
-	}
+	helpers.ValidateLog(t, "Received management plane request", logBuf)
 
 	// Clear the log buffer
 	logBuf.Reset()

--- a/internal/command/command_service.go
+++ b/internal/command/command_service.go
@@ -17,9 +17,10 @@ import (
 
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
 	"github.com/nginx/agent/v3/internal/config"
+	"github.com/nginx/agent/v3/internal/datasource/proto"
 	"github.com/nginx/agent/v3/internal/grpc"
 	"github.com/nginx/agent/v3/internal/logger"
-	"github.com/nginx/agent/v3/pkg/uuid"
+
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	backoffHelpers "github.com/nginx/agent/v3/internal/backoff"
@@ -87,7 +88,7 @@ func (cs *CommandService) UpdateDataPlaneStatus(
 
 	request := &mpi.UpdateDataPlaneStatusRequest{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.GenerateUUIDV7(),
+			MessageId:     proto.GenerateMessageID(),
 			CorrelationId: correlationID,
 			Timestamp:     timestamppb.Now(),
 		},
@@ -137,7 +138,7 @@ func (cs *CommandService) UpdateDataPlaneHealth(ctx context.Context, instanceHea
 
 	request := &mpi.UpdateDataPlaneHealthRequest{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.GenerateUUIDV7(),
+			MessageId:     proto.GenerateMessageID(),
 			CorrelationId: correlationID,
 			Timestamp:     timestamppb.Now(),
 		},
@@ -215,7 +216,7 @@ func (cs *CommandService) CreateConnection(
 
 	request := &mpi.CreateConnectionRequest{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.GenerateUUIDV7(),
+			MessageId:     proto.GenerateMessageID(),
 			CorrelationId: correlationID,
 			Timestamp:     timestamppb.Now(),
 		},

--- a/internal/command/command_service.go
+++ b/internal/command/command_service.go
@@ -14,11 +14,12 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/google/uuid"
+
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
 	"github.com/nginx/agent/v3/internal/config"
 	"github.com/nginx/agent/v3/internal/grpc"
 	"github.com/nginx/agent/v3/internal/logger"
+	"github.com/nginx/agent/v3/pkg/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	backoffHelpers "github.com/nginx/agent/v3/internal/backoff"
@@ -86,7 +87,7 @@ func (cs *CommandService) UpdateDataPlaneStatus(
 
 	request := &mpi.UpdateDataPlaneStatusRequest{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.NewString(),
+			MessageId:     uuid.GenerateUUIDV7(),
 			CorrelationId: correlationID,
 			Timestamp:     timestamppb.Now(),
 		},
@@ -136,7 +137,7 @@ func (cs *CommandService) UpdateDataPlaneHealth(ctx context.Context, instanceHea
 
 	request := &mpi.UpdateDataPlaneHealthRequest{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.NewString(),
+			MessageId:     uuid.GenerateUUIDV7(),
 			CorrelationId: correlationID,
 			Timestamp:     timestamppb.Now(),
 		},
@@ -214,7 +215,7 @@ func (cs *CommandService) CreateConnection(
 
 	request := &mpi.CreateConnectionRequest{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.NewString(),
+			MessageId:     uuid.GenerateUUIDV7(),
 			CorrelationId: correlationID,
 			Timestamp:     timestamppb.Now(),
 		},

--- a/internal/command/command_service_test.go
+++ b/internal/command/command_service_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"strings"
 	"testing"
 	"time"
 
@@ -122,9 +121,9 @@ func TestCommandService_UpdateDataPlaneStatusSubscribeError(t *testing.T) {
 	err := commandService.UpdateDataPlaneStatus(ctx, protos.GetHostResource())
 	require.Error(t, err)
 
-	if s := logBuf.String(); !strings.Contains(s, "Failed to send update data plane status") {
-		t.Errorf("Unexpected log %s", s)
-	}
+	helpers.ValidateLog(t, "Failed to send update data plane status", logBuf)
+
+	logBuf.Reset()
 }
 
 func TestCommandService_CreateConnection(t *testing.T) {

--- a/internal/datasource/proto/message.go
+++ b/internal/datasource/proto/message.go
@@ -13,8 +13,15 @@ import (
 	agentUuid "github.com/nginx/agent/v3/pkg/uuid"
 )
 
+// UUIDGenerator defines a function type for generating UUIDs.
+type UUIDGenerator func() (uuid.UUID, error)
+
+// DefaultUUIDGenerator is the production implementation for generating UUIDv7.
+var defaultUUIDGenerator UUIDGenerator = uuid.NewUUID
+
+// GenerateMessageID generates a unique message ID, falling back to sha256 and timestamp if UUID generation fails.
 func GenerateMessageID() string {
-	uuidv7, err := uuid.NewUUID()
+	uuidv7, err := defaultUUIDGenerator()
 	if err != nil {
 		slog.Debug("Issue generating uuidv7, using sha256 and timestamp instead", "error", err)
 		return agentUuid.Generate("%s", time.Now().String())

--- a/internal/datasource/proto/message.go
+++ b/internal/datasource/proto/message.go
@@ -1,0 +1,23 @@
+// Copyright (c) F5, Inc.
+//
+// This source code is licensed under the Apache License, Version 2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+
+package proto
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/nginx/agent/v3/pkg/uuid"
+)
+
+func GenerateMessageID() string {
+	uuidv7, err := uuid.GenerateUUIDV7()
+	if err != nil {
+		slog.Debug("issue generating uuidv7, using sha256 and timestamp instead", "error", err)
+		return uuid.Generate("%s", time.Now().String())
+	}
+
+	return uuidv7
+}

--- a/internal/datasource/proto/message.go
+++ b/internal/datasource/proto/message.go
@@ -9,15 +9,16 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/nginx/agent/v3/pkg/uuid"
+	"github.com/google/uuid"
+	agentUuid "github.com/nginx/agent/v3/pkg/uuid"
 )
 
 func GenerateMessageID() string {
-	uuidv7, err := uuid.GenerateUUIDV7()
+	uuidv7, err := uuid.NewUUID()
 	if err != nil {
-		slog.Debug("issue generating uuidv7, using sha256 and timestamp instead", "error", err)
-		return uuid.Generate("%s", time.Now().String())
+		slog.Debug("Issue generating uuidv7, using sha256 and timestamp instead", "error", err)
+		return agentUuid.Generate("%s", time.Now().String())
 	}
 
-	return uuidv7
+	return uuidv7.String()
 }

--- a/internal/datasource/proto/message_test.go
+++ b/internal/datasource/proto/message_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) F5, Inc.
+//
+// This source code is licensed under the Apache License, Version 2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+
+package proto
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUUIDv7Regex(t *testing.T) {
+	// Define the UUIDv7 regex
+	uuidv7Regex := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+	// Define test cases
+	tests := []struct {
+		name        string
+		input       string
+		expectMatch bool
+	}{
+		{
+			name:        "Valid UUIDv7 with variant 8",
+			input:       "01876395-3f9d-7c91-89a3-4f57e53a1a4b",
+			expectMatch: true,
+		},
+		{
+			name:        "Valid UUIDv7 with variant a",
+			input:       "01876395-3f9d-7c91-9f00-4f57e53a1a4b",
+			expectMatch: true,
+		},
+		{
+			name:        "Invalid UUIDv7 - wrong version",
+			input:       "01876395-3f9d-6c91-89a3-4f57e53a1a4b",
+			expectMatch: false,
+		},
+		{
+			name:        "Invalid UUIDv7 - wrong variant",
+			input:       "01876395-3f9d-7c91-7a00-4f57e53a1a4b",
+			expectMatch: false,
+		},
+		{
+			name:        "Invalid UUIDv7 - extra characters",
+			input:       "01876395-3f9d-7c91-89a3-4f57e53a1a4b123",
+			expectMatch: false,
+		},
+		{
+			name:        "Invalid UUIDv7 - missing characters",
+			input:       "01876395-3f9d-7c91-89a3-4f57e53a",
+			expectMatch: false,
+		},
+	}
+
+	// Iterate over test cases
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match := uuidv7Regex.MatchString(tt.input)
+			assert.Equal(t, tt.expectMatch, match, "Regex match result did not match expectation")
+		})
+	}
+}

--- a/internal/datasource/proto/message_test.go
+++ b/internal/datasource/proto/message_test.go
@@ -6,14 +6,14 @@
 package proto
 
 import (
+	"bytes"
 	"errors"
-	"log/slog"
 	"regexp"
 	"testing"
 
 	"github.com/nginx/agent/v3/test/helpers"
+	"github.com/nginx/agent/v3/test/stub"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/google/uuid"
 )
@@ -99,20 +99,16 @@ func TestGenerateMessageID(t *testing.T) {
 			defaultUUIDGenerator = tt.mockFunc
 
 			if tt.expectError {
-				logHandler := helpers.NewTestLogHandler()
-				logger := slog.New(logHandler)
-				slog.SetDefault(logger)
+				logBuf := &bytes.Buffer{}
+				stub.StubLoggerWith(logBuf)
 
 				got := GenerateMessageID()
 				assert.NotEmpty(t, got)
 
 				// Inspect logs
-				logs := logHandler.Logs()
-				require.NotEmpty(t, logs, "Expected log entries but got none")
-				assert.Equal(t,
-					"Issue generating uuidv7, using sha256 and timestamp instead",
-					logs[0].Message,
-					"Expected specific log message")
+				helpers.ValidateLog(t, "Issue generating uuidv7, using sha256 and timestamp instead", logBuf)
+
+				logBuf.Reset()
 			} else {
 				got := GenerateMessageID()
 

--- a/internal/file/file_manager_service.go
+++ b/internal/file/file_manager_service.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/nginx/agent/v3/internal/datasource/proto"
 	"github.com/nginx/agent/v3/internal/model"
 
 	"github.com/cenkalti/backoff/v4"
@@ -23,7 +24,6 @@ import (
 	"github.com/nginx/agent/v3/internal/grpc"
 	"github.com/nginx/agent/v3/internal/logger"
 	"github.com/nginx/agent/v3/pkg/files"
-	"github.com/nginx/agent/v3/pkg/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	backoffHelpers "github.com/nginx/agent/v3/internal/backoff"
@@ -97,7 +97,7 @@ func (fms *FileManagerService) UpdateOverview(
 
 	request := &mpi.UpdateOverviewRequest{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.GenerateUUIDV7(),
+			MessageId:     proto.GenerateMessageID(),
 			CorrelationId: requestCorrelationID.Value.String(),
 			Timestamp:     timestamppb.Now(),
 		},
@@ -169,7 +169,7 @@ func (fms *FileManagerService) UpdateFile(
 			Contents: contents,
 		},
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.GenerateUUIDV7(),
+			MessageId:     proto.GenerateMessageID(),
 			CorrelationId: correlationID,
 			Timestamp:     timestamppb.Now(),
 		},
@@ -326,7 +326,7 @@ func (fms *FileManagerService) fileUpdate(ctx context.Context, file *mpi.File) e
 	getFile := func() (*mpi.GetFileResponse, error) {
 		return fms.fileServiceClient.GetFile(ctx, &mpi.GetFileRequest{
 			MessageMeta: &mpi.MessageMeta{
-				MessageId:     uuid.GenerateUUIDV7(),
+				MessageId:     proto.GenerateMessageID(),
 				CorrelationId: logger.GetCorrelationID(ctx),
 				Timestamp:     timestamppb.Now(),
 			},

--- a/internal/file/file_manager_service.go
+++ b/internal/file/file_manager_service.go
@@ -17,12 +17,13 @@ import (
 	"github.com/nginx/agent/v3/internal/model"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/google/uuid"
+
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
 	"github.com/nginx/agent/v3/internal/config"
 	"github.com/nginx/agent/v3/internal/grpc"
 	"github.com/nginx/agent/v3/internal/logger"
 	"github.com/nginx/agent/v3/pkg/files"
+	"github.com/nginx/agent/v3/pkg/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	backoffHelpers "github.com/nginx/agent/v3/internal/backoff"
@@ -96,7 +97,7 @@ func (fms *FileManagerService) UpdateOverview(
 
 	request := &mpi.UpdateOverviewRequest{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.NewString(),
+			MessageId:     uuid.GenerateUUIDV7(),
 			CorrelationId: requestCorrelationID.Value.String(),
 			Timestamp:     timestamppb.Now(),
 		},
@@ -168,7 +169,7 @@ func (fms *FileManagerService) UpdateFile(
 			Contents: contents,
 		},
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.NewString(),
+			MessageId:     uuid.GenerateUUIDV7(),
 			CorrelationId: correlationID,
 			Timestamp:     timestamppb.Now(),
 		},
@@ -325,7 +326,7 @@ func (fms *FileManagerService) fileUpdate(ctx context.Context, file *mpi.File) e
 	getFile := func() (*mpi.GetFileResponse, error) {
 		return fms.fileServiceClient.GetFile(ctx, &mpi.GetFileRequest{
 			MessageMeta: &mpi.MessageMeta{
-				MessageId:     uuid.NewString(),
+				MessageId:     uuid.GenerateUUIDV7(),
 				CorrelationId: logger.GetCorrelationID(ctx),
 				Timestamp:     timestamppb.Now(),
 			},

--- a/internal/file/file_plugin.go
+++ b/internal/file/file_plugin.go
@@ -11,11 +11,11 @@ import (
 	"log/slog"
 
 	"github.com/nginx/agent/v3/pkg/files"
-	"github.com/nginx/agent/v3/pkg/uuid"
 
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
 	"github.com/nginx/agent/v3/internal/bus"
 	"github.com/nginx/agent/v3/internal/config"
+	"github.com/nginx/agent/v3/internal/datasource/proto"
 	"github.com/nginx/agent/v3/internal/grpc"
 	"github.com/nginx/agent/v3/internal/logger"
 	"github.com/nginx/agent/v3/internal/model"
@@ -319,7 +319,7 @@ func (fp *FilePlugin) handleConfigUploadRequest(ctx context.Context, msg *bus.Me
 
 	response := &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.GenerateUUIDV7(),
+			MessageId:     proto.GenerateMessageID(),
 			CorrelationId: correlationID,
 			Timestamp:     timestamppb.Now(),
 		},
@@ -343,7 +343,7 @@ func (fp *FilePlugin) createDataPlaneResponse(correlationID string, status mpi.C
 ) *mpi.DataPlaneResponse {
 	return &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.GenerateUUIDV7(),
+			MessageId:     proto.GenerateMessageID(),
 			CorrelationId: correlationID,
 			Timestamp:     timestamppb.Now(),
 		},

--- a/internal/file/file_plugin.go
+++ b/internal/file/file_plugin.go
@@ -11,8 +11,8 @@ import (
 	"log/slog"
 
 	"github.com/nginx/agent/v3/pkg/files"
+	"github.com/nginx/agent/v3/pkg/uuid"
 
-	"github.com/google/uuid"
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
 	"github.com/nginx/agent/v3/internal/bus"
 	"github.com/nginx/agent/v3/internal/config"
@@ -319,7 +319,7 @@ func (fp *FilePlugin) handleConfigUploadRequest(ctx context.Context, msg *bus.Me
 
 	response := &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.NewString(),
+			MessageId:     uuid.GenerateUUIDV7(),
 			CorrelationId: correlationID,
 			Timestamp:     timestamppb.Now(),
 		},
@@ -343,7 +343,7 @@ func (fp *FilePlugin) createDataPlaneResponse(correlationID string, status mpi.C
 ) *mpi.DataPlaneResponse {
 	return &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.NewString(),
+			MessageId:     uuid.GenerateUUIDV7(),
 			CorrelationId: correlationID,
 			Timestamp:     timestamppb.Now(),
 		},

--- a/internal/file/file_plugin_test.go
+++ b/internal/file/file_plugin_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/nginx/agent/v3/internal/bus/busfakes"
+	"github.com/nginx/agent/v3/internal/datasource/proto"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -23,7 +24,6 @@ import (
 	"github.com/nginx/agent/v3/internal/grpc/grpcfakes"
 	"github.com/nginx/agent/v3/internal/model"
 	"github.com/nginx/agent/v3/pkg/files"
-	"github.com/nginx/agent/v3/pkg/uuid"
 	"github.com/nginx/agent/v3/test/helpers"
 	"github.com/nginx/agent/v3/test/protos"
 	"github.com/nginx/agent/v3/test/types"
@@ -441,7 +441,7 @@ func TestFilePlugin_Process_ConfigApplyRollbackCompleteTopic(t *testing.T) {
 
 	expectedResponse := &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.GenerateUUIDV7(),
+			MessageId:     proto.GenerateMessageID(),
 			CorrelationId: "dfsbhj6-bc92-30c1-a9c9-85591422068e",
 			Timestamp:     timestamppb.Now(),
 		},

--- a/internal/file/file_plugin_test.go
+++ b/internal/file/file_plugin_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/nginx/agent/v3/internal/bus/busfakes"
 
-	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
@@ -24,6 +23,7 @@ import (
 	"github.com/nginx/agent/v3/internal/grpc/grpcfakes"
 	"github.com/nginx/agent/v3/internal/model"
 	"github.com/nginx/agent/v3/pkg/files"
+	"github.com/nginx/agent/v3/pkg/uuid"
 	"github.com/nginx/agent/v3/test/helpers"
 	"github.com/nginx/agent/v3/test/protos"
 	"github.com/nginx/agent/v3/test/types"
@@ -441,7 +441,7 @@ func TestFilePlugin_Process_ConfigApplyRollbackCompleteTopic(t *testing.T) {
 
 	expectedResponse := &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.NewString(),
+			MessageId:     uuid.GenerateUUIDV7(),
 			CorrelationId: "dfsbhj6-bc92-30c1-a9c9-85591422068e",
 			Timestamp:     timestamppb.Now(),
 		},

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"github.com/nginx/agent/v3/internal/config"
-	"github.com/nginx/agent/v3/pkg/uuid"
+	"github.com/nginx/agent/v3/internal/datasource/proto"
 )
 
 const (
@@ -121,7 +121,7 @@ func (h contextHandler) observe(ctx context.Context) (as []slog.Attr) {
 }
 
 func GenerateCorrelationID() slog.Attr {
-	return slog.Any(CorrelationIDKey, uuid.GenerateUUIDV7())
+	return slog.Any(CorrelationIDKey, proto.GenerateMessageID())
 }
 
 func GetCorrelationID(ctx context.Context) string {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -13,8 +13,8 @@ import (
 	"path"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/nginx/agent/v3/internal/config"
+	"github.com/nginx/agent/v3/pkg/uuid"
 )
 
 const (
@@ -121,7 +121,7 @@ func (h contextHandler) observe(ctx context.Context) (as []slog.Attr) {
 }
 
 func GenerateCorrelationID() slog.Attr {
-	return slog.Any(CorrelationIDKey, uuid.NewString())
+	return slog.Any(CorrelationIDKey, uuid.GenerateUUIDV7())
 }
 
 func GetCorrelationID(ctx context.Context) string {

--- a/internal/resource/resource_plugin.go
+++ b/internal/resource/resource_plugin.go
@@ -10,8 +10,8 @@ import (
 	"log/slog"
 
 	"github.com/nginx/agent/v3/internal/config"
+	"github.com/nginx/agent/v3/internal/datasource/proto"
 	"github.com/nginx/agent/v3/internal/model"
-	"github.com/nginx/agent/v3/pkg/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
@@ -186,7 +186,7 @@ func (*Resource) createDataPlaneResponse(correlationID string, status mpi.Comman
 ) *mpi.DataPlaneResponse {
 	return &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.GenerateUUIDV7(),
+			MessageId:     proto.GenerateMessageID(),
 			CorrelationId: correlationID,
 			Timestamp:     timestamppb.Now(),
 		},

--- a/internal/resource/resource_plugin.go
+++ b/internal/resource/resource_plugin.go
@@ -9,9 +9,9 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/google/uuid"
 	"github.com/nginx/agent/v3/internal/config"
 	"github.com/nginx/agent/v3/internal/model"
+	"github.com/nginx/agent/v3/pkg/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
@@ -186,7 +186,7 @@ func (*Resource) createDataPlaneResponse(correlationID string, status mpi.Comman
 ) *mpi.DataPlaneResponse {
 	return &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.NewString(),
+			MessageId:     uuid.GenerateUUIDV7(),
 			CorrelationId: correlationID,
 			Timestamp:     timestamppb.Now(),
 		},

--- a/internal/watcher/file/file_watcher_service_test.go
+++ b/internal/watcher/file/file_watcher_service_test.go
@@ -10,10 +10,10 @@ import (
 	"context"
 	"os"
 	"path"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/nginx/agent/v3/test/helpers"
 	"github.com/nginx/agent/v3/test/stub"
 
 	"github.com/fsnotify/fsnotify"
@@ -127,9 +127,9 @@ func TestFileWatcherService_removeWatcher(t *testing.T) {
 	fileWatcherService.directoriesBeingWatched.Store(testDirectory, true)
 	fileWatcherService.removeWatcher(ctx, testDirectory)
 
-	if s := logBuf.String(); !strings.Contains(s, "Failed to remove file watcher") {
-		t.Errorf("Unexpected log %s", s)
-	}
+	helpers.ValidateLog(t, "Failed to remove file watcher", logBuf)
+
+	logBuf.Reset()
 }
 
 func TestFileWatcherService_isEventSkippable(t *testing.T) {

--- a/internal/watcher/instance/nginx_config_parser_test.go
+++ b/internal/watcher/instance/nginx_config_parser_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -936,9 +935,9 @@ func TestNginxConfigParser_ignoreLog(t *testing.T) {
 			ncp := NewNginxConfigParser(agentConfig)
 			assert.Equal(t, test.expected, ncp.ignoreLog(test.logPath))
 
-			if s := logBuf.String(); !strings.Contains(s, test.expectedLog) {
-				t.Errorf("Expected to receive log: %s", test.expectedLog)
-			}
+			helpers.ValidateLog(t, test.expectedLog, logBuf)
+
+			logBuf.Reset()
 		})
 	}
 }

--- a/internal/watcher/watcher_plugin_test.go
+++ b/internal/watcher/watcher_plugin_test.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/nginx/agent/v3/internal/bus/busfakes"
+	"github.com/nginx/agent/v3/pkg/uuid"
 
-	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/nginx/agent/v3/internal/watcher/health"
@@ -138,7 +138,7 @@ func TestWatcher_Process_ConfigApplySuccessfulTopic(t *testing.T) {
 
 	response := &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.NewString(),
+			MessageId:     uuid.GenerateUUIDV7(),
 			CorrelationId: "dfsbhj6-bc92-30c1-a9c9-85591422068e",
 			Timestamp:     timestamppb.Now(),
 		},
@@ -172,7 +172,7 @@ func TestWatcher_Process_RollbackCompleteTopic(t *testing.T) {
 
 	response := &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.NewString(),
+			MessageId:     uuid.GenerateUUIDV7(),
 			CorrelationId: "dfsbhj6-bc92-30c1-a9c9-85591422068e",
 			Timestamp:     timestamppb.Now(),
 		},

--- a/internal/watcher/watcher_plugin_test.go
+++ b/internal/watcher/watcher_plugin_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/nginx/agent/v3/internal/bus/busfakes"
-	"github.com/nginx/agent/v3/pkg/uuid"
+	"github.com/nginx/agent/v3/internal/datasource/proto"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -138,7 +138,7 @@ func TestWatcher_Process_ConfigApplySuccessfulTopic(t *testing.T) {
 
 	response := &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.GenerateUUIDV7(),
+			MessageId:     proto.GenerateMessageID(),
 			CorrelationId: "dfsbhj6-bc92-30c1-a9c9-85591422068e",
 			Timestamp:     timestamppb.Now(),
 		},
@@ -172,7 +172,7 @@ func TestWatcher_Process_RollbackCompleteTopic(t *testing.T) {
 
 	response := &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.GenerateUUIDV7(),
+			MessageId:     proto.GenerateMessageID(),
 			CorrelationId: "dfsbhj6-bc92-30c1-a9c9-85591422068e",
 			Timestamp:     timestamppb.Now(),
 		},

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -8,10 +8,27 @@ package uuid
 import (
 	"crypto/sha256"
 	"fmt"
+	"log/slog"
+	"time"
 
 	"github.com/google/uuid"
 )
 
+// Generate creates a UUID based on a hashed string derived from the input format and arguments.
+// This function is used primarilty in generating the NGINX Id
+//
+// Parameters:
+//   - format: A format string, similar to fmt.Sprintf.
+//   - a: Variadic arguments to be substituted into the format string.
+//
+// Process:
+//  1. Creates a SHA-256 hash from the formatted string (using `fmt.Sprintf`).
+//  2. Converts the hash to a hexadecimal string.
+//  3. Generates an MD5-based UUID using the hashed string.
+//
+// Returns:
+//
+//	A string representation of the generated UUID.
 func Generate(format string, a ...interface{}) string {
 	h := sha256.New()
 	s := fmt.Sprintf(format, a...)
@@ -19,4 +36,27 @@ func Generate(format string, a ...interface{}) string {
 	id := fmt.Sprintf("%x", h.Sum(nil))
 
 	return uuid.NewMD5(uuid.Nil, []byte(id)).String()
+}
+
+// GenerateUUIDV7 generates a UUID using the UUIDv7 standard.
+//
+// UUIDv7 is designed to be time-ordered and unique, making it suitable for systems requiring
+// high scalability and reliable uniqueness across distributed systems.
+//
+// Process:
+//  1. Attempts to generate a UUIDv7 using the `uuid.NewV7()` function.
+//  2. If UUIDv7 generation fails, logs the error using `slog` and falls back to a SHA-256-based UUID
+//     generated with the current timestamp.
+//
+// Returns:
+//
+//	A string representation of the generated UUID.
+func GenerateUUIDV7() string {
+	id, err := uuid.NewV7()
+	if err != nil {
+		slog.Debug("issuing generating uuidv7, using sha256 and timestamp instead", "error", err)
+		return Generate("%s", time.Now().String())
+	}
+
+	return id.String()
 }

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -35,26 +35,3 @@ func Generate(format string, a ...interface{}) string {
 
 	return uuid.NewMD5(uuid.Nil, []byte(id)).String()
 }
-
-// GenerateUUIDV7 generates a UUID using the UUIDv7 standard.
-//
-// UUIDv7 is designed to be time-ordered and unique, making it suitable for systems requiring
-// high scalability and reliable uniqueness across distributed systems.
-//
-// Process:
-//  1. Attempts to generate a UUIDv7 using the `uuid.NewV7()` function.
-//  2. If UUIDv7 generation fails, logs the error using `slog` and falls back to a SHA-256-based UUID
-//     generated with the current timestamp.
-//
-// Returns:
-//
-//		A string representation of the generated UUID if successful. An empty string if unsuccessful
-//	 An error
-func GenerateUUIDV7() (string, error) {
-	id, err := uuid.NewV7()
-	if err != nil {
-		return "", err
-	}
-
-	return id.String(), err
-}

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -8,8 +8,6 @@ package uuid
 import (
 	"crypto/sha256"
 	"fmt"
-	"log/slog"
-	"time"
 
 	"github.com/google/uuid"
 )
@@ -50,13 +48,13 @@ func Generate(format string, a ...interface{}) string {
 //
 // Returns:
 //
-//	A string representation of the generated UUID.
-func GenerateUUIDV7() string {
+//		A string representation of the generated UUID if successful. An empty string if unsuccessful
+//	 An error
+func GenerateUUIDV7() (string, error) {
 	id, err := uuid.NewV7()
 	if err != nil {
-		slog.Debug("issuing generating uuidv7, using sha256 and timestamp instead", "error", err)
-		return Generate("%s", time.Now().String())
+		return "", err
 	}
 
-	return id.String()
+	return id.String(), err
 }

--- a/pkg/uuid/uuid_test.go
+++ b/pkg/uuid/uuid_test.go
@@ -8,7 +8,6 @@ package uuid
 import (
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,7 +18,6 @@ func TestGenerate(t *testing.T) {
 }
 
 func TestGenerateUUIDV7_Success(t *testing.T) {
-	result := GenerateUUIDV7()
-	_, err := uuid.Parse(result)
+	_, err := GenerateUUIDV7()
 	assert.NoError(t, err, "Generated UUIDv7 should be valid")
 }

--- a/pkg/uuid/uuid_test.go
+++ b/pkg/uuid/uuid_test.go
@@ -8,6 +8,7 @@ package uuid
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,4 +16,10 @@ func TestGenerate(t *testing.T) {
 	result := Generate("%s_%s_%s", "test1", "test2", "test3")
 	expected := "02be9e7f-a802-35d4-9e4a-6c677259a87d"
 	assert.Equal(t, expected, result)
+}
+
+func TestGenerateUUIDV7_Success(t *testing.T) {
+	result := GenerateUUIDV7()
+	_, err := uuid.Parse(result)
+	assert.NoError(t, err, "Generated UUIDv7 should be valid")
 }

--- a/pkg/uuid/uuid_test.go
+++ b/pkg/uuid/uuid_test.go
@@ -16,8 +16,3 @@ func TestGenerate(t *testing.T) {
 	expected := "02be9e7f-a802-35d4-9e4a-6c677259a87d"
 	assert.Equal(t, expected, result)
 }
-
-func TestGenerateUUIDV7_Success(t *testing.T) {
-	_, err := GenerateUUIDV7()
-	assert.NoError(t, err, "Generated UUIDv7 should be valid")
-}

--- a/test/helpers/os_utils.go
+++ b/test/helpers/os_utils.go
@@ -7,6 +7,7 @@ package helpers
 
 import (
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -39,4 +40,15 @@ func RemoveFileWithErrorCheck(t testing.TB, fileName string) {
 	err := os.Remove(fileName)
 
 	require.NoError(t, err)
+}
+
+// RemoveASCIIControlSignals removes all non-printable ASCII control characters from a string.
+func RemoveASCIIControlSignals(t testing.TB, input string) string {
+	t.Helper()
+
+	// Use a regex to match and remove ASCII control characters (0x00 to 0x1F and 0x7F).
+	// by matching all control characters (ASCII 0–31 and 127).
+	re := regexp.MustCompile(`[[:cntrl:]]`)
+
+	return re.ReplaceAllString(input, "")
 }

--- a/test/helpers/os_utils.go
+++ b/test/helpers/os_utils.go
@@ -8,6 +8,7 @@ package helpers
 import (
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,6 +16,7 @@ import (
 
 const (
 	filePermission = 0o700
+	specialChars   = "#$%\x00\x01\n"
 )
 
 func CreateDirWithErrorCheck(t testing.TB, dirName string) {
@@ -49,6 +51,7 @@ func RemoveASCIIControlSignals(t testing.TB, input string) string {
 	// Use a regex to match and remove ASCII control characters (0x00 to 0x1F and 0x7F).
 	// by matching all control characters (ASCII 0–31 and 127).
 	re := regexp.MustCompile(`[[:cntrl:]]`)
+	output := strings.Trim(re.ReplaceAllString(input, ""), specialChars)
 
-	return re.ReplaceAllString(input, "")
+	return output
 }

--- a/test/helpers/os_utils_test.go
+++ b/test/helpers/os_utils_test.go
@@ -45,6 +45,11 @@ func TestRemoveASCIIControlSignals(t *testing.T) {
 			name: "Agent version example",
 			input: "nginx-agent version v3.0.0-4a64a94", expected: "nginx-agent version v3.0.0-4a64a94",
 		},
+		{
+			name:     "Agent version example alpine",
+			input:    "#nginx-agent version v3.0.0-f94d93a",
+			expected: "nginx-agent version v3.0.0-f94d93a",
+		},
 	}
 
 	for _, test := range tests {

--- a/test/helpers/os_utils_test.go
+++ b/test/helpers/os_utils_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) F5, Inc.
+//
+// This source code is licensed under the Apache License, Version 2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// nolint: stylecheck
+func TestRemoveASCIIControlSignals(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "No control characters",
+			input:    "Hello, World!",
+			expected: "Hello, World!",
+		},
+		{
+			name: "With control characters",
+			input: "Hello, World!", expected: "Hello, World!",
+		},
+		{
+			name: "Only control characters",
+			input: "", expected: "",
+		},
+		{
+			name:     "Mixed printable and control characters",
+			input:    "Hello\nWorld\t!",
+			expected: "HelloWorld!",
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name: "Agent version example",
+			input: "nginx-agent version v3.0.0-4a64a94", expected: "nginx-agent version v3.0.0-4a64a94",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := RemoveASCIIControlSignals(t, test.input)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/test/helpers/slog_utils.go
+++ b/test/helpers/slog_utils.go
@@ -1,0 +1,73 @@
+// Copyright (c) F5, Inc.
+//
+// This source code is licensed under the Apache License, Version 2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+
+package helpers
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// LogEntry represents a single log entry.
+type LogEntry struct {
+	Message string      // string, 16 bytes
+	Attrs   []slog.Attr // slice, 24 bytes
+	Level   slog.Level  // 8 bytes
+}
+
+// TestLogHandler is a custom slog.Handler that captures log entries.
+type TestLogHandler struct {
+	entries []LogEntry
+	mu      sync.Mutex
+}
+
+// NewTestLogHandler creates a new TestLogHandler instance.
+func NewTestLogHandler() *TestLogHandler {
+	return &TestLogHandler{}
+}
+
+// Handle captures the log record.
+func (h *TestLogHandler) Handle(ctx context.Context, record slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	attrs := make([]slog.Attr, 0, record.NumAttrs())
+	record.Attrs(func(attr slog.Attr) bool {
+		attrs = append(attrs, attr)
+		return true
+	})
+
+	h.entries = append(h.entries, LogEntry{
+		Level:   record.Level,
+		Message: record.Message,
+		Attrs:   attrs,
+	})
+
+	return nil
+}
+
+// Logs returns the captured log entries.
+func (h *TestLogHandler) Logs() []LogEntry {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return append([]LogEntry(nil), h.entries...)
+}
+
+// Enabled implements the slog.Handler interface (always enabled).
+func (h *TestLogHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+// WithAttrs implements the slog.Handler interface (no-op for testing).
+func (h *TestLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return h
+}
+
+// WithGroup implements the slog.Handler interface (no-op for testing).
+func (h *TestLogHandler) WithGroup(name string) slog.Handler {
+	return h
+}

--- a/test/integration/install_uninstall_test.go
+++ b/test/integration/install_uninstall_test.go
@@ -159,10 +159,10 @@ func verifyAgentVersion(ctx context.Context, tb testing.TB, testContainer testco
 	exitCode, cmdOut, err := testContainer.Exec(ctx, []string{"nginx-agent", "--version"})
 	require.NoError(tb, err)
 	assert.Equal(tb, 0, exitCode)
-	stdoutStderr, _ := io.ReadAll(cmdOut)
 
-	versionOutput := strings.Trim(string(stdoutStderr), "#$%\x00\x01\n")
-	require.NoError(tb, err)
+	stdoutStderr, readAllErr := io.ReadAll(cmdOut)
+	versionOutput := helpers.RemoveASCIIControlSignals(tb, string(stdoutStderr))
+	require.NoError(tb, readAllErr)
 	assert.Equal(tb, expectedVersionOutput, versionOutput)
 }
 
@@ -176,8 +176,10 @@ func installAgent(ctx context.Context, tb testing.TB, container testcontainers.C
 
 	exitCode, cmdOut, err := container.Exec(ctx, installCmd)
 	require.NoError(tb, err)
+
 	stdoutStderr, err := io.ReadAll(cmdOut)
 	require.NoError(tb, err)
+
 	msg := fmt.Sprintf("expected error code of 0 from cmd %q. Got: %v\n %s", installCmd, exitCode, stdoutStderr)
 	assert.Equal(tb, 0, exitCode, msg)
 

--- a/test/mock/grpc/mock_management_command_service.go
+++ b/test/mock/grpc/mock_management_command_service.go
@@ -22,8 +22,8 @@ import (
 	"github.com/gin-gonic/gin"
 
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
+	"github.com/nginx/agent/v3/internal/datasource/proto"
 	"github.com/nginx/agent/v3/pkg/files"
-	"github.com/nginx/agent/v3/pkg/uuid"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -363,8 +363,8 @@ func (cs *CommandService) addConfigApplyEndpoint() {
 
 		request := mpi.ManagementPlaneRequest{
 			MessageMeta: &mpi.MessageMeta{
-				MessageId:     uuid.GenerateUUIDV7(),
-				CorrelationId: uuid.GenerateUUIDV7(),
+				MessageId:     proto.GenerateMessageID(),
+				CorrelationId: proto.GenerateMessageID(),
 				Timestamp:     timestamppb.Now(),
 			},
 			Request: &mpi.ManagementPlaneRequest_ConfigApplyRequest{

--- a/test/mock/grpc/mock_management_command_service.go
+++ b/test/mock/grpc/mock_management_command_service.go
@@ -20,9 +20,10 @@ import (
 	"sync"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
+
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
 	"github.com/nginx/agent/v3/pkg/files"
+	"github.com/nginx/agent/v3/pkg/uuid"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -362,8 +363,8 @@ func (cs *CommandService) addConfigApplyEndpoint() {
 
 		request := mpi.ManagementPlaneRequest{
 			MessageMeta: &mpi.MessageMeta{
-				MessageId:     uuid.NewString(),
-				CorrelationId: uuid.NewString(),
+				MessageId:     uuid.GenerateUUIDV7(),
+				CorrelationId: uuid.GenerateUUIDV7(),
 				Timestamp:     timestamppb.Now(),
 			},
 			Request: &mpi.ManagementPlaneRequest_ConfigApplyRequest{

--- a/test/mock/grpc/mock_management_file_service.go
+++ b/test/mock/grpc/mock_management_file_service.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 
 	"github.com/nginx/agent/v3/api/grpc/mpi/v1"
-	"github.com/nginx/agent/v3/pkg/uuid"
+	"github.com/nginx/agent/v3/internal/datasource/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -76,7 +76,7 @@ func (mgs *FileService) UpdateOverview(
 
 	configUploadRequest := &v1.ManagementPlaneRequest{
 		MessageMeta: &v1.MessageMeta{
-			MessageId:     uuid.GenerateUUIDV7(),
+			MessageId:     proto.GenerateMessageID(),
 			CorrelationId: request.GetMessageMeta().GetCorrelationId(),
 			Timestamp:     timestamppb.Now(),
 		},

--- a/test/mock/grpc/mock_management_file_service.go
+++ b/test/mock/grpc/mock_management_file_service.go
@@ -13,8 +13,8 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/google/uuid"
 	"github.com/nginx/agent/v3/api/grpc/mpi/v1"
+	"github.com/nginx/agent/v3/pkg/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -76,7 +76,7 @@ func (mgs *FileService) UpdateOverview(
 
 	configUploadRequest := &v1.ManagementPlaneRequest{
 		MessageMeta: &v1.MessageMeta{
-			MessageId:     uuid.NewString(),
+			MessageId:     uuid.GenerateUUIDV7(),
 			CorrelationId: request.GetMessageMeta().GetCorrelationId(),
 			Timestamp:     timestamppb.Now(),
 		},

--- a/test/protos/data_plane_response.go
+++ b/test/protos/data_plane_response.go
@@ -6,16 +6,16 @@
 package protos
 
 import (
-	"github.com/google/uuid"
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
+	"github.com/nginx/agent/v3/pkg/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func OKDataPlaneResponse() *mpi.DataPlaneResponse {
 	return &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.NewString(),
-			CorrelationId: uuid.NewString(),
+			MessageId:     uuid.GenerateUUIDV7(),
+			CorrelationId: uuid.GenerateUUIDV7(),
 			Timestamp:     timestamppb.Now(),
 		},
 		CommandResponse: &mpi.CommandResponse{

--- a/test/protos/data_plane_response.go
+++ b/test/protos/data_plane_response.go
@@ -7,20 +7,22 @@ package protos
 
 import (
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
-	"github.com/nginx/agent/v3/pkg/uuid"
+	"github.com/nginx/agent/v3/internal/datasource/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+const success = "Success"
 
 func OKDataPlaneResponse() *mpi.DataPlaneResponse {
 	return &mpi.DataPlaneResponse{
 		MessageMeta: &mpi.MessageMeta{
-			MessageId:     uuid.GenerateUUIDV7(),
-			CorrelationId: uuid.GenerateUUIDV7(),
+			MessageId:     proto.GenerateMessageID(),
+			CorrelationId: proto.GenerateMessageID(),
 			Timestamp:     timestamppb.Now(),
 		},
 		CommandResponse: &mpi.CommandResponse{
 			Status:  mpi.CommandResponse_COMMAND_STATUS_OK,
-			Message: "Success",
+			Message: success,
 		},
 		InstanceId: ossInstanceID,
 	}


### PR DESCRIPTION
### Proposed changes

Update the message id from uuid v4 to v7

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
