### PR TITLE
Ignore NGINX cache manager process when looking for NGINX master process

### DIFF
--- a/internal/watcher/file/file_watcher_service.go
+++ b/internal/watcher/file/file_watcher_service.go
@@ -180,7 +180,6 @@ func (fws *FileWatcherService) isWatching(name string) bool {
 func (fws *FileWatcherService) handleEvent(ctx context.Context, event fsnotify.Event) {
 	if fws.enabled.Load() {
 		if fws.isEventSkippable(event) {
-			slog.DebugContext(ctx, "Skipping FSNotify event", "event", event)
 			return
 		}
 
@@ -238,7 +237,6 @@ func isExcludedFile(path string, excludeFiles []string) bool {
 			slog.Error("Invalid path for excluding file", "file_path", pattern)
 			continue
 		} else if ok {
-			slog.Debug("Excluding file from watcher as specified in config", "file_path", path)
 			return true
 		}
 	}

--- a/internal/watcher/instance/nginx_process_parser.go
+++ b/internal/watcher/instance/nginx_process_parser.go
@@ -103,16 +103,18 @@ func (npp *NginxProcessParser) Parse(ctx context.Context, processes []*nginxproc
 			continue
 		}
 
-		// proc is a master process
-		nginxInfo, err := npp.getInfo(ctx, proc)
-		if err != nil {
-			slog.DebugContext(ctx, "Unable to get NGINX info", "pid", proc.PID, "error", err)
+		// check if proc is a master process, process is not a worker but could be cache manager etc
+		if proc.IsMaster() {
+			nginxInfo, err := npp.getInfo(ctx, proc)
+			if err != nil {
+				slog.DebugContext(ctx, "Unable to get NGINX info", "pid", proc.PID, "error", err)
 
-			continue
+				continue
+			}
+
+			instance := convertInfoToInstance(*nginxInfo)
+			instanceMap[instance.GetInstanceMeta().GetInstanceId()] = instance
 		}
-
-		instance := convertInfoToInstance(*nginxInfo)
-		instanceMap[instance.GetInstanceMeta().GetInstanceId()] = instance
 	}
 
 	for _, instance := range instanceMap {

--- a/internal/watcher/instance/nginx_process_parser_test.go
+++ b/internal/watcher/instance/nginx_process_parser_test.go
@@ -352,6 +352,19 @@ func TestNginxProcessParser_Parse_Processes(t *testing.T) {
 			},
 			expected: instancesTest4,
 		},
+		{
+			name: "Test 5: 1 cache process",
+			processes: []*nginxprocess.Process{
+				{
+					PID:  1234,
+					PPID: 1,
+					Name: "nginx",
+					Cmd:  "nginx: cache manager process",
+					Exe:  exePath,
+				},
+			},
+			expected: map[string]*mpi.Instance{},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/watcher/instance/nginx_process_parser_test.go
+++ b/internal/watcher/instance/nginx_process_parser_test.go
@@ -363,7 +363,7 @@ func TestNginxProcessParser_Parse_Processes(t *testing.T) {
 					Exe:  exePath,
 				},
 			},
-			expected: map[string]*mpi.Instance{},
+			expected: make(map[string]*mpi.Instance),
 		},
 	}
 


### PR DESCRIPTION
### Proposed changes

Changed process parser to check that the process is a master process before adding it to the list of instances. 
Added test to check that the process parser doesn't pick up the cache manager process as a master process
Removed Log for skipping an event 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
