### PR TITLE
Update build-test-oss-image and build-test-plus-image make targets to take into account the OS type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ build-test-nginx-plus-and-nap-image:
 .PHONY: build-test-plus-image
 build-test-plus-image:
 	$(CONTAINER_BUILDENV) $(CONTAINER_CLITOOL) build -t nginx_plus_$(IMAGE_TAG) . \
-		--no-cache -f ./test/docker/nginx-plus/deb/Dockerfile \
+		--no-cache -f ./test/docker/nginx-plus/$(CONTAINER_OS_TYPE)/Dockerfile \
 		--secret id=nginx-crt,src=$(CERTS_DIR)/nginx-repo.crt \
 		--secret id=nginx-key,src=$(CERTS_DIR)/nginx-repo.key \
 		--build-arg PACKAGE_NAME=$(PACKAGE_NAME) \
@@ -216,7 +216,7 @@ build-test-plus-image:
 .PHONY: build-test-oss-image
 build-test-oss-image:
 	$(CONTAINER_BUILDENV) $(CONTAINER_CLITOOL) build -t nginx_oss_$(IMAGE_TAG) . \
-		--no-cache -f ./test/docker/nginx-oss/deb/Dockerfile \
+		--no-cache -f ./test/docker/nginx-oss/$(CONTAINER_OS_TYPE)/Dockerfile \
 		--target install-agent-local \
 		--build-arg PACKAGE_NAME=$(PACKAGE_NAME) \
 		--build-arg PACKAGES_REPO=$(OSS_PACKAGES_REPO) \


### PR DESCRIPTION
### Proposed changes

Update build-test-oss-image and build-test-plus-image make targets to take into account the OS type.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
