### PR TITLE
Fix deleted referenced files 

### DIFF
--- a/internal/file/file_manager_service.go
+++ b/internal/file/file_manager_service.go
@@ -178,7 +178,7 @@ func (fms *FileManagerService) UpdateOverview(
 	delta := files.ConvertToMapOfFiles(response.GetOverview().GetFiles())
 
 	if len(delta) != 0 {
-		return fms.updateFiles(ctx, delta, instanceID, iteration)
+		return fms.updateFiles(ctx, delta, request.GetOverview().GetFiles(), instanceID, iteration)
 	}
 
 	return err
@@ -202,6 +202,7 @@ func (fms *FileManagerService) setupIdentifiers(ctx context.Context, iteration i
 func (fms *FileManagerService) updateFiles(
 	ctx context.Context,
 	delta map[string]*mpi.File,
+	fileOverview []*mpi.File,
 	instanceID string,
 	iteration int,
 ) error {
@@ -217,7 +218,7 @@ func (fms *FileManagerService) updateFiles(
 	iteration++
 	slog.Debug("Updating file overview", "attempt_number", iteration)
 
-	return fms.UpdateOverview(ctx, instanceID, diffFiles, iteration)
+	return fms.UpdateOverview(ctx, instanceID, fileOverview, iteration)
 }
 
 func (fms *FileManagerService) UpdateFile(
@@ -483,7 +484,7 @@ func (fms *FileManagerService) DetermineFileActions(
 	fileDiff := make(map[string]*model.FileCache) // Files that have changed, key is file name
 	fileContents := make(map[string][]byte)       // contents of the file, key is file name
 
-	manifestFiles, filesMap, manifestFileErr := fms.manifestFile()
+	_, filesMap, manifestFileErr := fms.manifestFile()
 
 	if manifestFileErr != nil {
 		if errors.Is(manifestFileErr, os.ErrNotExist) {
@@ -524,14 +525,15 @@ func (fms *FileManagerService) DetermineFileActions(
 		}
 		// if file doesn't exist in the current files, file has been added
 		// set file action
-		if !ok {
+		if _, statErr := os.Stat(modifiedFile.File.GetFileMeta().GetName()); errors.Is(statErr, os.ErrNotExist) {
+			slog.Info("File is not present on disk", "file", modifiedFile.File.GetFileMeta().GetName())
 			modifiedFile.Action = model.Add
 			fileDiff[modifiedFile.File.GetFileMeta().GetName()] = modifiedFile
 
 			continue
 			// if file currently exists and file hash is different, file has been updated
 			// copy contents, set file action
-		} else if modifiedFile.File.GetFileMeta().GetHash() != currentFile.GetFileMeta().GetHash() {
+		} else if ok && modifiedFile.File.GetFileMeta().GetHash() != currentFile.GetFileMeta().GetHash() {
 			fileContent, readErr := os.ReadFile(fileName)
 			if readErr != nil {
 				return nil, nil, fmt.Errorf("error reading file %s, error: %w", fileName, readErr)
@@ -539,24 +541,6 @@ func (fms *FileManagerService) DetermineFileActions(
 			modifiedFile.Action = model.Update
 			fileContents[fileName] = fileContent
 			fileDiff[modifiedFile.File.GetFileMeta().GetName()] = modifiedFile
-		}
-
-		// If the file is unreferenced we check if the file has been updated since the last time
-		// Also check if the unreferenced file still exists
-		if manifestFiles[modifiedFile.File.GetFileMeta().GetName()] != nil &&
-			!manifestFiles[modifiedFile.File.GetFileMeta().GetName()].ManifestFileMeta.Referenced {
-			if fileStats, err := os.Stat(modifiedFile.File.GetFileMeta().GetName()); errors.Is(err, os.ErrNotExist) {
-				modifiedFile.Action = model.Add
-				fileDiff[modifiedFile.File.GetFileMeta().GetName()] = modifiedFile
-			} else if timestamppb.New(fileStats.ModTime()) != modifiedFile.File.GetFileMeta().GetModifiedTime() {
-				fileContent, readErr := os.ReadFile(fileName)
-				if readErr != nil {
-					return nil, nil, fmt.Errorf("error reading file %s, error: %w", fileName, readErr)
-				}
-				modifiedFile.Action = model.Update
-				fileContents[fileName] = fileContent
-				fileDiff[modifiedFile.File.GetFileMeta().GetName()] = modifiedFile
-			}
 		}
 	}
 

--- a/internal/file/file_manager_service_test.go
+++ b/internal/file/file_manager_service_test.go
@@ -490,13 +490,20 @@ func TestFileManagerService_DetermineFileActions(t *testing.T) {
 	updateErr := os.WriteFile(updateTestFile.Name(), updatedFileContent, 0o600)
 	require.NoError(t, updateErr)
 
-	addTestFileName := tempDir + "/nginx_add.conf"
+	addTestFileName := tempDir + "nginx_add.conf"
 
 	unmanagedFile := helpers.CreateFileWithErrorCheck(t, tempDir, "nginx_unmanaged.conf")
 	defer helpers.RemoveFileWithErrorCheck(t, unmanagedFile.Name())
 	unmanagedFileContent := []byte("test unmanaged file")
 	unmanagedErr := os.WriteFile(unmanagedFile.Name(), unmanagedFileContent, 0o600)
 	require.NoError(t, unmanagedErr)
+
+	addTestFile := helpers.CreateFileWithErrorCheck(t, tempDir, "nginx_add.conf")
+	defer helpers.RemoveFileWithErrorCheck(t, addTestFile.Name())
+	t.Logf("Adding file: %s", addTestFile.Name())
+	addFileContent := []byte("test add file")
+	addErr := os.WriteFile(addTestFile.Name(), addFileContent, 0o600)
+	require.NoError(t, addErr)
 
 	tests := []struct {
 		expectedError   error
@@ -572,9 +579,9 @@ func TestFileManagerService_DetermineFileActions(t *testing.T) {
 		{
 			name: "Test 2: Files same as on disk",
 			modifiedFiles: map[string]*model.FileCache{
-				addTestFileName: {
+				addTestFile.Name(): {
 					File: &mpi.File{
-						FileMeta: protos.FileMeta(addTestFileName, files.GenerateHash(fileContent)),
+						FileMeta: protos.FileMeta(addTestFile.Name(), files.GenerateHash(fileContent)),
 					},
 				},
 				updateTestFile.Name(): {
@@ -595,8 +602,8 @@ func TestFileManagerService_DetermineFileActions(t *testing.T) {
 				updateTestFile.Name(): {
 					FileMeta: protos.FileMeta(updateTestFile.Name(), files.GenerateHash(fileContent)),
 				},
-				addTestFileName: {
-					FileMeta: protos.FileMeta(addTestFileName, files.GenerateHash(fileContent)),
+				addTestFile.Name(): {
+					FileMeta: protos.FileMeta(addTestFile.Name(), files.GenerateHash(fileContent)),
 				},
 			},
 			expectedCache:   make(map[string]*model.FileCache),
@@ -612,10 +619,11 @@ func TestFileManagerService_DetermineFileActions(t *testing.T) {
 			defer manifestFile.Close()
 			manifestDirPath = tempDir
 			manifestFilePath = manifestFile.Name()
-			t.Logf("path: %s", manifestFilePath)
+
 			fakeFileServiceClient := &v1fakes.FakeFileServiceClient{}
 			fileManagerService := NewFileManagerService(fakeFileServiceClient, types.AgentConfig())
 			require.NoError(tt, err)
+
 			diff, contents, fileActionErr := fileManagerService.DetermineFileActions(test.currentFiles,
 				test.modifiedFiles)
 			require.NoError(tt, fileActionErr)

--- a/internal/watcher/watcher_plugin.go
+++ b/internal/watcher/watcher_plugin.go
@@ -198,11 +198,9 @@ func (w *Watcher) handleConfigApplySuccess(ctx context.Context, msg *bus.Message
 
 	// If the config apply had no changes to any files, it is results in a ConfigApplySuccessfulTopic with an empty
 	// configContext being sent, there is no need to reparse the config as no change has occurred.
-	if successMessage.ConfigContext.InstanceID == "" {
-		slog.DebugContext(ctx, "NginxConfigContext is empty, no need to reparse config")
-		return
+	if successMessage.ConfigContext.InstanceID != "" {
+		w.instanceWatcherService.HandleNginxConfigContextUpdate(ctx, instanceID, successMessage.ConfigContext)
 	}
-	w.instanceWatcherService.HandleNginxConfigContextUpdate(ctx, instanceID, successMessage.ConfigContext)
 
 	w.watcherMutex.Lock()
 	w.instancesWithConfigApplyInProgress = slices.DeleteFunc(
@@ -213,8 +211,8 @@ func (w *Watcher) handleConfigApplySuccess(ctx context.Context, msg *bus.Message
 	)
 
 	w.fileWatcherService.SetEnabled(true)
-	w.watcherMutex.Unlock()
 	w.instanceWatcherService.SetEnabled(true)
+	w.watcherMutex.Unlock()
 }
 
 func (w *Watcher) handleHealthRequest(ctx context.Context) {


### PR DESCRIPTION
### Proposed changes

When a referenced file was deleted on disk it wasn't always added back when another config apply pushed. 
Also fix watchers not being enabled after a config apply resulted in no changes. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
