### PR TITLE
fix: flaky test

### DIFF
--- a/api/grpc/mpi/v1/helpers_test.go
+++ b/api/grpc/mpi/v1/helpers_test.go
@@ -65,7 +65,7 @@ func TestConvertToStructs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ConvertToStructs(tt.input)
 
-			assert.Equal(t, tt.expected, got)
+			assert.ElementsMatch(t, tt.expected, got)
 			assert.Equal(t, tt.wantErr, err != nil)
 		})
 	}


### PR DESCRIPTION
### Proposed changes

`TestConvertToStructs` was occasionally failing because it was expecting `range` over a `map` to be a consistent order, but per [spec]:

> The iteration order over maps is not specified and is not guaranteed to be the same from one iteration to the next.

Uses `ElementsMatch` so the test passes even when the order of elements is different.

[spec]: https://go.dev/ref/spec#RangeClause

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
