### PR TITLE
Send create connection after disconnect from management plane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,97 +113,97 @@ jobs:
           OS_RELEASE="${{ matrix.container.image }}" OS_VERSION="${{ matrix.container.version }}" \
             make integration-test
 
-#  official-oss-image-integration-tests:
-#    name: Integration Tests - Official OSS Images
-#    needs: build-unsigned-snapshot
-#    if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.ref_name, 'dependabot/') }}
-#    runs-on: ubuntu-22.04
-#    strategy:
-#      matrix:
-#        container:
-#          - image: "bookworm"
-#            version: "stable"
-#            release: "debian"
-#          - image: "bookworm"
-#            version: "mainline"
-#            release: "debian"
-#          - image: "alpine"
-#            version: "stable"
-#            release: "alpine"
-#          - image: "alpine"
-#            version: "mainline"
-#            release: "alpine"
-#    steps:
-#      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-#      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-#        with:
-#          go-version-file: 'go.mod'
-#          cache: false
-#      - name: Download Packages
-#        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
-#        with:
-#          name: nginx-agent-unsigned-snapshots
-#          path: build
-#      - name: Run Integration Tests
-#        run: |
-#          go install github.com/goreleaser/nfpm/v2/cmd/nfpm@${{ env.NFPM_VERSION }}
-#          CONTAINER_NGINX_IMAGE_REGISTRY="docker-registry.nginx.com" \
-#          TAG="${{ matrix.container.version }}-${{ matrix.container.image }}" \
-#          OS_RELEASE="${{ matrix.container.release }}" OS_VERSION="${{ matrix.container.version }}" \
-#            make official-image-integration-test
+  official-oss-image-integration-tests:
+    name: Integration Tests - Official OSS Images
+    needs: build-unsigned-snapshot
+    if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.ref_name, 'dependabot/') }}
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        container:
+          - image: "bookworm"
+            version: "stable"
+            release: "debian"
+          - image: "bookworm"
+            version: "mainline"
+            release: "debian"
+          - image: "alpine"
+            version: "stable"
+            release: "alpine"
+          - image: "alpine"
+            version: "mainline"
+            release: "alpine"
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+      - name: Download Packages
+        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
+        with:
+          name: nginx-agent-unsigned-snapshots
+          path: build
+      - name: Run Integration Tests
+        run: |
+          go install github.com/goreleaser/nfpm/v2/cmd/nfpm@${{ env.NFPM_VERSION }}
+          CONTAINER_NGINX_IMAGE_REGISTRY="docker-registry.nginx.com" \
+          TAG="${{ matrix.container.version }}-${{ matrix.container.image }}" \
+          OS_RELEASE="${{ matrix.container.release }}" OS_VERSION="${{ matrix.container.version }}" \
+            make official-image-integration-test
 
-#  official-plus-image-integration-tests:
-#    name: Integration Tests - Official Plus Images
-#    needs: build-unsigned-snapshot
-#    if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.ref_name, 'dependabot/') }}
-#    runs-on: ubuntu-22.04
-#    strategy:
-#      matrix:
-#        container:
-#        - image: "alpine"
-#          version: "3.20"
-#          plus: "r32"
-#          release: "alpine"
-#          path: "/nginx-plus/agent"
-#        - image: "alpine"
-#          version: "3.19"
-#          plus: "r31"
-#          release: "alpine"
-#          path: "/nginx-plus/agent"
-#        - image: "debian"
-#          version: "bookworm"
-#          plus: "r32"
-#          release: "debian"
-#          path: "/nginx-plus/agent"
-#        - image: "debian"
-#          version: "bookworm"
-#          plus: "r31"
-#          release: "debian"
-#          path: "/nginx-plus/agent"
-#    steps:
-#      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-#      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-#        with:
-#          go-version-file: 'go.mod'
-#          cache: false
-#      - name: Download Packages
-#        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
-#        with:
-#          name: nginx-agent-unsigned-snapshots
-#          path: build
-#      - name: Login to Docker Registry
-#        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-#        with:
-#          registry: ${{ secrets.REGISTRY_URL }}
-#          username: ${{ secrets.REGISTRY_USERNAME }}
-#          password: ${{ secrets.REGISTRY_PASSWORD }}
-#      - name: Run Integration Tests
-#        run: |
-#          go install github.com/goreleaser/nfpm/v2/cmd/nfpm@${{ env.NFPM_VERSION }}
-#          CONTAINER_NGINX_IMAGE_REGISTRY="${{ secrets.REGISTRY_URL }}" \
-#          TAG="${{ matrix.container.plus }}-${{ matrix.container.image }}-${{ matrix.container.version }}" \
-#          OS_RELEASE="${{ matrix.container.release }}" OS_VERSION="${{ matrix.container.version }}" IMAGE_PATH="${{ matrix.container.path }}" \
-#            make official-image-integration-test
+  official-plus-image-integration-tests:
+    name: Integration Tests - Official Plus Images
+    needs: build-unsigned-snapshot
+    if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.ref_name, 'dependabot/') }}
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        container:
+        - image: "alpine"
+          version: "3.20"
+          plus: "r32"
+          release: "alpine"
+          path: "/nginx-plus/agent"
+        - image: "alpine"
+          version: "3.19"
+          plus: "r31"
+          release: "alpine"
+          path: "/nginx-plus/agent"
+        - image: "debian"
+          version: "bookworm"
+          plus: "r32"
+          release: "debian"
+          path: "/nginx-plus/agent"
+        - image: "debian"
+          version: "bookworm"
+          plus: "r31"
+          release: "debian"
+          path: "/nginx-plus/agent"
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+      - name: Download Packages
+        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
+        with:
+          name: nginx-agent-unsigned-snapshots
+          path: build
+      - name: Login to Docker Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ secrets.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Run Integration Tests
+        run: |
+          go install github.com/goreleaser/nfpm/v2/cmd/nfpm@${{ env.NFPM_VERSION }}
+          CONTAINER_NGINX_IMAGE_REGISTRY="${{ secrets.REGISTRY_URL }}" \
+          TAG="${{ matrix.container.plus }}-${{ matrix.container.image }}-${{ matrix.container.version }}" \
+          OS_RELEASE="${{ matrix.container.release }}" OS_VERSION="${{ matrix.container.version }}" IMAGE_PATH="${{ matrix.container.path }}" \
+            make official-image-integration-test
 
   performance-tests:
     name: Performance Tests
