### PR TITLE
Change self hosted runner tag

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -79,7 +79,7 @@ permissions:
 jobs:
   vars:
     name: Set workflow variables
-    runs-on: ubuntu-22.04-amd64
+    runs-on: ubuntu-22.04
     outputs:
       github_release: ${{steps.vars.outputs.github_release }}
       upload_azure: ${{steps.vars.outputs.upload_azure }}

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -79,7 +79,7 @@ permissions:
 jobs:
   vars:
     name: Set workflow variables
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-amd64
     outputs:
       github_release: ${{steps.vars.outputs.github_release }}
       upload_azure: ${{steps.vars.outputs.upload_azure }}
@@ -222,7 +222,7 @@ jobs:
 
   upload-packages:
     name: Upload packages
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-amd64
     needs: [vars,release-draft,tag-release]
     permissions:
       id-token: write


### PR DESCRIPTION
### Proposed changes

Use a self-hosted runner to run the Publish job as public runners lack access to the host.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
