### PR TITLE
Add setting config path from NGINX process

### DIFF
--- a/internal/collector/nginxplusreceiver/factory.go
+++ b/internal/collector/nginxplusreceiver/factory.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nginx/agent/v3/internal/collector/nginxplusreceiver/internal/metadata"
 )
 
+// nolint: ireturn
 const defaultTimeout = 10 * time.Second
 
 // nolint: ireturn

--- a/internal/watcher/instance/nginx_process_parser.go
+++ b/internal/watcher/instance/nginx_process_parser.go
@@ -150,10 +150,8 @@ func (npp *NginxProcessParser) getInfo(ctx context.Context, proc *nginxprocess.P
 	nginxInfo.ExePath = exePath
 	nginxInfo.ProcessID = proc.PID
 
-	if confPath != "" {
+	if nginxInfo.ConfPath = getNginxConfPath(ctx, nginxInfo); confPath != "" {
 		nginxInfo.ConfPath = confPath
-	} else {
-		nginxInfo.ConfPath = getNginxConfPath(ctx, nginxInfo)
 	}
 
 	loadableModules := getLoadableModules(nginxInfo)

--- a/internal/watcher/instance/nginx_process_parser_test.go
+++ b/internal/watcher/instance/nginx_process_parser_test.go
@@ -616,3 +616,14 @@ func TestNginxProcessParser_GetExe(t *testing.T) {
 		})
 	}
 }
+
+func TestGetConfigPathFromCommand(t *testing.T) {
+	result := getConfPathFromCommand("nginx: master process nginx -c /tmp/nginx.conf")
+	assert.Equal(t, "/tmp/nginx.conf", result)
+
+	result = getConfPathFromCommand("nginx: master process nginx -c")
+	assert.Equal(t, "", result)
+
+	result = getConfPathFromCommand("")
+	assert.Equal(t, "", result)
+}


### PR DESCRIPTION
### Proposed changes

- Set config path attribute when `nginx -c <filepath>` is used
- Created new unit test for getting the config path from the command

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
