### PR TITLE
Remove duplicate entires of certs in files

### DIFF
--- a/internal/watcher/instance/nginx_config_parser.go
+++ b/internal/watcher/instance/nginx_config_parser.go
@@ -139,7 +139,7 @@ func (ncp *NginxConfigParser) createNginxConfigContext(
 					nginxConfigContext.Files = append(nginxConfigContext.Files, rootFiles...)
 				case "ssl_certificate", "proxy_ssl_certificate", "ssl_client_certificate", "ssl_trusted_certificate":
 					sslCertFile := ncp.sslCert(ctx, directive.Args[0], rootDir)
-					if !ncp.checkDuplicate(nginxConfigContext.Files, sslCertFile) {
+					if !ncp.isDuplicateFile(nginxConfigContext.Files, sslCertFile) {
 						nginxConfigContext.Files = append(nginxConfigContext.Files, sslCertFile)
 					}
 
@@ -352,7 +352,7 @@ func (ncp *NginxConfigParser) sslCert(ctx context.Context, file, rootDir string)
 	return sslCertFile
 }
 
-func (ncp *NginxConfigParser) checkDuplicate(nginxConfigContextFiles []*mpi.File, newFile *mpi.File) bool {
+func (ncp *NginxConfigParser) isDuplicateFile(nginxConfigContextFiles []*mpi.File, newFile *mpi.File) bool {
 	for _, nginxConfigContextFile := range nginxConfigContextFiles {
 		if nginxConfigContextFile.GetFileMeta().GetName() == newFile.GetFileMeta().GetName() {
 			return true

--- a/internal/watcher/instance/nginx_config_parser.go
+++ b/internal/watcher/instance/nginx_config_parser.go
@@ -21,8 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	"google.golang.org/protobuf/proto"
-
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
 	"github.com/nginx/agent/v3/internal/config"
 	"github.com/nginx/agent/v3/internal/model"
@@ -356,7 +354,7 @@ func (ncp *NginxConfigParser) sslCert(ctx context.Context, file, rootDir string)
 
 func (ncp *NginxConfigParser) checkDuplicate(nginxConfigContextFiles []*mpi.File, newFile *mpi.File) bool {
 	for _, nginxConfigContextFile := range nginxConfigContextFiles {
-		if proto.Equal(nginxConfigContextFile, newFile) {
+		if nginxConfigContextFile.GetFileMeta().GetName() == newFile.GetFileMeta().GetName() {
 			return true
 		}
 	}

--- a/internal/watcher/instance/nginx_config_parser_test.go
+++ b/internal/watcher/instance/nginx_config_parser_test.go
@@ -978,11 +978,10 @@ func TestNginxConfigParser_checkDuplicate(t *testing.T) {
 			name: "Test 1: File already in files",
 			file: &mpi.File{
 				FileMeta: &mpi.FileMeta{
-					Name:         "/etc/nginx/certs/nginx-repo.crt",
-					Hash:         fileHash,
-					ModifiedTime: timestamppb.Now(),
-					Permissions:  "0640",
-					Size:         0,
+					Name:        "/etc/nginx/certs/nginx-repo.crt",
+					Hash:        fileHash,
+					Permissions: "0640",
+					Size:        0,
 				},
 			},
 			expected: true,
@@ -1006,11 +1005,10 @@ func TestNginxConfigParser_checkDuplicate(t *testing.T) {
 		Files: []*mpi.File{
 			{
 				FileMeta: &mpi.FileMeta{
-					Name:         "/etc/nginx/certs/nginx-repo.crt",
-					Hash:         fileHash,
-					ModifiedTime: timestamppb.Now(),
-					Permissions:  "0640",
-					Size:         0,
+					Name:        "/etc/nginx/certs/nginx-repo.crt",
+					Hash:        fileHash,
+					Permissions: "0640",
+					Size:        0,
 				},
 			},
 			{

--- a/internal/watcher/instance/nginx_config_parser_test.go
+++ b/internal/watcher/instance/nginx_config_parser_test.go
@@ -1046,7 +1046,7 @@ func TestNginxConfigParser_checkDuplicate(t *testing.T) {
 	for _, test := range tests {
 		ncp := NewNginxConfigParser(types.AgentConfig())
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, ncp.checkDuplicate(nginxConfigContextFiles.Files, test.file))
+			assert.Equal(t, test.expected, ncp.isDuplicateFile(nginxConfigContextFiles.Files, test.file))
 		})
 	}
 }

--- a/internal/watcher/instance/nginx_config_parser_test.go
+++ b/internal/watcher/instance/nginx_config_parser_test.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"testing"
 
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/nginx/agent/v3/internal/model"
 	"github.com/nginx/agent/v3/pkg/files"
@@ -957,6 +959,94 @@ func TestNginxConfigParser_ignoreLog(t *testing.T) {
 			helpers.ValidateLog(t, test.expectedLog, logBuf)
 
 			logBuf.Reset()
+		})
+	}
+}
+
+func TestNginxConfigParser_checkDuplicate(t *testing.T) {
+	fileContent := []byte("location /test {\n    return 200 \"Test location\\n\";\n}")
+	fileContentNew := []byte("some test data")
+	fileHash := files.GenerateHash(fileContent)
+	fileHashNew := files.GenerateHash(fileContentNew)
+
+	tests := []struct {
+		file     *mpi.File
+		name     string
+		expected bool
+	}{
+		{
+			name: "Test 1: File already in files",
+			file: &mpi.File{
+				FileMeta: &mpi.FileMeta{
+					Name:         "/etc/nginx/certs/nginx-repo.crt",
+					Hash:         fileHash,
+					ModifiedTime: timestamppb.Now(),
+					Permissions:  "0640",
+					Size:         0,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Test 2: File not in files",
+			file: &mpi.File{
+				FileMeta: &mpi.FileMeta{
+					Name:         "/etc/nginx/certs/nginx-repo.crt",
+					Hash:         fileHashNew,
+					ModifiedTime: timestamppb.Now(),
+					Permissions:  "0640",
+					Size:         0,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	nginxConfigContextFiles := model.NginxConfigContext{
+		Files: []*mpi.File{
+			{
+				FileMeta: &mpi.FileMeta{
+					Name:         "/etc/nginx/certs/nginx-repo.crt",
+					Hash:         fileHash,
+					ModifiedTime: timestamppb.Now(),
+					Permissions:  "0640",
+					Size:         0,
+				},
+			},
+			{
+				FileMeta: &mpi.FileMeta{
+					Name:         "/etc/nginx/keys/nginx-repo.key",
+					Hash:         fileHash,
+					ModifiedTime: timestamppb.Now(),
+					Permissions:  "0640",
+					Size:         0,
+				},
+			},
+			{
+				FileMeta: &mpi.FileMeta{
+					Name:         "/etc/nginx/keys/inline_key.pem",
+					Hash:         fileHash,
+					ModifiedTime: timestamppb.Now(),
+					Permissions:  "0640",
+					Size:         0,
+				},
+			},
+			{
+				FileMeta: &mpi.FileMeta{
+					Name:         "/etc/nginx/certs/inline_cert.pem",
+					Hash:         fileHash,
+					ModifiedTime: timestamppb.Now(),
+					Permissions:  "0640",
+					Size:         0,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		ncp := NewNginxConfigParser(types.AgentConfig())
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, ncp.checkDuplicate(nginxConfigContextFiles.Files, test.file))
 		})
 	}
 }

--- a/internal/watcher/instance/nginx_config_parser_test.go
+++ b/internal/watcher/instance/nginx_config_parser_test.go
@@ -978,10 +978,11 @@ func TestNginxConfigParser_checkDuplicate(t *testing.T) {
 			name: "Test 1: File already in files",
 			file: &mpi.File{
 				FileMeta: &mpi.FileMeta{
-					Name:        "/etc/nginx/certs/nginx-repo.crt",
-					Hash:        fileHash,
-					Permissions: "0640",
-					Size:        0,
+					Name:         "/etc/nginx/certs/nginx-repo.crt",
+					Hash:         fileHashNew,
+					ModifiedTime: timestamppb.Now(),
+					Permissions:  "0640",
+					Size:         0,
 				},
 			},
 			expected: true,
@@ -990,7 +991,7 @@ func TestNginxConfigParser_checkDuplicate(t *testing.T) {
 			name: "Test 2: File not in files",
 			file: &mpi.File{
 				FileMeta: &mpi.FileMeta{
-					Name:         "/etc/nginx/certs/nginx-repo.crt",
+					Name:         "/etc/nginx/certs/nginx-repo-new.crt",
 					Hash:         fileHashNew,
 					ModifiedTime: timestamppb.Now(),
 					Permissions:  "0640",
@@ -1005,10 +1006,11 @@ func TestNginxConfigParser_checkDuplicate(t *testing.T) {
 		Files: []*mpi.File{
 			{
 				FileMeta: &mpi.FileMeta{
-					Name:        "/etc/nginx/certs/nginx-repo.crt",
-					Hash:        fileHash,
-					Permissions: "0640",
-					Size:        0,
+					Name:         "/etc/nginx/certs/nginx-repo.crt",
+					Hash:         fileHash,
+					ModifiedTime: timestamppb.Now(),
+					Permissions:  "0640",
+					Size:         0,
 				},
 			},
 			{


### PR DESCRIPTION
### Proposed changes

Check if cert is already in NginxConfigConext Files before adding cert. Certs which are referenced multiple times in a config no longer appear multiple times in the FileOverview etc 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
