### PR TITLE
Create make collector target without NAP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,12 +231,22 @@ build-mock-management-otel-collector-image: build-mock-management-otel-collector
 .PHONY: run-mock-management-otel-collector
 run-mock-management-otel-collector: ## Run mock management plane OTel collector
 	@echo "🚀 Running mock management plane OTel collector"
-	AGENT_IMAGE_WITH_NGINX_PLUS=nginx_plus_$(IMAGE_TAG):latest AGENT_IMAGE_WITH_NGINX_OSS=nginx_oss_$(IMAGE_TAG):latest AGENT_IMAGE_WITH_NGINX_PLUS_AND_NAP=nginx_plus_and_nap_$(IMAGE_TAG):latest $(CONTAINER_COMPOSE) -f ./test/mock/collector/docker-compose.yaml up -d
+	AGENT_IMAGE_WITH_NGINX_PLUS=nginx_plus_$(IMAGE_TAG):latest AGENT_IMAGE_WITH_NGINX_OSS=nginx_oss_$(IMAGE_TAG):latest AGENT_IMAGE_WITH_NGINX_PLUS_AND_NAP=nginx_plus_and_nap_$(IMAGE_TAG):latest $(CONTAINER_COMPOSE) -f ./test/mock/collector/nginx-plus-and-nap/docker-compose.yaml up -d
 
 .PHONY: stop-mock-management-otel-collector
 stop-mock-management-otel-collector: ## Stop running mock management plane OTel collector
 	@echo "Stopping mock management plane OTel collector"
-	AGENT_IMAGE_WITH_NGINX_PLUS=nginx_plus_$(IMAGE_TAG):latest AGENT_IMAGE_WITH_NGINX_OSS=nginx_oss_$(IMAGE_TAG):latest AGENT_IMAGE_WITH_NGINX_PLUS_AND_NAP=nginx_plus_and_nap_$(IMAGE_TAG):latest $(CONTAINER_COMPOSE) -f ./test/mock/collector/docker-compose.yaml down
+	AGENT_IMAGE_WITH_NGINX_PLUS=nginx_plus_$(IMAGE_TAG):latest AGENT_IMAGE_WITH_NGINX_OSS=nginx_oss_$(IMAGE_TAG):latest AGENT_IMAGE_WITH_NGINX_PLUS_AND_NAP=nginx_plus_and_nap_$(IMAGE_TAG):latest $(CONTAINER_COMPOSE) -f ./test/mock/collector/nginx-plus-and-nap/docker-compose.yaml down
+
+.PHONY: run-mock-otel-collector-without-nap
+run-mock-otel-collector-without-nap:
+	@echo "🚀 Running mock management plane OTel collector without NAP"
+	AGENT_IMAGE_WITH_NGINX_PLUS=nginx_plus_$(IMAGE_TAG):latest AGENT_IMAGE_WITH_NGINX_OSS=nginx_oss_$(IMAGE_TAG):latest $(CONTAINER_COMPOSE) -f ./test/mock/collector/docker-compose.yaml up -d
+
+.PHONY: stop-mock-otel-collector-without-nap
+stop-mock-otel-collector-without-nap: ## Stop running mock management plane OTel collector
+	@echo "Stopping mock management plane OTel collector without NAP"
+	AGENT_IMAGE_WITH_NGINX_PLUS=nginx_plus_$(IMAGE_TAG):latest AGENT_IMAGE_WITH_NGINX_OSS=nginx_oss_$(IMAGE_TAG):latest $(CONTAINER_COMPOSE) -f ./test/mock/collector/docker-compose.yaml down
 
 generate: ## Generate golang code
 	@echo "🗄️ Generating proto files"

