### PR TITLE
Send create connection after updating credentials

### DIFF
--- a/internal/command/command_service.go
+++ b/internal/command/command_service.go
@@ -560,11 +560,6 @@ func (cs *CommandService) connectCallback(
 
 		validatedError := grpc.ValidateGrpcError(connectErr)
 		if validatedError != nil {
-			codeError, ok := status.FromError(validatedError)
-			if ok && codeError.Message() == "grpc: the client connection is closing" {
-				return nil, backoff.Permanent(fmt.Errorf("failed to create connection: %w, "+
-					"stopping retry", validatedError))
-			}
 			slog.ErrorContext(ctx, "Failed to create connection", "error", validatedError)
 
 			return nil, validatedError

--- a/internal/command/command_service_test.go
+++ b/internal/command/command_service_test.go
@@ -200,13 +200,15 @@ func TestCommandService_CreateConnection(t *testing.T) {
 
 func TestCommandService_UpdateClient(t *testing.T) {
 	commandServiceClient := &v1fakes.FakeCommandServiceClient{}
+	ctx := context.Background()
 
 	commandService := NewCommandService(
 		commandServiceClient,
 		types.AgentConfig(),
 		make(chan *mpi.ManagementPlaneRequest),
 	)
-	commandService.UpdateClient(commandServiceClient)
+	err := commandService.UpdateClient(ctx, commandServiceClient)
+	require.NoError(t, err)
 	assert.NotNil(t, commandService.commandServiceClient)
 }
 

--- a/internal/command/commandfakes/fake_command_service.go
+++ b/internal/command/commandfakes/fake_command_service.go
@@ -50,10 +50,17 @@ type FakeCommandService struct {
 	subscribeArgsForCall []struct {
 		arg1 context.Context
 	}
-	UpdateClientStub        func(v1.CommandServiceClient)
+	UpdateClientStub        func(context.Context, v1.CommandServiceClient) error
 	updateClientMutex       sync.RWMutex
 	updateClientArgsForCall []struct {
-		arg1 v1.CommandServiceClient
+		arg1 context.Context
+		arg2 v1.CommandServiceClient
+	}
+	updateClientReturns struct {
+		result1 error
+	}
+	updateClientReturnsOnCall map[int]struct {
+		result1 error
 	}
 	UpdateDataPlaneHealthStub        func(context.Context, []*v1.InstanceHealth) error
 	updateDataPlaneHealthMutex       sync.RWMutex
@@ -295,17 +302,24 @@ func (fake *FakeCommandService) SubscribeArgsForCall(i int) context.Context {
 	return argsForCall.arg1
 }
 
-func (fake *FakeCommandService) UpdateClient(arg1 v1.CommandServiceClient) {
+func (fake *FakeCommandService) UpdateClient(arg1 context.Context, arg2 v1.CommandServiceClient) error {
 	fake.updateClientMutex.Lock()
+	ret, specificReturn := fake.updateClientReturnsOnCall[len(fake.updateClientArgsForCall)]
 	fake.updateClientArgsForCall = append(fake.updateClientArgsForCall, struct {
-		arg1 v1.CommandServiceClient
-	}{arg1})
+		arg1 context.Context
+		arg2 v1.CommandServiceClient
+	}{arg1, arg2})
 	stub := fake.UpdateClientStub
-	fake.recordInvocation("UpdateClient", []interface{}{arg1})
+	fakeReturns := fake.updateClientReturns
+	fake.recordInvocation("UpdateClient", []interface{}{arg1, arg2})
 	fake.updateClientMutex.Unlock()
 	if stub != nil {
-		fake.UpdateClientStub(arg1)
+		return stub(arg1, arg2)
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
 }
 
 func (fake *FakeCommandService) UpdateClientCallCount() int {
@@ -314,17 +328,40 @@ func (fake *FakeCommandService) UpdateClientCallCount() int {
 	return len(fake.updateClientArgsForCall)
 }
 
-func (fake *FakeCommandService) UpdateClientCalls(stub func(v1.CommandServiceClient)) {
+func (fake *FakeCommandService) UpdateClientCalls(stub func(context.Context, v1.CommandServiceClient) error) {
 	fake.updateClientMutex.Lock()
 	defer fake.updateClientMutex.Unlock()
 	fake.UpdateClientStub = stub
 }
 
-func (fake *FakeCommandService) UpdateClientArgsForCall(i int) v1.CommandServiceClient {
+func (fake *FakeCommandService) UpdateClientArgsForCall(i int) (context.Context, v1.CommandServiceClient) {
 	fake.updateClientMutex.RLock()
 	defer fake.updateClientMutex.RUnlock()
 	argsForCall := fake.updateClientArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeCommandService) UpdateClientReturns(result1 error) {
+	fake.updateClientMutex.Lock()
+	defer fake.updateClientMutex.Unlock()
+	fake.UpdateClientStub = nil
+	fake.updateClientReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeCommandService) UpdateClientReturnsOnCall(i int, result1 error) {
+	fake.updateClientMutex.Lock()
+	defer fake.updateClientMutex.Unlock()
+	fake.UpdateClientStub = nil
+	if fake.updateClientReturnsOnCall == nil {
+		fake.updateClientReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.updateClientReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeCommandService) UpdateDataPlaneHealth(arg1 context.Context, arg2 []*v1.InstanceHealth) error {

--- a/internal/file/file_plugin.go
+++ b/internal/file/file_plugin.go
@@ -51,6 +51,7 @@ func (fp *FilePlugin) Init(ctx context.Context, messagePipe bus.MessagePipeInter
 }
 
 func (fp *FilePlugin) Close(ctx context.Context) error {
+	slog.InfoContext(ctx, "Closing file plugin")
 	return fp.conn.Close(ctx)
 }
 

--- a/internal/grpc/grpc.go
+++ b/internal/grpc/grpc.go
@@ -353,7 +353,8 @@ func ProtoValidatorStreamClientInterceptor() (grpc.StreamClientInterceptor, erro
 func ValidateGrpcError(err error) error {
 	if err != nil {
 		if statusError, ok := status.FromError(err); ok {
-			if statusError.Code() == codes.InvalidArgument || statusError.Code() == codes.Unimplemented {
+			if statusError.Code() == codes.InvalidArgument || statusError.Code() == codes.Unimplemented ||
+				statusError.Code() == codes.Canceled {
 				return backoff.Permanent(err)
 			}
 		}

--- a/internal/grpc/grpc.go
+++ b/internal/grpc/grpc.go
@@ -115,12 +115,11 @@ func (gc *GrpcConnection) FileServiceClient() mpi.FileServiceClient {
 }
 
 func (gc *GrpcConnection) Close(ctx context.Context) error {
-	slog.InfoContext(ctx, "Closing grpc connection")
-
 	gc.mutex.Lock()
 	defer gc.mutex.Unlock()
 
 	if gc.conn != nil {
+		slog.InfoContext(ctx, "Closing grpc connection")
 		err := gc.conn.Close()
 		gc.conn = nil
 		if err != nil {

--- a/internal/resource/resource_plugin.go
+++ b/internal/resource/resource_plugin.go
@@ -60,7 +60,7 @@ func (r *Resource) Init(ctx context.Context, messagePipe bus.MessagePipeInterfac
 }
 
 func (*Resource) Close(ctx context.Context) error {
-	slog.DebugContext(ctx, "Closing resource plugin")
+	slog.InfoContext(ctx, "Closing resource plugin")
 	return nil
 }
 

--- a/internal/watcher/watcher_plugin.go
+++ b/internal/watcher/watcher_plugin.go
@@ -112,7 +112,7 @@ func (w *Watcher) Init(ctx context.Context, messagePipe bus.MessagePipeInterface
 // nolint: unparam
 // error is always nil
 func (w *Watcher) Close(ctx context.Context) error {
-	slog.DebugContext(ctx, "Closing watcher plugin")
+	slog.InfoContext(ctx, "Closing watcher plugin")
 
 	w.cancel()
 


### PR DESCRIPTION
### Proposed changes
When a token is updated a create connection request is now sent
- We now check if the error during the create connection callback is that the grpc connection is closing. If this is the error we then stop trying to create a connection as it will not be successful until a new connection is created which it wont be able to do until exiting the callback. 
- also added logs about closing the plugins to make it more clear what is happening

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
