### PR TITLE
Allow underscores in hostname

### DIFF
--- a/api/grpc/mpi/v1/command.pb.go
+++ b/api/grpc/mpi/v1/command.pb.go
@@ -2655,10 +2655,10 @@ const file_mpi_v1_command_proto_rawDesc = "" +
 	"\tinstances\x18\x02 \x03(\v2\x10.mpi.v1.InstanceR\tinstances\x12/\n" +
 	"\thost_info\x18\x03 \x01(\v2\x10.mpi.v1.HostInfoH\x00R\bhostInfo\x12>\n" +
 	"\x0econtainer_info\x18\x04 \x01(\v2\x15.mpi.v1.ContainerInfoH\x00R\rcontainerInfoB\x06\n" +
-	"\x04info\"\x8b\x01\n" +
+	"\x04info\"\x81\x01\n" +
 	"\bHostInfo\x12!\n" +
-	"\ahost_id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x06hostId\x12$\n" +
-	"\bhostname\x18\x02 \x01(\tB\b\xbaH\x05r\x03\xa8\x01\x01R\bhostname\x126\n" +
+	"\ahost_id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x06hostId\x12\x1a\n" +
+	"\bhostname\x18\x02 \x01(\tR\bhostname\x126\n" +
 	"\frelease_info\x18\x03 \x01(\v2\x13.mpi.v1.ReleaseInfoR\vreleaseInfo\"\x86\x01\n" +
 	"\vReleaseInfo\x12\x1a\n" +
 	"\bcodename\x18\x01 \x01(\tR\bcodename\x12\x0e\n" +
@@ -2666,10 +2666,10 @@ const file_mpi_v1_command_proto_rawDesc = "" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12\x1d\n" +
 	"\n" +
 	"version_id\x18\x04 \x01(\tR\tversionId\x12\x18\n" +
-	"\aversion\x18\x05 \x01(\tR\aversion\"\x9a\x01\n" +
+	"\aversion\x18\x05 \x01(\tR\aversion\"\x90\x01\n" +
 	"\rContainerInfo\x12+\n" +
-	"\fcontainer_id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\vcontainerId\x12$\n" +
-	"\bhostname\x18\x02 \x01(\tB\b\xbaH\x05r\x03\xa8\x01\x01R\bhostname\x126\n" +
+	"\fcontainer_id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\vcontainerId\x12\x1a\n" +
+	"\bhostname\x18\x02 \x01(\tR\bhostname\x126\n" +
 	"\frelease_info\x18\x03 \x01(\v2\x13.mpi.v1.ReleaseInfoR\vreleaseInfo\"\x87\x01\n" +
 	"\x18CreateConnectionResponse\x123\n" +
 	"\bresponse\x18\x01 \x01(\v2\x17.mpi.v1.CommandResponseR\bresponse\x126\n" +

--- a/api/grpc/mpi/v1/command.proto
+++ b/api/grpc/mpi/v1/command.proto
@@ -65,7 +65,7 @@ message HostInfo {
     // The host identifier
     string host_id = 1 [(buf.validate.field).string.uuid = true];
     // The name of the host
-    string hostname = 2 [(buf.validate.field).string.address = true];
+    string hostname = 2;
     // Release information of the host
     ReleaseInfo release_info = 3;
 }
@@ -89,7 +89,7 @@ message ContainerInfo {
     // The identifier of the container
     string container_id = 1 [(buf.validate.field).string.uuid = true];
     // The name of the host
-    string hostname = 2 [(buf.validate.field).string.address = true];
+    string hostname = 2;
     // Release information of the container
     ReleaseInfo release_info = 3;
 }


### PR DESCRIPTION
### Proposed changes

Remove validation that doesn't allow underscores in a hostname. 
- Docker allows you to set a hostname to have an underscore `docker run --hostname example_test.net test_image`
     
### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
