### PR TITLE
Update Manifest file during a ConfigContextUpdate

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,7 +139,7 @@ func checkCollectorConfiguration(collector *Collector, config *Config) {
 	if isOTelExporterConfigured(collector) && config.IsGrpcClientConfigured() && config.IsAuthConfigured() &&
 		config.IsTLSConfigured() {
 		slog.Info("No collector configuration found in NGINX Agent config, command server configuration found." +
-			"Using default collector configuration")
+			" Using default collector configuration")
 		defaultCollector(collector, config)
 	}
 }

--- a/internal/file/file_manager_service.go
+++ b/internal/file/file_manager_service.go
@@ -468,7 +468,7 @@ func (fms *FileManagerService) checkAllowedDirectory(checkFiles []*mpi.File) err
 
 // DetermineFileActions compares two sets of files to determine the file action for each file. Returns a map of files
 // that have changed and a map of the contents for each updated and deleted file. Key to both maps is file path
-// nolint: revive,cyclop
+// nolint: revive,cyclop,gocognit
 func (fms *FileManagerService) DetermineFileActions(
 	currentFiles map[string]*mpi.File,
 	modifiedFiles map[string]*model.FileCache,
@@ -543,7 +543,8 @@ func (fms *FileManagerService) DetermineFileActions(
 
 		// If the file is unreferenced we check if the file has been updated since the last time
 		// Also check if the unreferenced file still exists
-		if !manifestFiles[modifiedFile.File.GetFileMeta().GetName()].ManifestFileMeta.Referenced {
+		if manifestFiles[modifiedFile.File.GetFileMeta().GetName()] != nil &&
+			!manifestFiles[modifiedFile.File.GetFileMeta().GetName()].ManifestFileMeta.Referenced {
 			if fileStats, err := os.Stat(modifiedFile.File.GetFileMeta().GetName()); errors.Is(err, os.ErrNotExist) {
 				modifiedFile.Action = model.Add
 				fileDiff[modifiedFile.File.GetFileMeta().GetName()] = modifiedFile
@@ -586,6 +587,8 @@ func (fms *FileManagerService) UpdateCurrentFilesOnDisk(
 	return nil
 }
 
+// seems to be a control flag, avoid control coupling
+// nolint: revive
 func (fms *FileManagerService) UpdateManifestFile(currentFiles map[string]*mpi.File, referenced bool) (err error) {
 	currentManifestFiles, _, readError := fms.manifestFile()
 	if readError != nil && !errors.Is(readError, os.ErrNotExist) {

--- a/internal/file/file_manager_service.go
+++ b/internal/file/file_manager_service.go
@@ -484,7 +484,6 @@ func (fms *FileManagerService) DetermineFileActions(
 	fileContents := make(map[string][]byte)       // contents of the file, key is file name
 
 	manifestFiles, filesMap, manifestFileErr := fms.manifestFile()
-	slog.Info("DetermineFileActions - Manifest files: ", "", manifestFiles)
 
 	if manifestFileErr != nil {
 		if errors.Is(manifestFileErr, os.ErrNotExist) {
@@ -597,8 +596,6 @@ func (fms *FileManagerService) UpdateManifestFile(currentFiles map[string]*mpi.F
 	}
 
 	manifestFiles := fms.convertToManifestFileMap(currentFiles, referenced)
-
-	slog.Info("Current Manifest Files", "", currentManifestFiles)
 
 	// During a config apply every file is set to unreferenced
 	// When a new NGINX config context is detected

--- a/internal/file/file_manager_service.go
+++ b/internal/file/file_manager_service.go
@@ -484,6 +484,7 @@ func (fms *FileManagerService) DetermineFileActions(
 	fileContents := make(map[string][]byte)       // contents of the file, key is file name
 
 	manifestFiles, filesMap, manifestFileErr := fms.manifestFile()
+	slog.Info("DetermineFileActions - Manifest files: ", "", manifestFiles)
 
 	if manifestFileErr != nil {
 		if errors.Is(manifestFileErr, os.ErrNotExist) {
@@ -596,6 +597,8 @@ func (fms *FileManagerService) UpdateManifestFile(currentFiles map[string]*mpi.F
 	}
 
 	manifestFiles := fms.convertToManifestFileMap(currentFiles, referenced)
+
+	slog.Info("Current Manifest Files", "", currentManifestFiles)
 
 	// During a config apply every file is set to unreferenced
 	// When a new NGINX config context is detected

--- a/internal/file/file_manager_service.go
+++ b/internal/file/file_manager_service.go
@@ -61,7 +61,7 @@ type (
 		Rollback(ctx context.Context, instanceID string) error
 		UpdateFile(ctx context.Context, instanceID string, fileToUpdate *mpi.File) error
 		ClearCache()
-		UpdateCurrentFilesOnDisk(ctx context.Context, updateFiles map[string]*mpi.File)
+		UpdateCurrentFilesOnDisk(ctx context.Context, updateFiles map[string]*mpi.File, referenced bool) error
 		DetermineFileActions(currentFiles map[string]*mpi.File, modifiedFiles map[string]*model.FileCache) (
 			map[string]*model.FileCache, map[string][]byte, error)
 		IsConnected() bool
@@ -325,8 +325,7 @@ func (fms *FileManagerService) ConfigApply(ctx context.Context,
 	}
 	fileOverviewFiles := files.ConvertToMapOfFiles(fileOverview.GetFiles())
 	// Update map of current files on disk
-	fms.UpdateCurrentFilesOnDisk(ctx, fileOverviewFiles)
-	manifestFileErr := fms.UpdateManifestFile(fileOverviewFiles)
+	manifestFileErr := fms.UpdateCurrentFilesOnDisk(ctx, fileOverviewFiles, false)
 	if manifestFileErr != nil {
 		return model.RollbackRequired, manifestFileErr
 	}
@@ -376,7 +375,7 @@ func (fms *FileManagerService) Rollback(ctx context.Context, instanceID string) 
 	}
 
 	if areFilesUpdated {
-		manifestFileErr := fms.UpdateManifestFile(fms.currentFilesOnDisk)
+		manifestFileErr := fms.UpdateManifestFile(fms.currentFilesOnDisk, true)
 		if manifestFileErr != nil {
 			return manifestFileErr
 		}
@@ -470,8 +469,13 @@ func (fms *FileManagerService) checkAllowedDirectory(checkFiles []*mpi.File) err
 // DetermineFileActions compares two sets of files to determine the file action for each file. Returns a map of files
 // that have changed and a map of the contents for each updated and deleted file. Key to both maps is file path
 // nolint: revive,cyclop
-func (fms *FileManagerService) DetermineFileActions(currentFiles map[string]*mpi.File,
-	modifiedFiles map[string]*model.FileCache) (map[string]*model.FileCache, map[string][]byte, error,
+func (fms *FileManagerService) DetermineFileActions(
+	currentFiles map[string]*mpi.File,
+	modifiedFiles map[string]*model.FileCache,
+) (
+	map[string]*model.FileCache,
+	map[string][]byte,
+	error,
 ) {
 	fms.filesMutex.Lock()
 	defer fms.filesMutex.Unlock()
@@ -479,25 +483,25 @@ func (fms *FileManagerService) DetermineFileActions(currentFiles map[string]*mpi
 	fileDiff := make(map[string]*model.FileCache) // Files that have changed, key is file name
 	fileContents := make(map[string][]byte)       // contents of the file, key is file name
 
-	manifestFiles, manifestFileErr := fms.manifestFile()
+	manifestFiles, filesMap, manifestFileErr := fms.manifestFile()
 
 	if manifestFileErr != nil {
 		if errors.Is(manifestFileErr, os.ErrNotExist) {
-			manifestFiles = currentFiles
+			filesMap = currentFiles
 		} else {
 			return nil, nil, manifestFileErr
 		}
 	}
 	// if file is in manifestFiles but not in modified files, file has been deleted
 	// copy contents, set file action
-	for fileName, manifestFile := range manifestFiles {
+	for fileName, manifestFile := range filesMap {
 		_, exists := modifiedFiles[fileName]
 
 		if !exists {
 			// Read file contents before marking it deleted
 			fileContent, readErr := os.ReadFile(fileName)
 			if readErr != nil {
-				return nil, nil, fmt.Errorf("error reading file %s, error: %w", fileName, readErr)
+				return nil, nil, fmt.Errorf("error reading file %s: %w", fileName, readErr)
 			}
 			fileContents[fileName] = fileContent
 
@@ -510,7 +514,7 @@ func (fms *FileManagerService) DetermineFileActions(currentFiles map[string]*mpi
 
 	for _, modifiedFile := range modifiedFiles {
 		fileName := modifiedFile.File.GetFileMeta().GetName()
-		currentFile, ok := manifestFiles[modifiedFile.File.GetFileMeta().GetName()]
+		currentFile, ok := filesMap[modifiedFile.File.GetFileMeta().GetName()]
 		// default to unchanged action
 		modifiedFile.Action = model.Unchanged
 
@@ -523,6 +527,8 @@ func (fms *FileManagerService) DetermineFileActions(currentFiles map[string]*mpi
 		if !ok {
 			modifiedFile.Action = model.Add
 			fileDiff[modifiedFile.File.GetFileMeta().GetName()] = modifiedFile
+
+			continue
 			// if file currently exists and file hash is different, file has been updated
 			// copy contents, set file action
 		} else if modifiedFile.File.GetFileMeta().GetHash() != currentFile.GetFileMeta().GetHash() {
@@ -534,6 +540,23 @@ func (fms *FileManagerService) DetermineFileActions(currentFiles map[string]*mpi
 			fileContents[fileName] = fileContent
 			fileDiff[modifiedFile.File.GetFileMeta().GetName()] = modifiedFile
 		}
+
+		// If the file is unreferenced we check if the file has been updated since the last time
+		// Also check if the unreferenced file still exists
+		if !manifestFiles[modifiedFile.File.GetFileMeta().GetName()].ManifestFileMeta.Referenced {
+			if fileStats, err := os.Stat(modifiedFile.File.GetFileMeta().GetName()); errors.Is(err, os.ErrNotExist) {
+				modifiedFile.Action = model.Add
+				fileDiff[modifiedFile.File.GetFileMeta().GetName()] = modifiedFile
+			} else if timestamppb.New(fileStats.ModTime()) != modifiedFile.File.GetFileMeta().GetModifiedTime() {
+				fileContent, readErr := os.ReadFile(fileName)
+				if readErr != nil {
+					return nil, nil, fmt.Errorf("error reading file %s, error: %w", fileName, readErr)
+				}
+				modifiedFile.Action = model.Update
+				fileContents[fileName] = fileContent
+				fileDiff[modifiedFile.File.GetFileMeta().GetName()] = modifiedFile
+			}
+		}
 	}
 
 	return fileDiff, fileContents, nil
@@ -541,7 +564,11 @@ func (fms *FileManagerService) DetermineFileActions(currentFiles map[string]*mpi
 
 // UpdateCurrentFilesOnDisk updates the FileManagerService currentFilesOnDisk slice which contains the files
 // currently on disk
-func (fms *FileManagerService) UpdateCurrentFilesOnDisk(ctx context.Context, currentFiles map[string]*mpi.File) {
+func (fms *FileManagerService) UpdateCurrentFilesOnDisk(
+	ctx context.Context,
+	currentFiles map[string]*mpi.File,
+	referenced bool,
+) error {
 	fms.filesMutex.Lock()
 	defer fms.filesMutex.Unlock()
 
@@ -551,15 +578,34 @@ func (fms *FileManagerService) UpdateCurrentFilesOnDisk(ctx context.Context, cur
 		fms.currentFilesOnDisk[currentFile.GetFileMeta().GetName()] = currentFile
 	}
 
-	err := fms.UpdateManifestFile(currentFiles)
+	err := fms.UpdateManifestFile(currentFiles, referenced)
 	if err != nil {
-		slog.ErrorContext(ctx, "Failed to update manifest file", "error", err)
+		return fmt.Errorf("failed to update manifest file: %w", err)
 	}
+
+	return nil
 }
 
-func (fms *FileManagerService) UpdateManifestFile(currentFiles map[string]*mpi.File) (err error) {
-	manifestFiles := fms.convertToManifestFileMap(currentFiles)
-	manifestJSON, err := json.MarshalIndent(manifestFiles, "", "  ")
+func (fms *FileManagerService) UpdateManifestFile(currentFiles map[string]*mpi.File, referenced bool) (err error) {
+	currentManifestFiles, _, readError := fms.manifestFile()
+	if readError != nil && !errors.Is(readError, os.ErrNotExist) {
+		return fmt.Errorf("unable to read manifest file: %w", readError)
+	}
+
+	manifestFiles := fms.convertToManifestFileMap(currentFiles, referenced)
+
+	// During a config apply every file is set to unreferenced
+	// When a new NGINX config context is detected
+	// we update the files in the manifest by setting the referenced bool to true
+	if currentManifestFiles != nil && referenced {
+		for manifestFileName, manifestFile := range manifestFiles {
+			currentManifestFiles[manifestFileName] = manifestFile
+		}
+	} else {
+		currentManifestFiles = manifestFiles
+	}
+
+	manifestJSON, err := json.MarshalIndent(currentManifestFiles, "", "  ")
 	if err != nil {
 		return fmt.Errorf("unable to marshal manifest file json: %w", err)
 	}
@@ -584,30 +630,31 @@ func (fms *FileManagerService) UpdateManifestFile(currentFiles map[string]*mpi.F
 	return nil
 }
 
-func (fms *FileManagerService) manifestFile() (map[string]*mpi.File, error) {
+func (fms *FileManagerService) manifestFile() (map[string]*model.ManifestFile, map[string]*mpi.File, error) {
 	if _, err := os.Stat(manifestFilePath); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	file, err := os.ReadFile(manifestFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read manifest file: %w", err)
+		return nil, nil, fmt.Errorf("failed to read manifest file: %w", err)
 	}
 
 	var manifestFiles map[string]*model.ManifestFile
 
 	err = json.Unmarshal(file, &manifestFiles)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse manifest file: %w", err)
+		return nil, nil, fmt.Errorf("failed to parse manifest file: %w", err)
 	}
 
 	fileMap := fms.convertToFileMap(manifestFiles)
 
-	return fileMap, nil
+	return manifestFiles, fileMap, nil
 }
 
 func (fms *FileManagerService) convertToManifestFileMap(
 	currentFiles map[string]*mpi.File,
+	referenced bool,
 ) map[string]*model.ManifestFile {
 	manifestFileMap := make(map[string]*model.ManifestFile)
 
@@ -615,19 +662,20 @@ func (fms *FileManagerService) convertToManifestFileMap(
 		if currentFile == nil || currentFile.GetFileMeta() == nil {
 			continue
 		}
-		manifestFile := fms.convertToManifestFile(currentFile)
+		manifestFile := fms.convertToManifestFile(currentFile, referenced)
 		manifestFileMap[name] = manifestFile
 	}
 
 	return manifestFileMap
 }
 
-func (fms *FileManagerService) convertToManifestFile(file *mpi.File) *model.ManifestFile {
+func (fms *FileManagerService) convertToManifestFile(file *mpi.File, referenced bool) *model.ManifestFile {
 	return &model.ManifestFile{
 		ManifestFileMeta: &model.ManifestFileMeta{
-			Name: file.GetFileMeta().GetName(),
-			Size: file.GetFileMeta().GetSize(),
-			Hash: file.GetFileMeta().GetHash(),
+			Name:       file.GetFileMeta().GetName(),
+			Size:       file.GetFileMeta().GetSize(),
+			Hash:       file.GetFileMeta().GetHash(),
+			Referenced: referenced,
 		},
 	}
 }

--- a/internal/file/file_manager_service_test.go
+++ b/internal/file/file_manager_service_test.go
@@ -497,9 +497,6 @@ func TestFileManagerService_DetermineFileActions(t *testing.T) {
 	unmanagedErr := os.WriteFile(unmanagedFile.Name(), unmanagedFileContent, 0o600)
 	require.NoError(t, unmanagedErr)
 
-	manifestDirPath = tempDir
-	manifestFilePath = manifestDirPath + "/manifest.json"
-
 	tests := []struct {
 		expectedError   error
 		modifiedFiles   map[string]*model.FileCache
@@ -508,69 +505,69 @@ func TestFileManagerService_DetermineFileActions(t *testing.T) {
 		expectedContent map[string][]byte
 		name            string
 	}{
-		// {
-		//	name: "Test 1: Add, Update & Delete Files",
-		//	modifiedFiles: map[string]*model.FileCache{
-		//		addTestFileName: {
-		//			File: &mpi.File{
-		//				FileMeta:  protos.FileMeta(addTestFileName, files.GenerateHash(fileContent)),
-		//				Unmanaged: false,
-		//			},
-		//		},
-		//		updateTestFile.Name(): {
-		//			File: &mpi.File{
-		//				FileMeta:  protos.FileMeta(updateTestFile.Name(), files.GenerateHash(updatedFileContent)),
-		//				Unmanaged: false,
-		//			},
-		//		},
-		//		unmanagedFile.Name(): {
-		//			File: &mpi.File{
-		//				FileMeta:  protos.FileMeta(unmanagedFile.Name(), files.GenerateHash(unmanagedFileContent)),
-		//				Unmanaged: true,
-		//			},
-		//		},
-		//	},
-		//	currentFiles: map[string]*mpi.File{
-		//		deleteTestFile.Name(): {
-		//			FileMeta: protos.FileMeta(deleteTestFile.Name(), files.GenerateHash(fileContent)),
-		//		},
-		//		updateTestFile.Name(): {
-		//			FileMeta: protos.FileMeta(updateTestFile.Name(), files.GenerateHash(fileContent)),
-		//		},
-		//		unmanagedFile.Name(): {
-		//			FileMeta:  protos.FileMeta(unmanagedFile.Name(), files.GenerateHash(fileContent)),
-		//			Unmanaged: true,
-		//		},
-		//	},
-		//	expectedCache: map[string]*model.FileCache{
-		//		deleteTestFile.Name(): {
-		//			File: &mpi.File{
-		//				FileMeta:  protos.ManifestFileMeta(deleteTestFile.Name(), files.GenerateHash(fileContent)),
-		//				Unmanaged: false,
-		//			},
-		//			Action: model.Delete,
-		//		},
-		//		updateTestFile.Name(): {
-		//			File: &mpi.File{
-		//				FileMeta:  protos.FileMeta(updateTestFile.Name(), files.GenerateHash(updatedFileContent)),
-		//				Unmanaged: false,
-		//			},
-		//			Action: model.Update,
-		//		},
-		//		addTestFileName: {
-		//			File: &mpi.File{
-		//				FileMeta:  protos.FileMeta(addTestFileName, files.GenerateHash(fileContent)),
-		//				Unmanaged: false,
-		//			},
-		//			Action: model.Add,
-		//		},
-		//	},
-		//	expectedContent: map[string][]byte{
-		//		deleteTestFile.Name(): fileContent,
-		//		updateTestFile.Name(): updatedFileContent,
-		//	},
-		//	expectedError: nil,
-		// },
+		{
+			name: "Test 1: Add, Update & Delete Files",
+			modifiedFiles: map[string]*model.FileCache{
+				addTestFileName: {
+					File: &mpi.File{
+						FileMeta:  protos.FileMeta(addTestFileName, files.GenerateHash(fileContent)),
+						Unmanaged: false,
+					},
+				},
+				updateTestFile.Name(): {
+					File: &mpi.File{
+						FileMeta:  protos.FileMeta(updateTestFile.Name(), files.GenerateHash(updatedFileContent)),
+						Unmanaged: false,
+					},
+				},
+				unmanagedFile.Name(): {
+					File: &mpi.File{
+						FileMeta:  protos.FileMeta(unmanagedFile.Name(), files.GenerateHash(unmanagedFileContent)),
+						Unmanaged: true,
+					},
+				},
+			},
+			currentFiles: map[string]*mpi.File{
+				deleteTestFile.Name(): {
+					FileMeta: protos.FileMeta(deleteTestFile.Name(), files.GenerateHash(fileContent)),
+				},
+				updateTestFile.Name(): {
+					FileMeta: protos.FileMeta(updateTestFile.Name(), files.GenerateHash(fileContent)),
+				},
+				unmanagedFile.Name(): {
+					FileMeta:  protos.FileMeta(unmanagedFile.Name(), files.GenerateHash(fileContent)),
+					Unmanaged: true,
+				},
+			},
+			expectedCache: map[string]*model.FileCache{
+				deleteTestFile.Name(): {
+					File: &mpi.File{
+						FileMeta:  protos.ManifestFileMeta(deleteTestFile.Name(), files.GenerateHash(fileContent)),
+						Unmanaged: false,
+					},
+					Action: model.Delete,
+				},
+				updateTestFile.Name(): {
+					File: &mpi.File{
+						FileMeta:  protos.FileMeta(updateTestFile.Name(), files.GenerateHash(updatedFileContent)),
+						Unmanaged: false,
+					},
+					Action: model.Update,
+				},
+				addTestFileName: {
+					File: &mpi.File{
+						FileMeta:  protos.FileMeta(addTestFileName, files.GenerateHash(fileContent)),
+						Unmanaged: false,
+					},
+					Action: model.Add,
+				},
+			},
+			expectedContent: map[string][]byte{
+				deleteTestFile.Name(): fileContent,
+				updateTestFile.Name(): updatedFileContent,
+			},
+			expectedError: nil,
+		},
 		{
 			name: "Test 2: Files same as on disk",
 			modifiedFiles: map[string]*model.FileCache{

--- a/internal/file/file_manager_service_test.go
+++ b/internal/file/file_manager_service_test.go
@@ -223,7 +223,7 @@ func TestFileManagerService_ConfigApply_Update(t *testing.T) {
 	agentConfig := types.AgentConfig()
 	agentConfig.AllowedDirectories = []string{tempDir}
 	fileManagerService := NewFileManagerService(fakeFileServiceClient, agentConfig)
-	fileManagerService.UpdateCurrentFilesOnDisk(filesOnDisk)
+	fileManagerService.UpdateCurrentFilesOnDisk(ctx, filesOnDisk)
 
 	request := protos.CreateConfigApplyRequest(overview)
 
@@ -269,7 +269,7 @@ func TestFileManagerService_ConfigApply_Delete(t *testing.T) {
 	agentConfig := types.AgentConfig()
 	agentConfig.AllowedDirectories = []string{tempDir}
 	fileManagerService := NewFileManagerService(fakeFileServiceClient, agentConfig)
-	fileManagerService.UpdateCurrentFilesOnDisk(filesOnDisk)
+	fileManagerService.UpdateCurrentFilesOnDisk(ctx, filesOnDisk)
 
 	request := protos.CreateConfigApplyRequest(overview)
 
@@ -286,7 +286,18 @@ func TestFileManagerService_ConfigApply_Delete(t *testing.T) {
 	require.NoError(t, err)
 	assert.NoFileExists(t, tempFile.Name())
 	assert.Equal(t, fileManagerService.rollbackFileContents[tempFile.Name()], fileContent)
-	assert.Equal(t, fileManagerService.fileActions[tempFile.Name()].File, filesOnDisk[tempFile.Name()])
+	assert.Equal(t,
+		fileManagerService.fileActions[tempFile.Name()].File.GetFileMeta().GetName(),
+		filesOnDisk[tempFile.Name()].GetFileMeta().GetName(),
+	)
+	assert.Equal(t,
+		fileManagerService.fileActions[tempFile.Name()].File.GetFileMeta().GetHash(),
+		filesOnDisk[tempFile.Name()].GetFileMeta().GetHash(),
+	)
+	assert.Equal(t,
+		fileManagerService.fileActions[tempFile.Name()].File.GetFileMeta().GetSize(),
+		filesOnDisk[tempFile.Name()].GetFileMeta().GetSize(),
+	)
 	assert.Equal(t, model.OK, writeStatus)
 }
 

--- a/internal/file/file_manager_service_test.go
+++ b/internal/file/file_manager_service_test.go
@@ -508,69 +508,69 @@ func TestFileManagerService_DetermineFileActions(t *testing.T) {
 		expectedContent map[string][]byte
 		name            string
 	}{
-		{
-			name: "Test 1: Add, Update & Delete Files",
-			modifiedFiles: map[string]*model.FileCache{
-				addTestFileName: {
-					File: &mpi.File{
-						FileMeta:  protos.FileMeta(addTestFileName, files.GenerateHash(fileContent)),
-						Unmanaged: false,
-					},
-				},
-				updateTestFile.Name(): {
-					File: &mpi.File{
-						FileMeta:  protos.FileMeta(updateTestFile.Name(), files.GenerateHash(updatedFileContent)),
-						Unmanaged: false,
-					},
-				},
-				unmanagedFile.Name(): {
-					File: &mpi.File{
-						FileMeta:  protos.FileMeta(unmanagedFile.Name(), files.GenerateHash(unmanagedFileContent)),
-						Unmanaged: true,
-					},
-				},
-			},
-			currentFiles: map[string]*mpi.File{
-				deleteTestFile.Name(): {
-					FileMeta: protos.FileMeta(deleteTestFile.Name(), files.GenerateHash(fileContent)),
-				},
-				updateTestFile.Name(): {
-					FileMeta: protos.FileMeta(updateTestFile.Name(), files.GenerateHash(fileContent)),
-				},
-				unmanagedFile.Name(): {
-					FileMeta:  protos.FileMeta(unmanagedFile.Name(), files.GenerateHash(fileContent)),
-					Unmanaged: true,
-				},
-			},
-			expectedCache: map[string]*model.FileCache{
-				deleteTestFile.Name(): {
-					File: &mpi.File{
-						FileMeta:  protos.ManifestFileMeta(deleteTestFile.Name(), files.GenerateHash(fileContent)),
-						Unmanaged: false,
-					},
-					Action: model.Delete,
-				},
-				updateTestFile.Name(): {
-					File: &mpi.File{
-						FileMeta:  protos.FileMeta(updateTestFile.Name(), files.GenerateHash(updatedFileContent)),
-						Unmanaged: false,
-					},
-					Action: model.Update,
-				},
-				addTestFileName: {
-					File: &mpi.File{
-						FileMeta:  protos.FileMeta(addTestFileName, files.GenerateHash(fileContent)),
-						Unmanaged: false,
-					},
-					Action: model.Add,
-				},
-			},
-			expectedContent: map[string][]byte{
-				deleteTestFile.Name(): fileContent,
-				updateTestFile.Name(): updatedFileContent,
-			},
-			expectedError: nil,
-		},
+		//{
+		//	name: "Test 1: Add, Update & Delete Files",
+		//	modifiedFiles: map[string]*model.FileCache{
+		//		addTestFileName: {
+		//			File: &mpi.File{
+		//				FileMeta:  protos.FileMeta(addTestFileName, files.GenerateHash(fileContent)),
+		//				Unmanaged: false,
+		//			},
+		//		},
+		//		updateTestFile.Name(): {
+		//			File: &mpi.File{
+		//				FileMeta:  protos.FileMeta(updateTestFile.Name(), files.GenerateHash(updatedFileContent)),
+		//				Unmanaged: false,
+		//			},
+		//		},
+		//		unmanagedFile.Name(): {
+		//			File: &mpi.File{
+		//				FileMeta:  protos.FileMeta(unmanagedFile.Name(), files.GenerateHash(unmanagedFileContent)),
+		//				Unmanaged: true,
+		//			},
+		//		},
+		//	},
+		//	currentFiles: map[string]*mpi.File{
+		//		deleteTestFile.Name(): {
+		//			FileMeta: protos.FileMeta(deleteTestFile.Name(), files.GenerateHash(fileContent)),
+		//		},
+		//		updateTestFile.Name(): {
+		//			FileMeta: protos.FileMeta(updateTestFile.Name(), files.GenerateHash(fileContent)),
+		//		},
+		//		unmanagedFile.Name(): {
+		//			FileMeta:  protos.FileMeta(unmanagedFile.Name(), files.GenerateHash(fileContent)),
+		//			Unmanaged: true,
+		//		},
+		//	},
+		//	expectedCache: map[string]*model.FileCache{
+		//		deleteTestFile.Name(): {
+		//			File: &mpi.File{
+		//				FileMeta:  protos.ManifestFileMeta(deleteTestFile.Name(), files.GenerateHash(fileContent)),
+		//				Unmanaged: false,
+		//			},
+		//			Action: model.Delete,
+		//		},
+		//		updateTestFile.Name(): {
+		//			File: &mpi.File{
+		//				FileMeta:  protos.FileMeta(updateTestFile.Name(), files.GenerateHash(updatedFileContent)),
+		//				Unmanaged: false,
+		//			},
+		//			Action: model.Update,
+		//		},
+		//		addTestFileName: {
+		//			File: &mpi.File{
+		//				FileMeta:  protos.FileMeta(addTestFileName, files.GenerateHash(fileContent)),
+		//				Unmanaged: false,
+		//			},
+		//			Action: model.Add,
+		//		},
+		//	},
+		//	expectedContent: map[string][]byte{
+		//		deleteTestFile.Name(): fileContent,
+		//		updateTestFile.Name(): updatedFileContent,
+		//	},
+		//	expectedError: nil,
+		//},
 		{
 			name: "Test 2: Files same as on disk",
 			modifiedFiles: map[string]*model.FileCache{

--- a/internal/file/file_manager_service_test.go
+++ b/internal/file/file_manager_service_test.go
@@ -611,7 +611,8 @@ func TestFileManagerService_DetermineFileActions(t *testing.T) {
 		t.Run(test.name, func(tt *testing.T) {
 			// Delete manifest file if it already exists
 			dir := helpers.CreateManifestDirWithErrorCheck(t, manifestDirPath, "manifest.json")
-			manifestFilePath = dir + "manifest.json"
+			manifestFilePath = dir + "/manifest.json"
+			t.Logf("path: %s", manifestFilePath)
 			fakeFileServiceClient := &v1fakes.FakeFileServiceClient{}
 			fileManagerService := NewFileManagerService(fakeFileServiceClient, types.AgentConfig())
 			err = fileManagerService.UpdateManifestFile(test.currentFiles, true)

--- a/internal/file/file_manager_service_test.go
+++ b/internal/file/file_manager_service_test.go
@@ -508,7 +508,7 @@ func TestFileManagerService_DetermineFileActions(t *testing.T) {
 		expectedContent map[string][]byte
 		name            string
 	}{
-		//{
+		// {
 		//	name: "Test 1: Add, Update & Delete Files",
 		//	modifiedFiles: map[string]*model.FileCache{
 		//		addTestFileName: {
@@ -570,7 +570,7 @@ func TestFileManagerService_DetermineFileActions(t *testing.T) {
 		//		updateTestFile.Name(): updatedFileContent,
 		//	},
 		//	expectedError: nil,
-		//},
+		// },
 		{
 			name: "Test 2: Files same as on disk",
 			modifiedFiles: map[string]*model.FileCache{

--- a/internal/file/file_manager_service_test.go
+++ b/internal/file/file_manager_service_test.go
@@ -499,7 +499,6 @@ func TestFileManagerService_DetermineFileActions(t *testing.T) {
 
 	manifestDirPath = tempDir
 	manifestFilePath = manifestDirPath + "/manifest.json"
-	helpers.CreateFileWithErrorCheck(t, manifestDirPath, "manifest.json")
 
 	tests := []struct {
 		expectedError   error
@@ -610,6 +609,7 @@ func TestFileManagerService_DetermineFileActions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
+			helpers.CreateManifestFileWithErrorCheck(t, manifestDirPath, "manifest.json")
 			fakeFileServiceClient := &v1fakes.FakeFileServiceClient{}
 			fileManagerService := NewFileManagerService(fakeFileServiceClient, types.AgentConfig())
 			err = fileManagerService.UpdateManifestFile(test.currentFiles, true)

--- a/internal/file/file_manager_service_test.go
+++ b/internal/file/file_manager_service_test.go
@@ -631,10 +631,13 @@ func CreateTestManifestFile(t testing.TB, tempDir string, currentFiles map[strin
 	fileManagerService := NewFileManagerService(fakeFileServiceClient, types.AgentConfig())
 	manifestFiles := fileManagerService.convertToManifestFileMap(currentFiles, true)
 	manifestJSON, err := json.MarshalIndent(manifestFiles, "", "  ")
+	require.NoError(t, err)
 	file, err := os.CreateTemp(tempDir, "manifest.json")
 	require.NoError(t, err)
 
 	_, err = file.Write(manifestJSON)
+	require.NoError(t, err)
+
 	return file
 }
 

--- a/internal/file/file_manager_service_test.go
+++ b/internal/file/file_manager_service_test.go
@@ -223,7 +223,8 @@ func TestFileManagerService_ConfigApply_Update(t *testing.T) {
 	agentConfig := types.AgentConfig()
 	agentConfig.AllowedDirectories = []string{tempDir}
 	fileManagerService := NewFileManagerService(fakeFileServiceClient, agentConfig)
-	fileManagerService.UpdateCurrentFilesOnDisk(ctx, filesOnDisk)
+	err := fileManagerService.UpdateCurrentFilesOnDisk(ctx, filesOnDisk, false)
+	require.NoError(t, err)
 
 	request := protos.CreateConfigApplyRequest(overview)
 
@@ -269,7 +270,8 @@ func TestFileManagerService_ConfigApply_Delete(t *testing.T) {
 	agentConfig := types.AgentConfig()
 	agentConfig.AllowedDirectories = []string{tempDir}
 	fileManagerService := NewFileManagerService(fakeFileServiceClient, agentConfig)
-	fileManagerService.UpdateCurrentFilesOnDisk(ctx, filesOnDisk)
+	err := fileManagerService.UpdateCurrentFilesOnDisk(ctx, filesOnDisk, false)
+	require.NoError(t, err)
 
 	request := protos.CreateConfigApplyRequest(overview)
 
@@ -610,7 +612,7 @@ func TestFileManagerService_DetermineFileActions(t *testing.T) {
 		t.Run(test.name, func(tt *testing.T) {
 			fakeFileServiceClient := &v1fakes.FakeFileServiceClient{}
 			fileManagerService := NewFileManagerService(fakeFileServiceClient, types.AgentConfig())
-			err = fileManagerService.UpdateManifestFile(test.currentFiles)
+			err = fileManagerService.UpdateManifestFile(test.currentFiles, true)
 			require.NoError(tt, err)
 			diff, contents, fileActionErr := fileManagerService.DetermineFileActions(test.currentFiles,
 				test.modifiedFiles)

--- a/internal/file/file_manager_service_test.go
+++ b/internal/file/file_manager_service_test.go
@@ -609,7 +609,9 @@ func TestFileManagerService_DetermineFileActions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			helpers.CreateManifestFileWithErrorCheck(t, manifestDirPath, "manifest.json")
+			// Delete manifest file if it already exists
+			dir := helpers.CreateManifestDirWithErrorCheck(t, manifestDirPath, "manifest.json")
+			manifestFilePath = dir + "manifest.json"
 			fakeFileServiceClient := &v1fakes.FakeFileServiceClient{}
 			fileManagerService := NewFileManagerService(fakeFileServiceClient, types.AgentConfig())
 			err = fileManagerService.UpdateManifestFile(test.currentFiles, true)

--- a/internal/file/file_plugin.go
+++ b/internal/file/file_plugin.go
@@ -136,6 +136,14 @@ func (fp *FilePlugin) handleConfigApplySuccess(ctx context.Context, msg *bus.Mes
 	}
 
 	fp.fileManagerService.ClearCache()
+	updateError := fp.fileManagerService.UpdateCurrentFilesOnDisk(
+		ctx,
+		files.ConvertToMapOfFiles(successMessage.ConfigContext.Files),
+		true,
+	)
+	if updateError != nil {
+		slog.ErrorContext(ctx, "Unable to update current files on disk", "error", updateError)
+	}
 	fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: successMessage.DataPlaneResponse})
 }
 
@@ -301,7 +309,14 @@ func (fp *FilePlugin) handleNginxConfigUpdate(ctx context.Context, msg *bus.Mess
 		return
 	}
 
-	fp.fileManagerService.UpdateCurrentFilesOnDisk(ctx, files.ConvertToMapOfFiles(nginxConfigContext.Files))
+	updateError := fp.fileManagerService.UpdateCurrentFilesOnDisk(
+		ctx,
+		files.ConvertToMapOfFiles(nginxConfigContext.Files),
+		true,
+	)
+	if updateError != nil {
+		slog.ErrorContext(ctx, "Unable to update current files on disk", "error", updateError)
+	}
 
 	err := fp.fileManagerService.UpdateOverview(ctx, nginxConfigContext.InstanceID, nginxConfigContext.Files, 0)
 	if err != nil {

--- a/internal/file/file_plugin.go
+++ b/internal/file/file_plugin.go
@@ -171,6 +171,7 @@ func (fp *FilePlugin) handleConfigApplyFailedRequest(ctx context.Context, msg *b
 }
 
 func (fp *FilePlugin) handleConfigApplyRequest(ctx context.Context, msg *bus.Message) {
+	slog.DebugContext(ctx, "File plugin received config apply request message")
 	var response *mpi.DataPlaneResponse
 	correlationID := logger.GetCorrelationID(ctx)
 
@@ -197,6 +198,7 @@ func (fp *FilePlugin) handleConfigApplyRequest(ctx context.Context, msg *bus.Mes
 
 	switch writeStatus {
 	case model.NoChange:
+		slog.DebugContext(ctx, "No changes required for config apply request")
 		dpResponse := fp.createDataPlaneResponse(
 			correlationID,
 			mpi.CommandResponse_COMMAND_STATUS_OK,
@@ -280,6 +282,7 @@ func (fp *FilePlugin) handleConfigApplyRequest(ctx context.Context, msg *bus.Mes
 
 		return
 	case model.OK:
+		slog.DebugContext(ctx, "Changes required for config apply request")
 		// Send WriteConfigSuccessfulTopic with Correlation and Instance ID for use by resource plugin
 		data := &model.ConfigApplyMessage{
 			CorrelationID: correlationID,
@@ -298,7 +301,7 @@ func (fp *FilePlugin) handleNginxConfigUpdate(ctx context.Context, msg *bus.Mess
 		return
 	}
 
-	fp.fileManagerService.UpdateCurrentFilesOnDisk(files.ConvertToMapOfFiles(nginxConfigContext.Files))
+	fp.fileManagerService.UpdateCurrentFilesOnDisk(ctx, files.ConvertToMapOfFiles(nginxConfigContext.Files))
 
 	err := fp.fileManagerService.UpdateOverview(ctx, nginxConfigContext.InstanceID, nginxConfigContext.Files, 0)
 	if err != nil {

--- a/internal/file/file_plugin_test.go
+++ b/internal/file/file_plugin_test.go
@@ -473,3 +473,44 @@ func TestFilePlugin_Process_ConfigApplyRollbackCompleteTopic(t *testing.T) {
 
 	assert.Equal(t, expectedResponse.GetInstanceId(), response.GetInstanceId())
 }
+
+func TestFilePlugin_Process_ConfigApplyCompleteTopic(t *testing.T) {
+	ctx := context.Background()
+	instance := protos.GetNginxOssInstance([]string{})
+	mockFileManager := &filefakes.FakeFileManagerServiceInterface{}
+
+	messagePipe := busfakes.NewFakeMessagePipe()
+	agentConfig := types.AgentConfig()
+	fakeGrpcConnection := &grpcfakes.FakeGrpcConnectionInterface{}
+	filePlugin := NewFilePlugin(agentConfig, fakeGrpcConnection)
+
+	err := filePlugin.Init(ctx, messagePipe)
+	require.NoError(t, err)
+	filePlugin.fileManagerService = mockFileManager
+	expectedResponse := &mpi.DataPlaneResponse{
+		MessageMeta: &mpi.MessageMeta{
+			MessageId:     id.GenerateMessageID(),
+			CorrelationId: "dfsbhj6-bc92-30c1-a9c9-85591422068e",
+			Timestamp:     timestamppb.Now(),
+		},
+		CommandResponse: &mpi.CommandResponse{
+			Status:  mpi.CommandResponse_COMMAND_STATUS_OK,
+			Message: "Config apply successful",
+			Error:   "",
+		},
+		InstanceId: instance.GetInstanceMeta().GetInstanceId(),
+	}
+
+	filePlugin.Process(ctx, &bus.Message{Topic: bus.ConfigApplyCompleteTopic, Data: expectedResponse})
+
+	messages := messagePipe.GetMessages()
+	response, ok := messages[0].Data.(*mpi.DataPlaneResponse)
+	assert.True(t, ok)
+
+	assert.Equal(t, expectedResponse.GetCommandResponse().GetStatus(), response.GetCommandResponse().GetStatus())
+	assert.Equal(t, expectedResponse.GetCommandResponse().GetMessage(), response.GetCommandResponse().GetMessage())
+	assert.Equal(t, expectedResponse.GetCommandResponse().GetError(), response.GetCommandResponse().GetError())
+	assert.Equal(t, expectedResponse.GetMessageMeta().GetCorrelationId(), response.GetMessageMeta().GetCorrelationId())
+
+	assert.Equal(t, expectedResponse.GetInstanceId(), response.GetInstanceId())
+}

--- a/internal/file/filefakes/fake_file_manager_service_interface.go
+++ b/internal/file/filefakes/fake_file_manager_service_interface.go
@@ -71,11 +71,18 @@ type FakeFileManagerServiceInterface struct {
 	setIsConnectedArgsForCall []struct {
 		arg1 bool
 	}
-	UpdateCurrentFilesOnDiskStub        func(context.Context, map[string]*v1.File)
+	UpdateCurrentFilesOnDiskStub        func(context.Context, map[string]*v1.File, bool) error
 	updateCurrentFilesOnDiskMutex       sync.RWMutex
 	updateCurrentFilesOnDiskArgsForCall []struct {
 		arg1 context.Context
 		arg2 map[string]*v1.File
+		arg3 bool
+	}
+	updateCurrentFilesOnDiskReturns struct {
+		result1 error
+	}
+	updateCurrentFilesOnDiskReturnsOnCall map[int]struct {
+		result1 error
 	}
 	UpdateFileStub        func(context.Context, string, *v1.File) error
 	updateFileMutex       sync.RWMutex
@@ -412,18 +419,25 @@ func (fake *FakeFileManagerServiceInterface) SetIsConnectedArgsForCall(i int) bo
 	return argsForCall.arg1
 }
 
-func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDisk(arg1 context.Context, arg2 map[string]*v1.File) {
+func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDisk(arg1 context.Context, arg2 map[string]*v1.File, arg3 bool) error {
 	fake.updateCurrentFilesOnDiskMutex.Lock()
+	ret, specificReturn := fake.updateCurrentFilesOnDiskReturnsOnCall[len(fake.updateCurrentFilesOnDiskArgsForCall)]
 	fake.updateCurrentFilesOnDiskArgsForCall = append(fake.updateCurrentFilesOnDiskArgsForCall, struct {
 		arg1 context.Context
 		arg2 map[string]*v1.File
-	}{arg1, arg2})
+		arg3 bool
+	}{arg1, arg2, arg3})
 	stub := fake.UpdateCurrentFilesOnDiskStub
-	fake.recordInvocation("UpdateCurrentFilesOnDisk", []interface{}{arg1, arg2})
+	fakeReturns := fake.updateCurrentFilesOnDiskReturns
+	fake.recordInvocation("UpdateCurrentFilesOnDisk", []interface{}{arg1, arg2, arg3})
 	fake.updateCurrentFilesOnDiskMutex.Unlock()
 	if stub != nil {
-		fake.UpdateCurrentFilesOnDiskStub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
 }
 
 func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDiskCallCount() int {
@@ -432,17 +446,40 @@ func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDiskCallCount()
 	return len(fake.updateCurrentFilesOnDiskArgsForCall)
 }
 
-func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDiskCalls(stub func(context.Context, map[string]*v1.File)) {
+func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDiskCalls(stub func(context.Context, map[string]*v1.File, bool) error) {
 	fake.updateCurrentFilesOnDiskMutex.Lock()
 	defer fake.updateCurrentFilesOnDiskMutex.Unlock()
 	fake.UpdateCurrentFilesOnDiskStub = stub
 }
 
-func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDiskArgsForCall(i int) (context.Context, map[string]*v1.File) {
+func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDiskArgsForCall(i int) (context.Context, map[string]*v1.File, bool) {
 	fake.updateCurrentFilesOnDiskMutex.RLock()
 	defer fake.updateCurrentFilesOnDiskMutex.RUnlock()
 	argsForCall := fake.updateCurrentFilesOnDiskArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDiskReturns(result1 error) {
+	fake.updateCurrentFilesOnDiskMutex.Lock()
+	defer fake.updateCurrentFilesOnDiskMutex.Unlock()
+	fake.UpdateCurrentFilesOnDiskStub = nil
+	fake.updateCurrentFilesOnDiskReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDiskReturnsOnCall(i int, result1 error) {
+	fake.updateCurrentFilesOnDiskMutex.Lock()
+	defer fake.updateCurrentFilesOnDiskMutex.Unlock()
+	fake.UpdateCurrentFilesOnDiskStub = nil
+	if fake.updateCurrentFilesOnDiskReturnsOnCall == nil {
+		fake.updateCurrentFilesOnDiskReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.updateCurrentFilesOnDiskReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeFileManagerServiceInterface) UpdateFile(arg1 context.Context, arg2 string, arg3 *v1.File) error {

--- a/internal/file/filefakes/fake_file_manager_service_interface.go
+++ b/internal/file/filefakes/fake_file_manager_service_interface.go
@@ -71,10 +71,11 @@ type FakeFileManagerServiceInterface struct {
 	setIsConnectedArgsForCall []struct {
 		arg1 bool
 	}
-	UpdateCurrentFilesOnDiskStub        func(map[string]*v1.File)
+	UpdateCurrentFilesOnDiskStub        func(context.Context, map[string]*v1.File)
 	updateCurrentFilesOnDiskMutex       sync.RWMutex
 	updateCurrentFilesOnDiskArgsForCall []struct {
-		arg1 map[string]*v1.File
+		arg1 context.Context
+		arg2 map[string]*v1.File
 	}
 	UpdateFileStub        func(context.Context, string, *v1.File) error
 	updateFileMutex       sync.RWMutex
@@ -411,16 +412,17 @@ func (fake *FakeFileManagerServiceInterface) SetIsConnectedArgsForCall(i int) bo
 	return argsForCall.arg1
 }
 
-func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDisk(arg1 map[string]*v1.File) {
+func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDisk(arg1 context.Context, arg2 map[string]*v1.File) {
 	fake.updateCurrentFilesOnDiskMutex.Lock()
 	fake.updateCurrentFilesOnDiskArgsForCall = append(fake.updateCurrentFilesOnDiskArgsForCall, struct {
-		arg1 map[string]*v1.File
-	}{arg1})
+		arg1 context.Context
+		arg2 map[string]*v1.File
+	}{arg1, arg2})
 	stub := fake.UpdateCurrentFilesOnDiskStub
-	fake.recordInvocation("UpdateCurrentFilesOnDisk", []interface{}{arg1})
+	fake.recordInvocation("UpdateCurrentFilesOnDisk", []interface{}{arg1, arg2})
 	fake.updateCurrentFilesOnDiskMutex.Unlock()
 	if stub != nil {
-		fake.UpdateCurrentFilesOnDiskStub(arg1)
+		fake.UpdateCurrentFilesOnDiskStub(arg1, arg2)
 	}
 }
 
@@ -430,17 +432,17 @@ func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDiskCallCount()
 	return len(fake.updateCurrentFilesOnDiskArgsForCall)
 }
 
-func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDiskCalls(stub func(map[string]*v1.File)) {
+func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDiskCalls(stub func(context.Context, map[string]*v1.File)) {
 	fake.updateCurrentFilesOnDiskMutex.Lock()
 	defer fake.updateCurrentFilesOnDiskMutex.Unlock()
 	fake.UpdateCurrentFilesOnDiskStub = stub
 }
 
-func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDiskArgsForCall(i int) map[string]*v1.File {
+func (fake *FakeFileManagerServiceInterface) UpdateCurrentFilesOnDiskArgsForCall(i int) (context.Context, map[string]*v1.File) {
 	fake.updateCurrentFilesOnDiskMutex.RLock()
 	defer fake.updateCurrentFilesOnDiskMutex.RUnlock()
 	argsForCall := fake.updateCurrentFilesOnDiskArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeFileManagerServiceInterface) UpdateFile(arg1 context.Context, arg2 string, arg3 *v1.File) error {

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -37,7 +37,8 @@ type ManifestFileMeta struct {
 	// The hash of the file contents sha256, hex encoded
 	Hash string `json:"hash"`
 	// The size of the file in bytes
-	Size int64 `json:"size"`
+	Size       int64 `json:"size"`
+	Referenced bool  `json:"referenced"`
 }
 type ConfigApplyMessage struct {
 	Error         error

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -37,8 +37,9 @@ type ManifestFileMeta struct {
 	// The hash of the file contents sha256, hex encoded
 	Hash string `json:"hash"`
 	// The size of the file in bytes
-	Size       int64 `json:"size"`
-	Referenced bool  `json:"referenced"`
+	Size int64 `json:"size"`
+	// File referenced in the NGINX config
+	Referenced bool `json:"referenced"`
 }
 type ConfigApplyMessage struct {
 	Error         error

--- a/internal/watcher/watcher_plugin.go
+++ b/internal/watcher/watcher_plugin.go
@@ -158,7 +158,7 @@ func (*Watcher) Subscriptions() []string {
 }
 
 func (w *Watcher) handleConfigApplyRequest(ctx context.Context, msg *bus.Message) {
-	slog.Info("Watcher plugin received ConfigApplyRequest event")
+	slog.DebugContext(ctx, "Watcher plugin received ConfigApplyRequest event")
 	managementPlaneRequest, ok := msg.Data.(*mpi.ManagementPlaneRequest)
 	if !ok {
 		slog.ErrorContext(ctx, "Unable to cast message payload to *mpi.ManagementPlaneRequest",

--- a/test/helpers/os_utils.go
+++ b/test/helpers/os_utils.go
@@ -6,6 +6,7 @@
 package helpers
 
 import (
+	"errors"
 	"os"
 	"regexp"
 	"strings"
@@ -31,6 +32,20 @@ func CreateFileWithErrorCheck(t testing.TB, dir, fileName string) *os.File {
 	t.Helper()
 
 	testConf, err := os.CreateTemp(dir, fileName)
+	require.NoError(t, err)
+
+	return testConf
+}
+
+func CreateManifestFileWithErrorCheck(t testing.TB, dir, manifestFileName string) *os.File {
+	t.Helper()
+
+	if _, err := os.Stat(dir + manifestFileName); !errors.Is(err, os.ErrNotExist) {
+		removeErr := os.Remove(dir + manifestFileName)
+		require.NoError(t, removeErr)
+	}
+
+	testConf, err := os.CreateTemp(dir, manifestFileName)
 	require.NoError(t, err)
 
 	return testConf

--- a/test/helpers/os_utils.go
+++ b/test/helpers/os_utils.go
@@ -7,7 +7,6 @@ package helpers
 
 import (
 	"errors"
-	"log/slog"
 	"os"
 	"regexp"
 	"strings"
@@ -42,7 +41,7 @@ func CreateManifestDirWithErrorCheck(t testing.TB, dir, manifestFileName string)
 	t.Helper()
 
 	if _, err := os.Stat(dir + manifestFileName); !errors.Is(err, os.ErrNotExist) {
-		slog.Info("Manifest file exists, deleting", "", dir+manifestFileName)
+		t.Logf("Manifest file exists, deleting: %s", dir+manifestFileName)
 		removeErr := os.Remove(dir + manifestFileName)
 		require.NoError(t, removeErr)
 	}

--- a/test/helpers/os_utils.go
+++ b/test/helpers/os_utils.go
@@ -7,6 +7,7 @@ package helpers
 
 import (
 	"errors"
+	"log/slog"
 	"os"
 	"regexp"
 	"strings"
@@ -37,18 +38,16 @@ func CreateFileWithErrorCheck(t testing.TB, dir, fileName string) *os.File {
 	return testConf
 }
 
-func CreateManifestFileWithErrorCheck(t testing.TB, dir, manifestFileName string) *os.File {
+func CreateManifestDirWithErrorCheck(t testing.TB, dir, manifestFileName string) string {
 	t.Helper()
 
 	if _, err := os.Stat(dir + manifestFileName); !errors.Is(err, os.ErrNotExist) {
+		slog.Info("Manifest file exists, deleting", "", dir+manifestFileName)
 		removeErr := os.Remove(dir + manifestFileName)
 		require.NoError(t, removeErr)
 	}
 
-	testConf, err := os.CreateTemp(dir, manifestFileName)
-	require.NoError(t, err)
-
-	return testConf
+	return os.TempDir()
 }
 
 func RemoveFileWithErrorCheck(t testing.TB, fileName string) {


### PR DESCRIPTION
### Proposed changes

Update manifest file during a NginxConfigContext update, mark unreferenced files in the manfiest file during config apply and configContext update. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
