### PR TITLE
Prevent a file overview update request from being sent after a config apply request has being processed

### DIFF
--- a/internal/file/file_plugin.go
+++ b/internal/file/file_plugin.go
@@ -318,14 +318,16 @@ func (fp *FilePlugin) handleNginxConfigUpdate(ctx context.Context, msg *bus.Mess
 		slog.ErrorContext(ctx, "Unable to update current files on disk", "error", updateError)
 	}
 
-	err := fp.fileManagerService.UpdateOverview(ctx, nginxConfigContext.InstanceID, nginxConfigContext.Files, 0)
-	if err != nil {
-		slog.ErrorContext(
-			ctx,
-			"Failed to update file overview",
-			"instance_id", nginxConfigContext.InstanceID,
-			"error", err,
-		)
+	if !nginxConfigContext.TriggeredByConfigApply {
+		err := fp.fileManagerService.UpdateOverview(ctx, nginxConfigContext.InstanceID, nginxConfigContext.Files, 0)
+		if err != nil {
+			slog.ErrorContext(
+				ctx,
+				"Failed to update file overview",
+				"instance_id", nginxConfigContext.InstanceID,
+				"error", err,
+			)
+		}
 	}
 }
 

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -12,13 +12,14 @@ import (
 )
 
 type NginxConfigContext struct {
-	StubStatus       *APIDetails
-	PlusAPI          *APIDetails
-	InstanceID       string
-	Files            []*v1.File
-	AccessLogs       []*AccessLog
-	ErrorLogs        []*ErrorLog
-	NAPSysLogServers []string
+	StubStatus             *APIDetails
+	PlusAPI                *APIDetails
+	InstanceID             string
+	Files                  []*v1.File
+	AccessLogs             []*AccessLog
+	ErrorLogs              []*ErrorLog
+	NAPSysLogServers       []string
+	TriggeredByConfigApply bool
 }
 
 type APIDetails struct {

--- a/internal/resource/resource_service.go
+++ b/internal/resource/resource_service.go
@@ -213,6 +213,9 @@ func (r *ResourceService) ApplyConfig(ctx context.Context, instanceID string) (*
 		return nil, fmt.Errorf("failed to reload NGINX %w", reloadErr)
 	}
 
+	// Set TriggeredByConfigApply to true to prevent a UpdateFileOverview request from being sent
+	nginxConfigContext.TriggeredByConfigApply = true
+
 	return nginxConfigContext, nil
 }
 

--- a/test/integration/grpc_management_plane_api_test.go
+++ b/test/integration/grpc_management_plane_api_test.go
@@ -310,7 +310,7 @@ func TestGrpc_ConfigApply(t *testing.T) {
 
 		performConfigApply(t, nginxInstanceID)
 
-		responses = getManagementPlaneResponses(t, 2)
+		responses = getManagementPlaneResponses(t, 1)
 		t.Logf("Config apply responses: %v", responses)
 
 		sort.Slice(responses, func(i, j int) bool {
@@ -319,8 +319,6 @@ func TestGrpc_ConfigApply(t *testing.T) {
 
 		assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
 		assert.Equal(t, "Config apply successful", responses[0].GetCommandResponse().GetMessage())
-		assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[1].GetCommandResponse().GetStatus())
-		assert.Equal(t, "Successfully updated all files", responses[1].GetCommandResponse().GetMessage())
 	})
 
 	t.Run("Test 3: Invalid config", func(t *testing.T) {

--- a/test/integration/grpc_management_plane_api_test.go
+++ b/test/integration/grpc_management_plane_api_test.go
@@ -447,7 +447,7 @@ func TestGrpc_ConfigApply_Chunking(t *testing.T) {
 
 	performConfigApply(t, nginxInstanceID)
 
-	responses = getManagementPlaneResponses(t, 2)
+	responses = getManagementPlaneResponses(t, 1)
 	t.Logf("Config apply responses: %v", responses)
 
 	sort.Slice(responses, func(i, j int) bool {
@@ -456,8 +456,6 @@ func TestGrpc_ConfigApply_Chunking(t *testing.T) {
 
 	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
 	assert.Equal(t, "Config apply successful", responses[0].GetCommandResponse().GetMessage())
-	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[1].GetCommandResponse().GetStatus())
-	assert.Equal(t, "Successfully updated all files", responses[1].GetCommandResponse().GetMessage())
 }
 
 func performConfigApply(t *testing.T, nginxInstanceID string) {


### PR DESCRIPTION
### Proposed changes

Prevent a file overview update request from being sent after a config apply request has being processed.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
