### PR TITLE
Updated Docker Compose File Permissions

### DIFF
--- a/scripts/testing/docker-compose_otel-collector.yaml
+++ b/scripts/testing/docker-compose_otel-collector.yaml
@@ -15,7 +15,7 @@ services:
     restart: always
     command: ["--config=/etc/otel-collector-config.yaml"]
     volumes:
-      - ./otel-collector.yaml:/etc/otel-collector-config.yaml
+      - ./otel-collector.yaml:/etc/otel-collector-config.yaml:ro
     ports:
       - "1888:1888"   # pprof extension
       - "13133:13133" # health_check extension
@@ -30,7 +30,7 @@ services:
     image: prom/prometheus:latest
     container_name: prometheus
     volumes:
-      - ./prometheus.yaml:/etc/prometheus/prometheus.yml
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'

--- a/scripts/testing/docker-compose_otel-collector.yaml
+++ b/scripts/testing/docker-compose_otel-collector.yaml
@@ -25,6 +25,9 @@ services:
       - "8889:8889"   # prometheus exporter
     networks:
       - monitoring
+    read_only: true
+    tmpfs:
+      - /tmp:mode=666
 
   prometheus:
     image: prom/prometheus:latest
@@ -43,6 +46,9 @@ services:
       - monitoring
     depends_on:
       - otel-collector
+    read_only: true
+    tmpfs:
+      - /tmp:mode=666
 
   victoriametrics:
     image: victoriametrics/victoria-metrics:latest
@@ -60,3 +66,6 @@ services:
       - monitoring
     depends_on:
       - prometheus
+    read_only: true
+    tmpfs:
+      - /tmp:mode=666


### PR DESCRIPTION
### Proposed changes

- Set the config file permissions in `docker-compose_otel-collector.yaml` to read-only for additional security.
- Set service permissions to `read_only: true`.
- Added `tmpfs` mount to allow read-write access to `/tmp` directory.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
