### PR TITLE
Add Plus metrics receiver log messages

### DIFF
--- a/internal/collector/nginxplusreceiver/config.go
+++ b/internal/collector/nginxplusreceiver/config.go
@@ -16,10 +16,7 @@ import (
 	"github.com/nginx/agent/v3/internal/collector/nginxplusreceiver/internal/metadata"
 )
 
-const (
-	defaultCollectInterval = 10 * time.Second
-	defaultTimeout         = 10 * time.Second
-)
+const defaultCollectInterval = 10 * time.Second
 
 type Config struct {
 	confighttp.ClientConfig        `mapstructure:",squash"`

--- a/internal/collector/nginxplusreceiver/config.go
+++ b/internal/collector/nginxplusreceiver/config.go
@@ -16,7 +16,10 @@ import (
 	"github.com/nginx/agent/v3/internal/collector/nginxplusreceiver/internal/metadata"
 )
 
-const defaultCollectInterval = 10 * time.Second
+const (
+	defaultCollectInterval = 10 * time.Second
+	defaultTimeout         = 10 * time.Second
+)
 
 type Config struct {
 	confighttp.ClientConfig        `mapstructure:",squash"`
@@ -32,6 +35,7 @@ type APIDetails struct {
 }
 
 // Validate checks if the receiver configuration is valid
+// nolint: ireturn
 func (cfg *Config) Validate() error {
 	if cfg.APIDetails.URL == "" {
 		return errors.New("endpoint cannot be empty for nginxplusreceiver")

--- a/internal/collector/nginxplusreceiver/factory.go
+++ b/internal/collector/nginxplusreceiver/factory.go
@@ -7,7 +7,6 @@ package nginxplusreceiver
 import (
 	"context"
 	"errors"
-	"time"
 
 	"go.opentelemetry.io/collector/scraper"
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
@@ -18,8 +17,6 @@ import (
 
 	"github.com/nginx/agent/v3/internal/collector/nginxplusreceiver/internal/metadata"
 )
-
-const defaultTimeout = 10 * time.Second
 
 // nolint: ireturn
 func NewFactory() receiver.Factory {

--- a/internal/collector/otel_collector_plugin.go
+++ b/internal/collector/otel_collector_plugin.go
@@ -58,6 +58,8 @@ var (
 	initMutex            = &sync.Mutex{}
 )
 
+var pluginLogOrigin = slog.String("log_origin", "otel_collector_plugin.go")
+
 // NewCollector is the constructor for the Collector plugin.
 func New(conf *config.Config) (*Collector, error) {
 	initMutex.Lock()
@@ -262,7 +264,7 @@ func (oc *Collector) handleNginxConfigUpdate(ctx context.Context, msg *bus.Messa
 		return
 	}
 
-	reloadCollector := oc.checkForNewReceivers(nginxConfigContext)
+	reloadCollector := oc.checkForNewReceivers(ctx, nginxConfigContext)
 
 	if reloadCollector {
 		slog.InfoContext(ctx, "Reloading OTel collector config")
@@ -392,7 +394,7 @@ func (oc *Collector) restartCollector(ctx context.Context) {
 	}
 }
 
-func (oc *Collector) checkForNewReceivers(nginxConfigContext *model.NginxConfigContext) bool {
+func (oc *Collector) checkForNewReceivers(ctx context.Context, nginxConfigContext *model.NginxConfigContext) bool {
 	nginxReceiverFound, reloadCollector := oc.updateExistingNginxPlusReceiver(nginxConfigContext)
 
 	if !nginxReceiverFound && nginxConfigContext.PlusAPI.URL != "" {
@@ -407,10 +409,20 @@ func (oc *Collector) checkForNewReceivers(nginxConfigContext *model.NginxConfigC
 				},
 			},
 		)
+		slog.DebugContext(
+			ctx,
+			"NGINX Plus API found, NGINX Plus receiver enabled to scrape metrics",
+			pluginLogOrigin,
+		)
 
 		reloadCollector = true
 	} else if nginxConfigContext.PlusAPI.URL == "" {
-		reloadCollector = oc.addNginxOssReceiver(nginxConfigContext)
+		slog.WarnContext(
+			ctx,
+			"NGINX Plus API is not configured, searching for stub status endpoint",
+			pluginLogOrigin,
+		)
+		reloadCollector = oc.addNginxOssReceiver(ctx, nginxConfigContext)
 	}
 
 	if oc.config.IsFeatureEnabled(pkgConfig.FeatureLogsNap) {
@@ -425,7 +437,7 @@ func (oc *Collector) checkForNewReceivers(nginxConfigContext *model.NginxConfigC
 	return reloadCollector
 }
 
-func (oc *Collector) addNginxOssReceiver(nginxConfigContext *model.NginxConfigContext) bool {
+func (oc *Collector) addNginxOssReceiver(ctx context.Context, nginxConfigContext *model.NginxConfigContext) bool {
 	nginxReceiverFound, reloadCollector := oc.updateExistingNginxOSSReceiver(nginxConfigContext)
 
 	if !nginxReceiverFound && nginxConfigContext.StubStatus.URL != "" {
@@ -441,8 +453,11 @@ func (oc *Collector) addNginxOssReceiver(nginxConfigContext *model.NginxConfigCo
 				AccessLogs: toConfigAccessLog(nginxConfigContext.AccessLogs),
 			},
 		)
+		slog.DebugContext(ctx, "Stub status endpoint found, OSS receiver enabled to scrape metrics", pluginLogOrigin)
 
 		reloadCollector = true
+	} else if nginxConfigContext.StubStatus.URL == "" {
+		slog.WarnContext(ctx, "Stub status endpoint not found, NGINX metrics not available", pluginLogOrigin)
 	}
 
 	return reloadCollector


### PR DESCRIPTION
### Proposed changes

* Logging a warning if Plus API is not configured and OSS scraper is used for scraping metrics
* Warning If both Plus API and stub status endpoints are not configured and metrics are disabled

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