@@ -312,9 +312,8 @@ jobs:
     if: ${{ github.ref_name == 'v3' &&
       !github.event.pull_request.head.repo.fork }}
     needs: [ lint, unit-test, performance-tests,
-             load-tests,
-#             official-oss-image-integration-tests,
-#             official-plus-image-integration-tests,
+             load-tests, official-oss-image-integration-tests,
+             official-plus-image-integration-tests,
              race-condition-test, integration-tests ]
     uses: ./.github/workflows/release-branch.yml
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,97 +113,97 @@ jobs:
           OS_RELEASE="${{ matrix.container.image }}" OS_VERSION="${{ matrix.container.version }}" \
             make integration-test
 
-  official-oss-image-integration-tests:
-    name: Integration Tests - Official OSS Images
-    needs: build-unsigned-snapshot
-    if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.ref_name, 'dependabot/') }}
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        container:
-          - image: "bookworm"
-            version: "stable"
-            release: "debian"
-          - image: "bookworm"
-            version: "mainline"
-            release: "debian"
-          - image: "alpine"
-            version: "stable"
-            release: "alpine"
-          - image: "alpine"
-            version: "mainline"
-            release: "alpine"
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-        with:
-          go-version-file: 'go.mod'
-          cache: false
-      - name: Download Packages
-        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
-        with:
-          name: nginx-agent-unsigned-snapshots
-          path: build
-      - name: Run Integration Tests
-        run: |
-          go install github.com/goreleaser/nfpm/v2/cmd/nfpm@${{ env.NFPM_VERSION }}
-          CONTAINER_NGINX_IMAGE_REGISTRY="docker-registry.nginx.com" \
-          TAG="${{ matrix.container.version }}-${{ matrix.container.image }}" \
-          OS_RELEASE="${{ matrix.container.release }}" OS_VERSION="${{ matrix.container.version }}" \
-            make official-image-integration-test
+#  official-oss-image-integration-tests:
+#    name: Integration Tests - Official OSS Images
+#    needs: build-unsigned-snapshot
+#    if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.ref_name, 'dependabot/') }}
+#    runs-on: ubuntu-22.04
+#    strategy:
+#      matrix:
+#        container:
+#          - image: "bookworm"
+#            version: "stable"
+#            release: "debian"
+#          - image: "bookworm"
+#            version: "mainline"
+#            release: "debian"
+#          - image: "alpine"
+#            version: "stable"
+#            release: "alpine"
+#          - image: "alpine"
+#            version: "mainline"
+#            release: "alpine"
+#    steps:
+#      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+#      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+#        with:
+#          go-version-file: 'go.mod'
+#          cache: false
+#      - name: Download Packages
+#        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
+#        with:
+#          name: nginx-agent-unsigned-snapshots
+#          path: build
+#      - name: Run Integration Tests
+#        run: |
+#          go install github.com/goreleaser/nfpm/v2/cmd/nfpm@${{ env.NFPM_VERSION }}
+#          CONTAINER_NGINX_IMAGE_REGISTRY="docker-registry.nginx.com" \
+#          TAG="${{ matrix.container.version }}-${{ matrix.container.image }}" \
+#          OS_RELEASE="${{ matrix.container.release }}" OS_VERSION="${{ matrix.container.version }}" \
+#            make official-image-integration-test
 