--- a/test/mock/collector/README.md
+++ b/test/mock/collector/README.md
@@ -14,6 +14,11 @@ make local-deb-package build-test-oss-image build-test-plus-image build-mock-man
 
 [**Note:** We need to build the test NGINX Plus with NAP image with the environment variable `OSARCH=amd64` since NGINX App Protect doesn't support ARM yet.]
 
+To build all images except the NGINX Plus & NGINX App Protect run the following
+```
+make local-deb-package build-test-oss-image build-test-plus-image build-mock-management-otel-collector-image
+```
+
 To start run everything run the following
 ```
 make run-mock-management-otel-collector

--- a/test/mock/collector/nginx-plus-and-nap/docker-compose.yaml
+++ b/test/mock/collector/nginx-plus-and-nap/docker-compose.yaml
@@ -7,13 +7,23 @@ volumes:
   grafana-storage:
 
 services:
+  agent-with-nginx-plus-and-nap:
+    image: ${AGENT_IMAGE_WITH_NGINX_PLUS_AND_NAP}
+    container_name: mock-collector-agent-with-nginx-plus-and-nap
+    volumes:
+      - ../nginx-agent.conf:/etc/nginx-agent/nginx-agent.conf
+      - ../nginx-plus-and-nap/nginx.conf:/etc/nginx/nginx.conf
+      - ../nginx-plus-and-nap/conf.d/default.conf:/etc/nginx/conf.d/default.conf
+    networks:
+      - metrics
+
   agent-with-nginx-plus:
     image: ${AGENT_IMAGE_WITH_NGINX_PLUS}
     container_name: mock-collector-agent-with-nginx-plus
     volumes:
-      - ./nginx-agent.conf:/etc/nginx-agent/nginx-agent.conf
-      - ./nginx-plus/nginx.conf:/etc/nginx/nginx.conf
-      - ./nginx-plus/conf.d/default.conf:/etc/nginx/conf.d/default.conf
+      - ../nginx-agent.conf:/etc/nginx-agent/nginx-agent.conf
+      - ../nginx-plus/nginx.conf:/etc/nginx/nginx.conf
+      - ../nginx-plus/conf.d/default.conf:/etc/nginx/conf.d/default.conf
     networks:
       - metrics
 
@@ -21,8 +31,8 @@ services:
     image: ${AGENT_IMAGE_WITH_NGINX_OSS}
     container_name: mock-collector-agent-with-nginx-oss
     volumes:
-      - ./nginx-agent.conf:/etc/nginx-agent/nginx-agent.conf
-      - ./nginx-oss:/etc/nginx/
+      - ../nginx-agent.conf:/etc/nginx-agent/nginx-agent.conf
+      - ../nginx-oss:/etc/nginx/
     networks:
       - metrics
 
@@ -33,7 +43,7 @@ services:
       - 4320:4317
       - 9775:9090
     volumes:
-      - ./otel-collector.yaml:/etc/otel-collector.yaml
+      - ../otel-collector.yaml:/etc/otel-collector.yaml
     networks:
       - metrics
 
@@ -44,7 +54,7 @@ services:
     ports:
       - "9090:9090"
     volumes:
-      - ./prometheus.yaml:/etc/prometheus/prometheus.yml
+      - ../prometheus.yaml:/etc/prometheus/prometheus.yml
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
     networks:
@@ -60,10 +70,10 @@ services:
       - "3002:3000"
     volumes:
       - grafana-storage:/var/lib/grafana
-      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
-      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
-      - ./grafana/provisioning/plugins:/etc/grafana/provisioning/plugins
-      - ./grafana/provisioning/dashboards:/var/lib/grafana/dashboards
+      - ../grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
+      - ../grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
+      - ../grafana/provisioning/plugins:/etc/grafana/provisioning/plugins
+      - ../grafana/provisioning/dashboards:/var/lib/grafana/dashboards
     networks:
       - metrics
 
@@ -74,7 +84,7 @@ services:
     ports:
       - "3100:3100"
     volumes:
-      - ./loki-config.yaml:/etc/loki/local-config.yaml
+      - ../loki-config.yaml:/etc/loki/local-config.yaml
     command: -config.file=/etc/loki/local-config.yaml
     networks:
       - metrics


### PR DESCRIPTION
### Proposed changes

- Added two new make targets to run and stop the mock otel collector without running NAP
- Creating a `docker-compose` file specifically for running with NAP
- Edited the old `docker-compose` file to not use NAP
- Updated `README.md` with steps on how to build without NAP

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
