### PR TITLE
CI: remove release workflow call on all v3 pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,23 +306,3 @@ jobs:
       - name: Push load test result
         if:  ${{ success() && github.ref_name == 'v3'}}
         run: git push 'https://github-actions:${{ secrets.GITHUB_TOKEN }}@github.com/nginx/agent.git' benchmark-results:benchmark-results
-
-  publish-packages:
-    name: Publish NGINX Agent v3 packages
-    if: ${{ github.ref_name == 'v3' &&
-      !github.event.pull_request.head.repo.fork }}
-    needs: [ lint, unit-test, performance-tests,
-             load-tests, official-oss-image-integration-tests,
-             official-plus-image-integration-tests,
-             race-condition-test, integration-tests ]
-    uses: ./.github/workflows/release-branch.yml
-    secrets: inherit
-    permissions:
-      id-token: write
-      contents: read
-    with:
-      packageVersion: "3.0.0"
-      packageBuildNo: "${{ github.run_number }}"
-      uploadAzure: true
-      publishPackages: true
-      releaseBranch: "v3"

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -39,35 +39,6 @@ on:
         description: 'Location to publish packages to'
         required: false
         default: "https://up-ap.nginx.com"
-  workflow_call:
-    inputs:
-      githubRelease:
-        type: boolean
-        default: false
-      packageVersion:
-        type: string
-        default: "3.0.0"
-      packageBuildNo:
-        type: string
-        default: "1"
-      uploadAzure:
-        type: boolean
-        default: true
-      publishPackages:
-        type: boolean
-        default: true
-      tagRelease:
-        type: boolean
-        default: false
-      createPullRequest:
-        type: boolean
-        default: false
-      releaseBranch:
-        type: string
-        required: true
-      uploadUrl:
-        type: string
-        default: "https://up-ap.nginx.com"
 
 env:
   NFPM_VERSION: 'v2.35.3'


### PR DESCRIPTION
### Proposed changes

- Remove the `workflow_call` trigger from `release-branch.yml` workflow. 
- Remove the call to release branch workflow from the `ci.yml` workflow

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