-  official-plus-image-integration-tests:
-    name: Integration Tests - Official Plus Images
-    needs: build-unsigned-snapshot
-    if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.ref_name, 'dependabot/') }}
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        container:
-        - image: "alpine"
-          version: "3.20"
-          plus: "r32"
-          release: "alpine"
-          path: "/nginx-plus/agent"
-        - image: "alpine"
-          version: "3.19"
-          plus: "r31"
-          release: "alpine"
-          path: "/nginx-plus/agent"
-        - image: "debian"
-          version: "bookworm"
-          plus: "r32"
-          release: "debian"
-          path: "/nginx-plus/agent"
-        - image: "debian"
-          version: "bookworm"
-          plus: "r31"
-          release: "debian"
-          path: "/nginx-plus/agent"
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-        with:
-          go-version-file: 'go.mod'
-          cache: false
-      - name: Download Packages
-        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
-        with:
-          name: nginx-agent-unsigned-snapshots
-          path: build
-      - name: Login to Docker Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          registry: ${{ secrets.REGISTRY_URL }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-      - name: Run Integration Tests
-        run: |
-          go install github.com/goreleaser/nfpm/v2/cmd/nfpm@${{ env.NFPM_VERSION }}
-          CONTAINER_NGINX_IMAGE_REGISTRY="${{ secrets.REGISTRY_URL }}" \
-          TAG="${{ matrix.container.plus }}-${{ matrix.container.image }}-${{ matrix.container.version }}" \
-          OS_RELEASE="${{ matrix.container.release }}" OS_VERSION="${{ matrix.container.version }}" IMAGE_PATH="${{ matrix.container.path }}" \
-            make official-image-integration-test
+#  official-plus-image-integration-tests:
+#    name: Integration Tests - Official Plus Images
+#    needs: build-unsigned-snapshot
+#    if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.ref_name, 'dependabot/') }}
+#    runs-on: ubuntu-22.04
+#    strategy:
+#      matrix:
+#        container:
+#        - image: "alpine"
+#          version: "3.20"
+#          plus: "r32"
+#          release: "alpine"
+#          path: "/nginx-plus/agent"
+#        - image: "alpine"
+#          version: "3.19"
+#          plus: "r31"
+#          release: "alpine"
+#          path: "/nginx-plus/agent"
+#        - image: "debian"
+#          version: "bookworm"
+#          plus: "r32"
+#          release: "debian"
+#          path: "/nginx-plus/agent"
+#        - image: "debian"
+#          version: "bookworm"
+#          plus: "r31"
+#          release: "debian"
+#          path: "/nginx-plus/agent"
+#    steps:
+#      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+#      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+#        with:
+#          go-version-file: 'go.mod'
+#          cache: false
+#      - name: Download Packages
+#        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
+#        with:
+#          name: nginx-agent-unsigned-snapshots
+#          path: build
+#      - name: Login to Docker Registry
+#        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+#        with:
+#          registry: ${{ secrets.REGISTRY_URL }}
+#          username: ${{ secrets.REGISTRY_USERNAME }}
+#          password: ${{ secrets.REGISTRY_PASSWORD }}
+#      - name: Run Integration Tests
+#        run: |
+#          go install github.com/goreleaser/nfpm/v2/cmd/nfpm@${{ env.NFPM_VERSION }}
+#          CONTAINER_NGINX_IMAGE_REGISTRY="${{ secrets.REGISTRY_URL }}" \
+#          TAG="${{ matrix.container.plus }}-${{ matrix.container.image }}-${{ matrix.container.version }}" \
+#          OS_RELEASE="${{ matrix.container.release }}" OS_VERSION="${{ matrix.container.version }}" IMAGE_PATH="${{ matrix.container.path }}" \
+#            make official-image-integration-test
 
   performance-tests:
     name: Performance Tests
@@ -312,8 +312,9 @@ jobs:
     if: ${{ github.ref_name == 'v3' &&
       !github.event.pull_request.head.repo.fork }}
     needs: [ lint, unit-test, performance-tests,
-             load-tests, official-oss-image-integration-tests,
-             official-plus-image-integration-tests,
+             load-tests,
+#             official-oss-image-integration-tests,
+#             official-plus-image-integration-tests,
              race-condition-test, integration-tests ]
     uses: ./.github/workflows/release-branch.yml
     secrets: inherit

--- a/internal/command/command_service_test.go
+++ b/internal/command/command_service_test.go
@@ -115,9 +115,9 @@ func TestCommandService_receiveCallback_configApplyRequest(t *testing.T) {
 	)
 
 	nginxInstance := protos.GetNginxOssInstance([]string{})
-	commandService.instancesMutex.Lock()
-	commandService.instances = append(commandService.instances, nginxInstance)
-	commandService.instancesMutex.Unlock()
+	commandService.resourceMutex.Lock()
+	commandService.resource.Instances = append(commandService.resource.Instances, nginxInstance)
+	commandService.resourceMutex.Unlock()
 
 	defer commandService.CancelSubscription(ctx)
 
@@ -414,9 +414,9 @@ func TestCommandService_isValidRequest(t *testing.T) {
 
 	nginxInstance := protos.GetNginxOssInstance([]string{})
 
-	commandService.instancesMutex.Lock()
-	commandService.instances = append(commandService.instances, nginxInstance)
-	commandService.instancesMutex.Unlock()
+	commandService.resourceMutex.Lock()
+	commandService.resource.Instances = append(commandService.resource.Instances, nginxInstance)
+	commandService.resourceMutex.Unlock()
 
 	testCases := []struct {
 		req    *mpi.ManagementPlaneRequest

--- a/internal/resource/resource_service.go
+++ b/internal/resource/resource_service.go
@@ -267,7 +267,9 @@ func (r *ResourceService) UpdateHTTPUpstreamServers(ctx context.Context, instanc
 
 	added, updated, deleted, updateError := plusClient.UpdateHTTPServers(ctx, upstream, servers)
 
-	slog.Warn("Error returned from NGINX Plus client, UpdateHTTPUpstreamServers", "err", updateError)
+	if updateError != nil {
+		slog.Warn("Error returned from NGINX Plus client, UpdateHTTPUpstreamServers", "err", updateError)
+	}
 
 	return added, updated, deleted, createPlusAPIError(updateError)
 }

--- a/test/integration/grpc_management_plane_api_test.go
+++ b/test/integration/grpc_management_plane_api_test.go
@@ -186,11 +186,12 @@ func setupLocalEnvironment(tb testing.TB) {
 
 func TestGrpc_Reconnection(t *testing.T) {
 	ctx := context.Background()
-	teardownTest := setupConnectionTest(t, true, false)
+	teardownTest := setupConnectionTest(t, false, false)
 	defer teardownTest(t)
 
 	timeout := 30 * time.Second
 
+	t.Logf("-------------------------------- Verify Original Connection")
 	originalID := verifyConnection(t, 2)
 
 	stopErr := mockManagementPlaneGrpcContainer.Stop(ctx, &timeout)
@@ -208,6 +209,7 @@ func TestGrpc_Reconnection(t *testing.T) {
 
 	time.Sleep(60 * time.Second)
 
+	t.Logf("-------------------------------- Verify Next Connection")
 	currentID := verifyConnection(t, 2)
 	assert.Equal(t, originalID, currentID)
 }

--- a/test/integration/grpc_management_plane_api_test.go
+++ b/test/integration/grpc_management_plane_api_test.go
@@ -231,6 +231,7 @@ func verifyConnection(t *testing.T, instancesLength int) string {
 	url := fmt.Sprintf("http://%s/api/v1/connection", mockManagementPlaneAPIAddress)
 	resp, err := client.R().EnableTrace().Get(url)
 
+	t.Logf("------------ url: %s", url)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode())
 

--- a/test/integration/grpc_management_plane_api_test.go
+++ b/test/integration/grpc_management_plane_api_test.go
@@ -12,6 +12,8 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"slices"
+	"sort"
 	"testing"
 	"time"
 
@@ -29,6 +31,10 @@ import (
 )
 
 const (
+	configApplyErrorMessage = "failed validating config NGINX config test failed exit status 1:" +
+		" nginx: [emerg] unexpected end of file, expecting \";\" or \"}\" in /etc/nginx/nginx.conf:2\nnginx: " +
+		"configuration file /etc/nginx/nginx.conf test failed\n"
+
 	retryCount       = 5
 	retryWaitTime    = 2 * time.Second
 	retryMaxWaitTime = 3 * time.Second
@@ -189,9 +195,8 @@ func TestGrpc_Reconnection(t *testing.T) {
 	teardownTest := setupConnectionTest(t, false, false)
 	defer teardownTest(t)
 
-	timeout := 30 * time.Second
+	timeout := 15 * time.Second
 
-	t.Logf("-------------------------------- Verify Original Connection")
 	originalID := verifyConnection(t, 2)
 
 	stopErr := mockManagementPlaneGrpcContainer.Stop(ctx, &timeout)
@@ -201,15 +206,14 @@ func TestGrpc_Reconnection(t *testing.T) {
 	startErr := mockManagementPlaneGrpcContainer.Start(ctx)
 	require.NoError(t, startErr)
 
-	// ipAddress, err := mockManagementPlaneGrpcContainer.Host(ctx)
-	// require.NoError(t, err)
-	// ports, err := mockManagementPlaneGrpcContainer.Ports(ctx)
-	// require.NoError(t, err)
-	// mockManagementPlaneAPIAddress = net.JoinHostPort(ipAddress, ports["9093/tcp"][0].HostPort)
+	ipAddress, err := mockManagementPlaneGrpcContainer.Host(ctx)
+	require.NoError(t, err)
+	ports, err := mockManagementPlaneGrpcContainer.Ports(ctx)
+	require.NoError(t, err)
+	mockManagementPlaneAPIAddress = net.JoinHostPort(ipAddress, ports["9093/tcp"][0].HostPort)
 
-	time.Sleep(60 * time.Second)
+	time.Sleep(5 * time.Second)
 
-	t.Logf("-------------------------------- Verify Next Connection")
 	currentID := verifyConnection(t, 2)
 	assert.Equal(t, originalID, currentID)
 }
@@ -224,6 +228,336 @@ func TestGrpc_StartUp(t *testing.T) {
 	verifyUpdateDataPlaneHealth(t)
 }
 
+func TestGrpc_ConfigUpload(t *testing.T) {
+	teardownTest := setupConnectionTest(t, true, false)
+	defer teardownTest(t)
+
+	nginxInstanceID := verifyConnection(t, 2)
+	assert.False(t, t.Failed())
+
+	responses := getManagementPlaneResponses(t, 1)
+
+	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
+	assert.Equal(t, "Successfully updated all files", responses[0].GetCommandResponse().GetMessage())
+
+	request := fmt.Sprintf(`{
+	"message_meta": {
+		"message_id": "5d0fa83e-351c-4009-90cd-1f2acce2d184",
+		"correlation_id": "79794c1c-8e91-47c1-a92c-b9a0c3f1a263",
+		"timestamp": "2023-01-15T01:30:15.01Z"
+	},
+	"config_upload_request": {
+      "overview" : {
+        "config_version": {
+          "instance_id": "%s"
+        }
+      }
+	}
+}`, nginxInstanceID)
+
+	t.Logf("Sending config upload request: %s", request)
+
+	client := resty.New()
+	client.SetRetryCount(retryCount).SetRetryWaitTime(retryWaitTime).SetRetryMaxWaitTime(retryMaxWaitTime)
+
+	url := fmt.Sprintf("http://%s/api/v1/requests", mockManagementPlaneAPIAddress)
+	resp, err := client.R().EnableTrace().SetBody(request).Post(url)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode())
+
+	responses = getManagementPlaneResponses(t, 2)
+
+	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
+	assert.Equal(t, "Successfully updated all files", responses[0].GetCommandResponse().GetMessage())
+	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[1].GetCommandResponse().GetStatus())
+	assert.Equal(t, "Successfully updated all files", responses[1].GetCommandResponse().GetMessage())
+}
+
+func TestGrpc_ConfigApply(t *testing.T) {
+	ctx := context.Background()
+	teardownTest := setupConnectionTest(t, false, false)
+	defer teardownTest(t)
+
+	instanceType := "OSS"
+	if os.Getenv("IMAGE_PATH") == "/nginx-plus/agent" {
+		instanceType = "PLUS"
+	}
+
+	nginxInstanceID := verifyConnection(t, 2)
+
+	responses := getManagementPlaneResponses(t, 1)
+	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
+	assert.Equal(t, "Successfully updated all files", responses[0].GetCommandResponse().GetMessage())
+
+	t.Run("Test 1: No config changes", func(t *testing.T) {
+		clearManagementPlaneResponses(t)
+		performConfigApply(t, nginxInstanceID)
+		responses = getManagementPlaneResponses(t, 1)
+		t.Logf("Config apply responses: %v", responses)
+
+		assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
+		assert.Equal(t, "Config apply successful, no files to change", responses[0].GetCommandResponse().GetMessage())
+	})
+
+	t.Run("Test 2: Valid config", func(t *testing.T) {
+		clearManagementPlaneResponses(t)
+		err := mockManagementPlaneGrpcContainer.CopyFileToContainer(
+			ctx,
+			"../config/nginx/nginx-with-test-location.conf",
+			fmt.Sprintf("/mock-management-plane-grpc/config/%s/etc/nginx/nginx.conf", nginxInstanceID),
+			0o666,
+		)
+		require.NoError(t, err)
+
+		performConfigApply(t, nginxInstanceID)
+
+		if instanceType == "OSS" {
+			responses = getManagementPlaneResponses(t, 1)
+			t.Logf("Config apply responses: %v", responses)
+
+			assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
+			assert.Equal(t, "Config apply successful", responses[0].GetCommandResponse().GetMessage())
+		} else {
+			// NGINX Plus contains two extra Successfully updated all files responses as the NginxConfigContext
+			// is updated, and the file overview is then updated
+			responses = getManagementPlaneResponses(t, 3)
+			t.Logf("Config apply responses: %v", responses)
+			assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
+			assert.Equal(t, "Config apply successful", responses[0].GetCommandResponse().GetMessage())
+			assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[1].GetCommandResponse().GetStatus())
+			assert.Equal(t, "Successfully updated all files", responses[1].GetCommandResponse().GetMessage())
+			assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[2].GetCommandResponse().GetStatus())
+			assert.Equal(t, "Successfully updated all files", responses[2].GetCommandResponse().GetMessage())
+		}
+	})
+
+	t.Run("Test 3: Invalid config", func(t *testing.T) {
+		clearManagementPlaneResponses(t)
+		err := mockManagementPlaneGrpcContainer.CopyFileToContainer(
+			ctx,
+			"../config/nginx/invalid-nginx.conf",
+			fmt.Sprintf("/mock-management-plane-grpc/config/%s/etc/nginx/nginx.conf", nginxInstanceID),
+			0o666,
+		)
+		require.NoError(t, err)
+
+		performConfigApply(t, nginxInstanceID)
+
+		if instanceType == "OSS" {
+			responses = getManagementPlaneResponses(t, 2)
+			t.Logf("Config apply responses: %v", responses)
+
+			assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_ERROR, responses[0].GetCommandResponse().GetStatus())
+			assert.Equal(t, "Config apply failed, rolling back config", responses[0].GetCommandResponse().GetMessage())
+			assert.Equal(t, configApplyErrorMessage, responses[0].GetCommandResponse().GetError())
+			assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_FAILURE, responses[1].GetCommandResponse().GetStatus())
+			assert.Equal(t, "Config apply failed, rollback successful", responses[1].GetCommandResponse().GetMessage())
+			assert.Equal(t, configApplyErrorMessage, responses[1].GetCommandResponse().GetError())
+		} else {
+			responses = getManagementPlaneResponses(t, 2)
+			t.Logf("Config apply responses: %v", len(responses))
+
+			assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_ERROR, responses[0].GetCommandResponse().GetStatus())
+			assert.Equal(t, "Config apply failed, rolling back config", responses[0].GetCommandResponse().GetMessage())
+			assert.Equal(t, configApplyErrorMessage, responses[0].GetCommandResponse().GetError())
+			assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_FAILURE, responses[1].GetCommandResponse().GetStatus())
+			assert.Equal(t, "Config apply failed, rollback successful", responses[1].GetCommandResponse().GetMessage())
+			assert.Equal(t, configApplyErrorMessage, responses[1].GetCommandResponse().GetError())
+		}
+	})
+
+	t.Run("Test 4: File not in allowed directory", func(t *testing.T) {
+		clearManagementPlaneResponses(t)
+		performInvalidConfigApply(t, nginxInstanceID)
+
+		responses = getManagementPlaneResponses(t, 1)
+		t.Logf("Config apply responses: %v", responses)
+
+		assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_FAILURE, responses[0].GetCommandResponse().GetStatus())
+		assert.Equal(t, "Config apply failed", responses[0].GetCommandResponse().GetMessage())
+		assert.Equal(
+			t,
+			"file not in allowed directories /unknown/nginx.conf",
+			responses[0].GetCommandResponse().GetError(),
+		)
+	})
+}
+
+func TestGrpc_FileWatcher(t *testing.T) {
+	ctx := context.Background()
+	teardownTest := setupConnectionTest(t, true, false)
+	defer teardownTest(t)
+
+	verifyConnection(t, 2)
+	assert.False(t, t.Failed())
+
+	err := container.CopyFileToContainer(
+		ctx,
+		"../config/nginx/nginx-with-server-block-access-log.conf",
+		"/etc/nginx/nginx.conf",
+		0o666,
+	)
+	require.NoError(t, err)
+
+	responses := getManagementPlaneResponses(t, 2)
+	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
+	assert.Equal(t, "Successfully updated all files", responses[0].GetCommandResponse().GetMessage())
+	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[1].GetCommandResponse().GetStatus())
+	assert.Equal(t, "Successfully updated all files", responses[1].GetCommandResponse().GetMessage())
+
+	verifyUpdateDataPlaneStatus(t)
+}
+
+func TestGrpc_DataplaneHealthRequest(t *testing.T) {
+	teardownTest := setupConnectionTest(t, true, false)
+	defer teardownTest(t)
+
+	verifyConnection(t, 2)
+
+	responses := getManagementPlaneResponses(t, 1)
+	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
+	assert.Equal(t, "Successfully updated all files", responses[0].GetCommandResponse().GetMessage())
+
+	assert.False(t, t.Failed())
+
+	request := `{
+			"message_meta": {
+				"message_id": "5d0fa83e-351c-4009-90cd-1f2acce2d184",
+				"correlation_id": "79794c1c-8e91-47c1-a92c-b9a0c3f1a263",
+				"timestamp": "2023-01-15T01:30:15.01Z"
+			},
+			"health_request": {}
+		}`
+
+	client := resty.New()
+	client.SetRetryCount(retryCount).SetRetryWaitTime(retryWaitTime).SetRetryMaxWaitTime(retryMaxWaitTime)
+
+	url := fmt.Sprintf("http://%s/api/v1/requests", mockManagementPlaneAPIAddress)
+	resp, err := client.R().EnableTrace().SetBody(request).Post(url)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode())
+
+	responses = getManagementPlaneResponses(t, 2)
+
+	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[1].GetCommandResponse().GetStatus())
+	assert.Equal(t, "Successfully sent the health status update", responses[1].GetCommandResponse().GetMessage())
+}
+
+func performConfigApply(t *testing.T, nginxInstanceID string) {
+	t.Helper()
+
+	client := resty.New()
+	client.SetRetryCount(retryCount).SetRetryWaitTime(retryWaitTime).SetRetryMaxWaitTime(retryMaxWaitTime)
+
+	url := fmt.Sprintf("http://%s/api/v1/instance/%s/config/apply", mockManagementPlaneAPIAddress, nginxInstanceID)
+	resp, err := client.R().EnableTrace().Post(url)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode())
+}
+
+func performInvalidConfigApply(t *testing.T, nginxInstanceID string) {
+	t.Helper()
+
+	client := resty.New()
+	client.SetRetryCount(retryCount).SetRetryWaitTime(retryWaitTime).SetRetryMaxWaitTime(retryMaxWaitTime)
+
+	body := fmt.Sprintf(`{
+			"message_meta": {
+				"message_id": "e2254df9-8edd-4900-91ce-88782473bcb9",
+				"correlation_id": "9673f3b4-bf33-4d98-ade1-ded9266f6818",
+				"timestamp": "2023-01-15T01:30:15.01Z"
+			},
+			"config_apply_request": {
+				"overview": {
+					"files": [{
+						"file_meta": {
+							"name": "/etc/nginx/nginx.conf",
+							"hash": "ea57e443-e968-3a50-b842-f37112acde71",
+							"modifiedTime": "2023-01-15T01:30:15.01Z",
+							"permissions": "0644",
+							"size": 0
+						},
+						"action": "FILE_ACTION_UPDATE"
+					}, 
+					{
+						"file_meta": {
+							"name": "/unknown/nginx.conf",
+							"hash": "bd1f337d-6874-35ea-9d4d-2b543efd42cf",
+							"modifiedTime": "2023-01-15T01:30:15.01Z",
+							"permissions": "0644",
+							"size": 0
+						},
+						"action": "FILE_ACTION_ADD"
+					}],
+					"config_version": {
+						"instance_id": "%s",
+						"version": "6f343257-55e3-309e-a2eb-bb13af5f80f4"
+					}
+				}
+			}
+		}`, nginxInstanceID)
+	url := fmt.Sprintf("http://%s/api/v1/requests", mockManagementPlaneAPIAddress)
+	resp, err := client.R().EnableTrace().SetBody(body).Post(url)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode())
+}
+
+func getManagementPlaneResponses(t *testing.T, numberOfExpectedResponses int) []*mpi.DataPlaneResponse {
+	t.Helper()
+
+	client := resty.New()
+	client.SetRetryCount(retryCount).SetRetryWaitTime(retryWaitTime).SetRetryMaxWaitTime(retryMaxWaitTime)
+	client.AddRetryCondition(
+		func(r *resty.Response, err error) bool {
+			responseData := r.Body()
+			assert.True(t, json.Valid(responseData))
+
+			response := []*mpi.DataPlaneResponse{}
+			unmarshalErr := json.Unmarshal(responseData, &response)
+			require.NoError(t, unmarshalErr)
+
+			return len(response) != numberOfExpectedResponses || r.StatusCode() == http.StatusNotFound
+		},
+	)
+
+	url := fmt.Sprintf("http://%s/api/v1/responses", mockManagementPlaneAPIAddress)
+	resp, err := client.R().EnableTrace().Get(url)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode())
+
+	responseData := resp.Body()
+	t.Logf("Responses: %s", string(responseData))
+	assert.True(t, json.Valid(responseData))
+
+	response := []*mpi.DataPlaneResponse{}
+	unmarshalErr := json.Unmarshal(responseData, &response)
+	require.NoError(t, unmarshalErr)
+
+	assert.Len(t, response, numberOfExpectedResponses)
+
+	slices.SortFunc(response, func(a, b *mpi.DataPlaneResponse) int {
+		return a.GetMessageMeta().GetTimestamp().AsTime().Compare(b.GetMessageMeta().GetTimestamp().AsTime())
+	})
+
+	return response
+}
+
+func clearManagementPlaneResponses(t *testing.T) {
+	t.Helper()
+
+	client := resty.New()
+
+	url := fmt.Sprintf("http://%s/api/v1/responses", mockManagementPlaneAPIAddress)
+	resp, err := client.R().EnableTrace().Delete(url)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode())
+}
+
 func verifyConnection(t *testing.T, instancesLength int) string {
 	t.Helper()
 
@@ -233,7 +567,6 @@ func verifyConnection(t *testing.T, instancesLength int) string {
 	url := fmt.Sprintf("http://%s/api/v1/connection", mockManagementPlaneAPIAddress)
 	resp, err := client.R().EnableTrace().Get(url)
 
-	t.Logf("------------ url: %s", url)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode())
 
@@ -342,4 +675,69 @@ func verifyUpdateDataPlaneHealth(t *testing.T) {
 	// Verify health metadata
 	assert.NotEmpty(t, healths[0].GetInstanceId())
 	assert.Equal(t, mpi.InstanceHealth_INSTANCE_HEALTH_STATUS_HEALTHY, healths[0].GetInstanceHealthStatus())
+}
+
+func verifyUpdateDataPlaneStatus(t *testing.T) {
+	t.Helper()
+
+	client := resty.New()
+	client.SetRetryCount(3).SetRetryWaitTime(50 * time.Millisecond).SetRetryMaxWaitTime(200 * time.Millisecond)
+
+	url := fmt.Sprintf("http://%s/api/v1/status", mockManagementPlaneAPIAddress)
+	resp, err := client.R().EnableTrace().Get(url)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode())
+
+	updateDataPlaneStatusRequest := mpi.UpdateDataPlaneStatusRequest{}
+
+	responseData := resp.Body()
+	t.Logf("Response: %s", string(responseData))
+	assert.True(t, json.Valid(responseData))
+
+	pb := protojson.UnmarshalOptions{DiscardUnknown: true}
+	unmarshalErr := pb.Unmarshal(responseData, &updateDataPlaneStatusRequest)
+	require.NoError(t, unmarshalErr)
+
+	t.Logf("UpdateDataPlaneStatusRequest: %v", &updateDataPlaneStatusRequest)
+
+	assert.NotNil(t, &updateDataPlaneStatusRequest)
+
+	// Verify message metadata
+	messageMeta := updateDataPlaneStatusRequest.GetMessageMeta()
+	assert.NotEmpty(t, messageMeta.GetCorrelationId())
+	assert.NotEmpty(t, messageMeta.GetMessageId())
+	assert.NotEmpty(t, messageMeta.GetTimestamp())
+
+	instances := updateDataPlaneStatusRequest.GetResource().GetInstances()
+	sort.Slice(instances, func(i, j int) bool {
+		return instances[i].GetInstanceMeta().GetInstanceType() < instances[j].GetInstanceMeta().GetInstanceType()
+	})
+	assert.Len(t, instances, 2)
+
+	// Verify agent instance metadata
+	assert.NotEmpty(t, instances[0].GetInstanceMeta().GetInstanceId())
+	assert.Equal(t, mpi.InstanceMeta_INSTANCE_TYPE_AGENT, instances[0].GetInstanceMeta().GetInstanceType())
+	assert.NotEmpty(t, instances[0].GetInstanceMeta().GetVersion())
+
+	// Verify agent instance configuration
+	assert.Empty(t, instances[0].GetInstanceConfig().GetActions())
+	assert.NotEmpty(t, instances[0].GetInstanceRuntime().GetProcessId())
+	assert.Equal(t, "/usr/bin/nginx-agent", instances[0].GetInstanceRuntime().GetBinaryPath())
+	assert.Equal(t, "/etc/nginx-agent/nginx-agent.conf", instances[0].GetInstanceRuntime().GetConfigPath())
+
+	// Verify NGINX instance metadata
+	assert.NotEmpty(t, instances[1].GetInstanceMeta().GetInstanceId())
+	if os.Getenv("IMAGE_PATH") == "/nginx-plus/agent" {
+		assert.Equal(t, mpi.InstanceMeta_INSTANCE_TYPE_NGINX_PLUS, instances[1].GetInstanceMeta().GetInstanceType())
+	} else {
+		assert.Equal(t, mpi.InstanceMeta_INSTANCE_TYPE_NGINX, instances[1].GetInstanceMeta().GetInstanceType())
+	}
+	assert.NotEmpty(t, instances[1].GetInstanceMeta().GetVersion())
+
+	// Verify NGINX instance configuration
+	assert.Empty(t, instances[1].GetInstanceConfig().GetActions())
+	assert.NotEmpty(t, instances[1].GetInstanceRuntime().GetProcessId())
+	assert.Equal(t, "/usr/sbin/nginx", instances[1].GetInstanceRuntime().GetBinaryPath())
+	assert.Equal(t, "/etc/nginx/nginx.conf", instances[1].GetInstanceRuntime().GetConfigPath())
 }

