### PR TITLE
Do not send UpdateOverview after handling a Config Update

### DIFF
--- a/internal/file/file_plugin.go
+++ b/internal/file/file_plugin.go
@@ -317,16 +317,6 @@ func (fp *FilePlugin) handleNginxConfigUpdate(ctx context.Context, msg *bus.Mess
 	if updateError != nil {
 		slog.ErrorContext(ctx, "Unable to update current files on disk", "error", updateError)
 	}
-
-	err := fp.fileManagerService.UpdateOverview(ctx, nginxConfigContext.InstanceID, nginxConfigContext.Files, 0)
-	if err != nil {
-		slog.ErrorContext(
-			ctx,
-			"Failed to update file overview",
-			"instance_id", nginxConfigContext.InstanceID,
-			"error", err,
-		)
-	}
 }
 
 func (fp *FilePlugin) handleConfigUploadRequest(ctx context.Context, msg *bus.Message) {


### PR DESCRIPTION
Removes unnecessary UpdateOverview as N1 doesn't need to be notified by Agent V3 for an update it just applied.

### Proposed changes

Following a Config Update being applied by Agent V3 successfully, there is no need to send a FileOverview update (N1 already knows it and could be in the process of storing it).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [X] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
