### PR TITLE
Add jitter to resty client in the integration tests

### DIFF
--- a/test/integration/nginx_less_mpi_connection_test.go
+++ b/test/integration/nginx_less_mpi_connection_test.go
@@ -16,6 +16,6 @@ func TestNginxLessGrpc_Connection(t *testing.T) {
 	teardownTest := setupConnectionTest(t, true, true)
 	defer teardownTest(t)
 
-	verifyConnection(t, 1)
+	verifyConnection(t, nil, 1)
 	assert.False(t, t.Failed())
 }


### PR DESCRIPTION
### Proposed changes

Add jitter to HTTP client in integration tests

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