--- a/test/integration/grpc_management_plane_api_test.go
+++ b/test/integration/grpc_management_plane_api_test.go
@@ -206,7 +206,7 @@ func TestGrpc_Reconnection(t *testing.T) {
 	// require.NoError(t, err)
 	// mockManagementPlaneAPIAddress = net.JoinHostPort(ipAddress, ports["9093/tcp"][0].HostPort)
 
-	time.Sleep(10 * time.Second)
+	time.Sleep(60 * time.Second)
 
 	currentID := verifyConnection(t, 2)
 	assert.Equal(t, originalID, currentID)

--- a/test/integration/grpc_management_plane_api_test.go
+++ b/test/integration/grpc_management_plane_api_test.go
@@ -200,11 +200,14 @@ func TestGrpc_Reconnection(t *testing.T) {
 	startErr := mockManagementPlaneGrpcContainer.Start(ctx)
 	require.NoError(t, startErr)
 
-	ipAddress, err := mockManagementPlaneGrpcContainer.Host(ctx)
-	require.NoError(t, err)
-	ports, err := mockManagementPlaneGrpcContainer.Ports(ctx)
-	require.NoError(t, err)
-	mockManagementPlaneAPIAddress = net.JoinHostPort(ipAddress, ports["9093/tcp"][0].HostPort)
+	//ipAddress, err := mockManagementPlaneGrpcContainer.Host(ctx)
+	//require.NoError(t, err)
+	//ports, err := mockManagementPlaneGrpcContainer.Ports(ctx)
+	//require.NoError(t, err)
+	//mockManagementPlaneAPIAddress = net.JoinHostPort(ipAddress, ports["9093/tcp"][0].HostPort)
+
+	time.Sleep(10 * time.Second)
+
 	currentID := verifyConnection(t, 2)
 	assert.Equal(t, originalID, currentID)
 }
@@ -225,7 +228,6 @@ func verifyConnection(t *testing.T, instancesLength int) string {
 	client := resty.New()
 	client.SetRetryCount(retryCount).SetRetryWaitTime(retryWaitTime).SetRetryMaxWaitTime(retryMaxWaitTime)
 
-	t.Logf("-------- mockManagementPlaneAPIAddress: %s", mockManagementPlaneAPIAddress)
 	url := fmt.Sprintf("http://%s/api/v1/connection", mockManagementPlaneAPIAddress)
 	resp, err := client.R().EnableTrace().Get(url)
 

--- a/test/integration/grpc_management_plane_api_test.go
+++ b/test/integration/grpc_management_plane_api_test.go
@@ -199,7 +199,7 @@ func TestGrpc_Reconnection(t *testing.T) {
 
 	startErr := mockManagementPlaneGrpcContainer.Start(ctx)
 	require.NoError(t, startErr)
-	
+
 	mockManagementPlaneGrpcAddress = "managementPlane:9092"
 	currentID := verifyConnection(t, 2)
 	assert.Equal(t, originalID, currentID)

--- a/test/integration/grpc_management_plane_api_test.go
+++ b/test/integration/grpc_management_plane_api_test.go
@@ -200,11 +200,11 @@ func TestGrpc_Reconnection(t *testing.T) {
 	startErr := mockManagementPlaneGrpcContainer.Start(ctx)
 	require.NoError(t, startErr)
 
-	//ipAddress, err := mockManagementPlaneGrpcContainer.Host(ctx)
-	//require.NoError(t, err)
-	//ports, err := mockManagementPlaneGrpcContainer.Ports(ctx)
-	//require.NoError(t, err)
-	//mockManagementPlaneAPIAddress = net.JoinHostPort(ipAddress, ports["9093/tcp"][0].HostPort)
+	// ipAddress, err := mockManagementPlaneGrpcContainer.Host(ctx)
+	// require.NoError(t, err)
+	// ports, err := mockManagementPlaneGrpcContainer.Ports(ctx)
+	// require.NoError(t, err)
+	// mockManagementPlaneAPIAddress = net.JoinHostPort(ipAddress, ports["9093/tcp"][0].HostPort)
 
 	time.Sleep(10 * time.Second)
 

--- a/test/integration/grpc_management_plane_api_test.go
+++ b/test/integration/grpc_management_plane_api_test.go
@@ -198,9 +198,9 @@ func TestGrpc_Reconnection(t *testing.T) {
 	require.NoError(t, stopErr)
 
 	startErr := mockManagementPlaneGrpcContainer.Start(ctx)
-
 	require.NoError(t, startErr)
-
+	
+	mockManagementPlaneGrpcAddress = "managementPlane:9092"
 	currentID := verifyConnection(t, 2)
 	assert.Equal(t, originalID, currentID)
 }

--- a/test/integration/grpc_management_plane_api_test.go
+++ b/test/integration/grpc_management_plane_api_test.go
@@ -200,7 +200,11 @@ func TestGrpc_Reconnection(t *testing.T) {
 	startErr := mockManagementPlaneGrpcContainer.Start(ctx)
 	require.NoError(t, startErr)
 
-	mockManagementPlaneGrpcAddress = "managementPlane:9092"
+	ipAddress, err := mockManagementPlaneGrpcContainer.Host(ctx)
+	require.NoError(t, err)
+	ports, err := mockManagementPlaneGrpcContainer.Ports(ctx)
+	require.NoError(t, err)
+	mockManagementPlaneAPIAddress = net.JoinHostPort(ipAddress, ports["9093/tcp"][0].HostPort)
 	currentID := verifyConnection(t, 2)
 	assert.Equal(t, originalID, currentID)
 }
@@ -221,6 +225,7 @@ func verifyConnection(t *testing.T, instancesLength int) string {
 	client := resty.New()
 	client.SetRetryCount(retryCount).SetRetryWaitTime(retryWaitTime).SetRetryMaxWaitTime(retryMaxWaitTime)
 
+	t.Logf("-------- mockManagementPlaneAPIAddress: %s", mockManagementPlaneAPIAddress)
 	url := fmt.Sprintf("http://%s/api/v1/connection", mockManagementPlaneAPIAddress)
 	resp, err := client.R().EnableTrace().Get(url)
 


### PR DESCRIPTION
### Proposed changes

If the agent looses connection to the management plane try to reestablish the connection and send a create connection request. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
