### PR TITLE
Update Default Backoff Settings

### DIFF
--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -41,11 +41,11 @@ const (
 	DefGRPCKeepAlivePermitWithoutStream = true
 
 	// Client Backoff defaults
-	DefBackoffInitialInterval     = 500 * time.Millisecond
+	DefBackoffInitialInterval     = 10 * time.Second
 	DefBackoffRandomizationFactor = 0.5 // the value is 0 <= and < 1
 	DefBackoffMultiplier          = 1.5
-	DefBackoffMaxInterval         = 5 * time.Second
-	DefBackoffMaxElapsedTime      = 30 * time.Second
+	DefBackoffMaxInterval         = 20 * time.Second
+	DefBackoffMaxElapsedTime      = 1 * time.Minute
 
 	// Watcher defaults
 	DefInstanceWatcherMonitoringFrequency       = 5 * time.Second

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -42,9 +42,9 @@ const (
 	DefGRPCKeepAlivePermitWithoutStream = true
 
 	// Client Backoff defaults
-	DefBackoffInitialInterval     = 10 * time.Second
+	DefBackoffInitialInterval     = 1 * time.Second
 	DefBackoffRandomizationFactor = 0.5 // the value is 0 <= and < 1
-	DefBackoffMultiplier          = 1.5
+	DefBackoffMultiplier          = 3
 	DefBackoffMaxInterval         = 20 * time.Second
 	DefBackoffMaxElapsedTime      = 1 * time.Minute
 

--- a/test/docker/load/Dockerfile
+++ b/test/docker/load/Dockerfile
@@ -94,6 +94,6 @@ RUN chmod -R +x ./build
 
 WORKDIR /agent/test/load
 
-RUN go test -v -timeout 30s ./...
+RUN go test -v -timeout 1m ./...
 
 CMD ["sh", "-c", "cat benchmarks.json"]


### PR DESCRIPTION
### Proposed changes

Update default backoff settings to 
- now try for 1 minute instead of 30 seconds
- try 3 times in 30 seconds and 5 times in 1 minute instead of 9+ times in 30s
### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
