### PR TITLE
Remove file contents from log 

### DIFF
--- a/internal/file/file_manager_service.go
+++ b/internal/file/file_manager_service.go
@@ -238,7 +238,7 @@ func (fms *FileManagerService) UpdateFile(
 	defer backoffCancel()
 
 	sendUpdateFile := func() (*mpi.UpdateFileResponse, error) {
-		slog.DebugContext(ctx, "Sending update file request", "request", request)
+		slog.DebugContext(ctx, "Sending update file request", "request_file", request.File, "request_message_meta", request.MessageMeta)
 		if fms.fileServiceClient == nil {
 			return nil, errors.New("file service client is not initialized")
 		}

--- a/internal/file/file_manager_service.go
+++ b/internal/file/file_manager_service.go
@@ -238,7 +238,8 @@ func (fms *FileManagerService) UpdateFile(
 	defer backoffCancel()
 
 	sendUpdateFile := func() (*mpi.UpdateFileResponse, error) {
-		slog.DebugContext(ctx, "Sending update file request", "request_file", request.File, "request_message_meta", request.MessageMeta)
+		slog.DebugContext(ctx, "Sending update file request", "request_file", request.GetFile(),
+			"request_message_meta", request.GetMessageMeta())
 		if fms.fileServiceClient == nil {
 			return nil, errors.New("file service client is not initialized")
 		}


### PR DESCRIPTION
### Proposed changes

When sending and update file request the agent was logging the request which contained the files contents, this has been removed to just log the file name and message meta of the request 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
