### PR TITLE
NGINXaaS: add skip tls verification option to otlp exporter

### DIFF
--- a/internal/collector/otelcol.tmpl
+++ b/internal/collector/otelcol.tmpl
@@ -156,6 +156,7 @@ exporters:
     tls:
       insecure: {{ if .TLS -}}false{{ else -}}true{{- end }}
       {{- if .TLS }}
+      insecure_skip_verify: {{ .TLS.SkipVerify }}
       {{ if gt (len .TLS.Ca) 0 -}}ca_file: "{{- .TLS.Ca -}}"{{- end }}
       {{ if gt (len .TLS.Cert) 0 -}}cert_file: "{{- .TLS.Cert -}}"{{- end }}
       {{ if gt (len .TLS.Key) 0 -}}key_file: "{{- .TLS.Key -}}"{{- end }}


### PR DESCRIPTION
### Proposed changes

For testing purposes, it makes life easier to configure whether or not to skip TLS verification in cases of self-signed certificates.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
