### PR TITLE
Fix remotely enabling/disabling features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,12 @@ OS                     := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 uname_m    := $(shell uname -m)
 
 ifeq ($(uname_m),aarch64)
-	OSARCH = arm64
+	OSARCH ?= arm64
 else
 	ifeq ($(uname_m),x86_64)
-		OSARCH = amd64
+		OSARCH ?= amd64
 	else
-		OSARCH = $(uname_m)
+		OSARCH ?= $(uname_m)
 	endif
 endif
 

--- a/src/core/environment.go
+++ b/src/core/environment.go
@@ -342,7 +342,6 @@ func (env *EnvironmentType) IsContainer() bool {
 	res, err, _ := singleflightGroup.Do(IsContainerKey, func() (interface{}, error) {
 		for _, filename := range []string{dockerEnv, containerEnv, k8sServiceAcct} {
 			if _, err := os.Stat(filename); err == nil {
-				log.Debugf("Is a container because (%s) exists", filename)
 				return true, nil
 			}
 		}

--- a/src/core/metrics/collectors/nginx.go
+++ b/src/core/metrics/collectors/nginx.go
@@ -29,6 +29,7 @@ type NginxCollector struct {
 }
 
 func NewNginxCollector(conf *config.Config, env core.Environment, collectorConf *metrics.NginxCollectorConfig, binary core.NginxBinary) *NginxCollector {
+	log.Debugf("Creating NGINX Collector")
 	host := env.NewHostInfo("agentVersion", &conf.Tags, conf.ConfigDirs, false)
 	dimensions := metrics.NewCommonDim(host, conf, collectorConf.NginxId)
 	dimensions.NginxConfPath = collectorConf.ConfPath
@@ -45,6 +46,7 @@ func NewNginxCollector(conf *config.Config, env core.Environment, collectorConf 
 }
 
 func buildSources(dimensions *metrics.CommonDim, binary core.NginxBinary, collectorConf *metrics.NginxCollectorConfig, conf *config.Config, env core.Environment) []metrics.NginxSource {
+	log.Debugf("Building NGINX metric sources")
 	var nginxSources []metrics.NginxSource
 	// worker metrics
 	if len(conf.Nginx.NginxCountingSocket) > 0 && conf.IsFeatureEnabled(agent_config.FeatureNginxCounting) {
@@ -68,6 +70,7 @@ func buildSources(dimensions *metrics.CommonDim, binary core.NginxBinary, collec
 			nginxSources = append(nginxSources, sources.NewNginxStatic(dimensions, sources.OSSNamespace))
 		}
 	}
+
 	return nginxSources
 }
 

--- a/src/core/metrics/sources/nginx_plus.go
+++ b/src/core/metrics/sources/nginx_plus.go
@@ -76,6 +76,7 @@ type ExtendedStats struct {
 }
 
 func NewNginxPlus(baseDimensions *metrics.CommonDim, nginxNamespace, plusNamespace, plusAPI string, clientVersion int) *NginxPlus {
+	log.Debug("Creating NGINX Plus metrics source")
 	return &NginxPlus{baseDimensions: baseDimensions, nginxNamespace: nginxNamespace, plusNamespace: plusNamespace, plusAPI: plusAPI, clientVersion: clientVersion, logger: NewMetricSourceLogger()}
 }
 

--- a/src/core/pipe.go
+++ b/src/core/pipe.go
@@ -71,7 +71,7 @@ func (p *MessagePipe) Register(size int, plugins []Plugin, extensionPlugins []Ex
 	pluginsRegistered := []string{}
 	extensionPluginsRegistered := []string{}
 
-	for _, plugin := range p.plugins {
+	for _, plugin := range plugins {
 		for _, subscription := range plugin.Subscriptions() {
 			p.regMu.Lock()
 			err := p.bus.Subscribe(subscription, plugin.Process)
@@ -83,7 +83,7 @@ func (p *MessagePipe) Register(size int, plugins []Plugin, extensionPlugins []Ex
 		pluginsRegistered = append(pluginsRegistered, *plugin.Info().name)
 	}
 
-	for _, plugin := range p.extensionPlugins {
+	for _, plugin := range extensionPlugins {
 		for _, subscription := range plugin.Subscriptions() {
 			p.regMu.Lock()
 			err := p.bus.Subscribe(subscription, plugin.Process)
@@ -94,6 +94,7 @@ func (p *MessagePipe) Register(size int, plugins []Plugin, extensionPlugins []Ex
 		}
 		extensionPluginsRegistered = append(extensionPluginsRegistered, *plugin.Info().name)
 	}
+
 	log.Infof("The following core plugins have been registered: %q", pluginsRegistered)
 	log.Infof("The following extension plugins have been registered: %q", extensionPluginsRegistered)
 
@@ -127,6 +128,8 @@ func (p *MessagePipe) DeRegister(pluginNames []string) error {
 					return err
 				}
 			}
+
+			plugin = nil
 		}
 	}
 

--- a/src/core/pipe.go
+++ b/src/core/pipe.go
@@ -128,8 +128,6 @@ func (p *MessagePipe) DeRegister(pluginNames []string) error {
 					return err
 				}
 			}
-
-			plugin = nil
 		}
 	}
 

--- a/src/plugins/agent_api.go
+++ b/src/plugins/agent_api.go
@@ -191,6 +191,7 @@ func (a *AgentAPI) Close() {
 	if err := a.server.Shutdown(context.Background()); err != nil {
 		log.Errorf("Agent API HTTP Server Shutdown Error: %v", err)
 	}
+	log.Info("Agent API is closed")
 }
 
 func (a *AgentAPI) Process(message *core.Message) {

--- a/src/plugins/commander.go
+++ b/src/plugins/commander.go
@@ -45,7 +45,6 @@ func (c *Commander) Init(pipeline core.MessagePipeInterface) {
 }
 
 func (c *Commander) Close() {
-	log.Info("Commander is wrapping up")
 	log.Info("Commander is closed")
 }
 

--- a/src/plugins/commander.go
+++ b/src/plugins/commander.go
@@ -38,14 +38,15 @@ func NewCommander(cmdr client.Commander, config *config.Config) *Commander {
 }
 
 func (c *Commander) Init(pipeline core.MessagePipeInterface) {
+	log.Info("Commander initializing")
 	c.pipeline = pipeline
 	c.ctx = pipeline.Context()
-	log.Info("Commander initializing")
 	go c.dispatchLoop()
 }
 
 func (c *Commander) Close() {
 	log.Info("Commander is wrapping up")
+	log.Info("Commander is closed")
 }
 
 func (c *Commander) Info() *core.Info {
@@ -158,7 +159,6 @@ func (c *Commander) dispatchLoop() {
 		case *proto.Command_AgentConnectRequest, *proto.Command_AgentConnectResponse:
 			topic = core.AgentConnected
 		case *proto.Command_AgentConfigRequest, *proto.Command_AgentConfig:
-			log.Debugf("agent config %T command data type received and ignored", cmd.GetData())
 			topic = core.AgentConfig
 		case *proto.Command_CmdStatus:
 			data := cmd.GetData().(*proto.Command_CmdStatus)

--- a/src/plugins/common.go
+++ b/src/plugins/common.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nginx/agent/v2/src/core/config"
 	"github.com/nginx/agent/v2/src/extensions"
 	log "github.com/sirupsen/logrus"
+	"go.uber.org/atomic"
 
 	agent_config "github.com/nginx/agent/sdk/v2/agent/config"
 	"github.com/nginx/agent/sdk/v2/agent/events"
@@ -36,7 +37,7 @@ func LoadPlugins(commander client.Commander, binary core.NginxBinary, env core.E
 
 	if (loadedConfig.IsFeatureEnabled(agent_config.FeatureMetrics) || loadedConfig.IsFeatureEnabled(agent_config.FeatureMetricsSender)) && reporter != nil {
 		corePlugins = append(corePlugins,
-			NewMetricsSender(reporter),
+			NewMetricsSender(reporter, atomic.NewBool(false)),
 		)
 	}
 
@@ -44,7 +45,7 @@ func LoadPlugins(commander client.Commander, binary core.NginxBinary, env core.E
 		NewConfigReader(loadedConfig),
 		NewNginx(commander, binary, env, loadedConfig, processes),
 		NewExtensions(loadedConfig, env),
-		NewFeatures(commander, loadedConfig, env, binary, loadedConfig.Version, processes, agentEventsMeta),
+		NewFeatures(commander, reporter, loadedConfig, env, binary, loadedConfig.Version, processes, agentEventsMeta),
 	)
 
 	if loadedConfig.IsFeatureEnabled(agent_config.FeatureRegistration) {

--- a/src/plugins/config_reader.go
+++ b/src/plugins/config_reader.go
@@ -37,6 +37,7 @@ func NewConfigReader(config *config.Config) *ConfigReader {
 }
 
 func (r *ConfigReader) Init(pipeline core.MessagePipeInterface) {
+	log.Info("ConfigReader initializing")
 	r.messagePipeline = pipeline
 }
 
@@ -46,6 +47,7 @@ func (r *ConfigReader) Info() *core.Info {
 
 func (r *ConfigReader) Close() {
 	log.Info("ConfigReader is wrapping up")
+	log.Info("ConfigReader is closed")
 }
 
 func (r *ConfigReader) Process(msg *core.Message) {
@@ -73,8 +75,10 @@ func (r *ConfigReader) Process(msg *core.Message) {
 			// Update the agent config on disk
 			switch commandData := cmd.Data.(type) {
 			case *proto.Command_AgentConfig:
+				log.Debugf("Config reader: AgentConfig message recevied: %v, topic: %v", commandData, msg.Topic())
 				r.updateAgentConfig(commandData.AgentConfig)
 			case *proto.Command_AgentConnectResponse:
+				log.Debugf("Config reader: AgentConnectResponse message recevied: %v, topic: %v", commandData, msg.Topic())
 				r.updateAgentConfig(commandData.AgentConnectResponse.AgentConfig)
 			}
 		}
@@ -152,7 +156,7 @@ func (r *ConfigReader) updateAgentConfig(payloadAgentConfig *proto.AgentConfig) 
 		}
 
 		if synchronizeFeatures {
-			log.Debugf("Agent config features changed, synchronizing features")
+			log.Info("Agent config features changed, synchronizing features")
 			r.synchronizeFeatures(payloadAgentConfig)
 			r.config.Features = payloadAgentConfig.Details.Features
 		}

--- a/src/plugins/config_reader.go
+++ b/src/plugins/config_reader.go
@@ -46,7 +46,6 @@ func (r *ConfigReader) Info() *core.Info {
 }
 
 func (r *ConfigReader) Close() {
-	log.Info("ConfigReader is wrapping up")
 	log.Info("ConfigReader is closed")
 }
 
@@ -186,17 +185,17 @@ func (r *ConfigReader) deRegisterPlugin(data string) {
 	if data == agent_config.FeatureFileWatcher {
 		err := r.messagePipeline.DeRegister([]string{agent_config.FeatureFileWatcher, agent_config.FeatureFileWatcherThrottle})
 		if err != nil {
-			log.Warnf("Error De-registering %v Plugin: %v", data, err)
+			log.Warnf("Error deregistering %v plugin: %v", data, err)
 		}
 	} else if data == agent_config.FeatureMetrics {
 		err := r.messagePipeline.DeRegister([]string{agent_config.FeatureMetrics, agent_config.FeatureMetricsThrottle, agent_config.FeatureMetricsSender})
 		if err != nil {
-			log.Warnf("Error De-registering %v Plugin: %v", data, err)
+			log.Warnf("Error deregistering %v plugin: %v", data, err)
 		}
 	} else {
 		err := r.messagePipeline.DeRegister([]string{data})
 		if err != nil {
-			log.Warnf("Error De-registering %v Plugin: %v", data, err)
+			log.Warnf("Error deregistering %v plugin: %v", data, err)
 		}
 	}
 }

--- a/src/plugins/dataplane_status.go
+++ b/src/plugins/dataplane_status.go
@@ -90,6 +90,7 @@ func (dps *DataPlaneStatus) Close() {
 	dps.softwareDetailsMutex.Unlock()
 	dps.healthTicker.Stop()
 	dps.sendStatus <- true
+	log.Info("DataPlaneStatus is closed")
 }
 
 func (dps *DataPlaneStatus) Info() *core.Info {

--- a/src/plugins/events.go
+++ b/src/plugins/events.go
@@ -63,7 +63,6 @@ func (a *Events) Init(pipeline core.MessagePipeInterface) {
 }
 
 func (a *Events) Close() {
-	log.Info("Events is wrapping up")
 	log.Info("Events is closed")
 }
 

--- a/src/plugins/events.go
+++ b/src/plugins/events.go
@@ -64,6 +64,7 @@ func (a *Events) Init(pipeline core.MessagePipeInterface) {
 
 func (a *Events) Close() {
 	log.Info("Events is wrapping up")
+	log.Info("Events is closed")
 }
 
 func (a *Events) Process(msg *core.Message) {

--- a/src/plugins/extensions.go
+++ b/src/plugins/extensions.go
@@ -36,7 +36,6 @@ func (e *Extensions) Init(pipeline core.MessagePipeInterface) {
 }
 
 func (e *Extensions) Close() {
-	log.Info("Extensions is wrapping up")
 	log.Info("Extensions is closed")
 }
 

--- a/src/plugins/extensions.go
+++ b/src/plugins/extensions.go
@@ -37,6 +37,7 @@ func (e *Extensions) Init(pipeline core.MessagePipeInterface) {
 
 func (e *Extensions) Close() {
 	log.Info("Extensions is wrapping up")
+	log.Info("Extensions is closed")
 }
 
 func (e *Extensions) Process(msg *core.Message) {

--- a/src/plugins/features.go
+++ b/src/plugins/features.go
@@ -97,7 +97,6 @@ func (f *Features) Init(pipeline core.MessagePipeInterface) {
 }
 
 func (f *Features) Close() {
-	log.Info("Features is wrapping up")
 	log.Info("Features is closed")
 }
 

--- a/src/plugins/features.go
+++ b/src/plugins/features.go
@@ -135,7 +135,7 @@ func (f *Features) Process(msg *core.Message) {
 
 func (f *Features) enableMetricsFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureMetrics) {
-
+		log.Debugf("Enabling metrics feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -154,7 +154,7 @@ func (f *Features) enableMetricsFeature(_ string) []core.Plugin {
 func (f *Features) enableMetricsCollectionFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureMetrics) &&
 		!f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureMetricsCollection) {
-
+		log.Debugf("Enabling metrics-collection feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -171,7 +171,7 @@ func (f *Features) enableMetricsCollectionFeature(_ string) []core.Plugin {
 func (f *Features) enableMetricsThrottleFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureMetrics) &&
 		!f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureMetricsThrottle) {
-
+		log.Debugf("Enabling metrics-throttle feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -188,7 +188,7 @@ func (f *Features) enableMetricsThrottleFeature(_ string) []core.Plugin {
 func (f *Features) enableMetricsSenderFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureMetrics) &&
 		!f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureMetricsSender) {
-
+		log.Debugf("Enabling metrics-sender feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -205,6 +205,7 @@ func (f *Features) enableMetricsSenderFeature(_ string) []core.Plugin {
 func (f *Features) enableAgentAPIFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureAgentAPI) {
 		conf, err := config.GetConfig(f.conf.ClientID)
+		log.Debugf("Enabling agent-api feature")
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
 		}
@@ -219,6 +220,7 @@ func (f *Features) enableAgentAPIFeature(_ string) []core.Plugin {
 
 func (f *Features) enableRegistrationFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureRegistration) {
+		log.Debugf("Enabling registration feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -234,6 +236,7 @@ func (f *Features) enableRegistrationFeature(_ string) []core.Plugin {
 
 func (f *Features) enableDataPlaneStatusFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureDataPlaneStatus) {
+		log.Debugf("Enabling dataplane-status feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -249,6 +252,7 @@ func (f *Features) enableDataPlaneStatusFeature(_ string) []core.Plugin {
 
 func (f *Features) enableProcessWatcherFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureProcessWatcher) {
+		log.Debugf("Enabling process-watcher feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -264,6 +268,7 @@ func (f *Features) enableProcessWatcherFeature(_ string) []core.Plugin {
 
 func (f *Features) enableActivityEventsFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureActivityEvents) {
+		log.Debugf("Enabling activity-events feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -279,6 +284,7 @@ func (f *Features) enableActivityEventsFeature(_ string) []core.Plugin {
 
 func (f *Features) enableFileWatcherFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureFileWatcher) {
+		log.Debugf("Enabling file-watcher feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -297,6 +303,7 @@ func (f *Features) enableNginxCountingFeature(_ string) []core.Plugin {
 	countingPlugins := []core.Plugin{}
 	if len(f.conf.Nginx.NginxCountingSocket) > 0 {
 		if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureNginxCounting) {
+			log.Debugf("Enabling nginx-counting feature")
 			conf, err := config.GetConfig(f.conf.ClientID)
 			if err != nil {
 				log.Warnf("Unable to get agent config, %v", err)

--- a/src/plugins/features_test.go
+++ b/src/plugins/features_test.go
@@ -93,10 +93,11 @@ func TestFeatures_Process(t *testing.T) {
 	binary.On("UpdateNginxDetailsFromProcesses", mock.Anything).Return()
 
 	cmdr := tutils.NewMockCommandClient()
+	reporter := tutils.NewMockMetricsReportClient()
 
 	configuration, _ := config.GetConfig("1234")
 
-	pluginUnderTest := NewFeatures(cmdr, configuration, env, binary, "agentVersion", processes, events.NewAgentEventMeta(
+	pluginUnderTest := NewFeatures(cmdr, reporter, configuration, env, binary, "agentVersion", processes, events.NewAgentEventMeta(
 		config.MODULE,
 		"v0.0.1",
 		"75231",

--- a/src/plugins/file_watcher.go
+++ b/src/plugins/file_watcher.go
@@ -104,6 +104,7 @@ func (fw *FileWatcher) Close() {
 	fw.enabled = false
 	fw.cancelFunction()
 	fw.watcher.Close()
+	log.Info("File Watcher is closed")
 }
 
 func (fw *FileWatcher) Process(message *core.Message) {

--- a/src/plugins/file_watcher_throttling.go
+++ b/src/plugins/file_watcher_throttling.go
@@ -59,12 +59,13 @@ func (fwt *FileWatchThrottle) SetStarted(newValue bool) {
 }
 
 func (fwt *FileWatchThrottle) Init(pipeline core.MessagePipeInterface) {
-	fwt.messagePipeline = pipeline
 	log.Info("FileWatchThrottle initializing")
+	fwt.messagePipeline = pipeline
 }
 
 func (fwt *FileWatchThrottle) Close() {
 	log.Info("FileWatchThrottle is wrapping up")
+	log.Info("FileWatchThrottle is closed")
 }
 
 func (fwt *FileWatchThrottle) Info() *core.Info {

--- a/src/plugins/file_watcher_throttling.go
+++ b/src/plugins/file_watcher_throttling.go
@@ -64,7 +64,6 @@ func (fwt *FileWatchThrottle) Init(pipeline core.MessagePipeInterface) {
 }
 
 func (fwt *FileWatchThrottle) Close() {
-	log.Info("FileWatchThrottle is wrapping up")
 	log.Info("FileWatchThrottle is closed")
 }
 

--- a/src/plugins/metrics.go
+++ b/src/plugins/metrics.go
@@ -72,11 +72,14 @@ func (m *Metrics) Init(pipeline core.MessagePipeInterface) {
 }
 
 func (m *Metrics) Close() {
+	log.Info("Metrics is wrapping up")
 	m.collectorsMutex.Lock()
-	m.cancel()
+	if m.cancel != nil {
+		m.cancel()
+	}
 	m.collectors = nil
 	m.collectorsMutex.Unlock()
-	log.Info("Metrics is wrapping up")
+	log.Info("Metrics is closed")
 }
 
 func (m *Metrics) Process(msg *core.Message) {

--- a/src/plugins/metrics.go
+++ b/src/plugins/metrics.go
@@ -73,12 +73,24 @@ func (m *Metrics) Init(pipeline core.MessagePipeInterface) {
 
 func (m *Metrics) Close() {
 	log.Info("Metrics is wrapping up")
+
 	m.collectorsMutex.Lock()
+
 	if m.cancel != nil {
 		m.cancel()
 	}
+
+	for _, collector := range m.collectors {
+		if nginxCollector, ok := collector.(*collectors.NginxCollector); ok {
+			nginxCollector.Stop()
+			log.Debugf("Removing nginx collector for nginx id: %s", nginxCollector.GetNginxId())
+		}
+	}
+
 	m.collectors = nil
+
 	m.collectorsMutex.Unlock()
+
 	log.Info("Metrics is closed")
 }
 

--- a/src/plugins/nginx.go
+++ b/src/plugins/nginx.go
@@ -719,7 +719,6 @@ func (n *Nginx) Info() *core.Info {
 
 // Close cleans up anything outstanding once the plugin ends
 func (n *Nginx) Close() {
-	log.Info("NginxBinary is wrapping up")
 	log.Info("NginxBinary is closed")
 }
 

--- a/src/plugins/nginx.go
+++ b/src/plugins/nginx.go
@@ -720,6 +720,7 @@ func (n *Nginx) Info() *core.Info {
 // Close cleans up anything outstanding once the plugin ends
 func (n *Nginx) Close() {
 	log.Info("NginxBinary is wrapping up")
+	log.Info("NginxBinary is closed")
 }
 
 func (n *Nginx) syncAgentConfigChange() {

--- a/src/plugins/nginx_counter.go
+++ b/src/plugins/nginx_counter.go
@@ -107,11 +107,11 @@ func (nc *NginxCounter) recieveSocketMessage(socketListener net.Listener) {
 }
 
 func (nc *NginxCounter) Close() {
+	log.Info("NGINX Counter is wrapping up")
 	if nc.socketListener != nil {
 		nc.socketListener.Close()
 	}
 
-	log.Info("NGINX Counter is wrapping up")
 	if err := os.RemoveAll(nc.serverAddress[1]); err != nil {
 		log.Warn("Error removing socket")
 	}
@@ -119,6 +119,7 @@ func (nc *NginxCounter) Close() {
 	nc.processMutex.RLock()
 	nc.nginxes = nil
 	nc.processMutex.RUnlock()
+	log.Info("NGINX Counter is closed")
 }
 
 func (nc *NginxCounter) Info() *core.Info {
@@ -128,7 +129,7 @@ func (nc *NginxCounter) Info() *core.Info {
 func (nc *NginxCounter) Process(msg *core.Message) {
 	switch {
 	case msg.Exact(core.AgentConnected):
-		nc.connected.Toggle()
+		nc.connected.Store(true)
 	case msg.Exact(core.NginxDetailProcUpdate):
 		// get the processes from this payload
 		nc.processMutex.Lock()

--- a/src/plugins/process_watcher.go
+++ b/src/plugins/process_watcher.go
@@ -72,12 +72,14 @@ func (pw *ProcessWatcher) Info() *core.Info {
 }
 
 func (pw *ProcessWatcher) Close() {
+	log.Info("ProcessWatcher is wrapping up")
+
 	pw.ticker.Stop()
 	pw.seenMasterProcs = nil
 	pw.seenWorkerProcs = nil
 	pw.nginxDetails = nil
 
-	log.Info("ProcessWatcher is wrapping up")
+	log.Info("ProcessWatcher is closed")
 }
 
 func (pw *ProcessWatcher) Process(message *core.Message) {}

--- a/src/plugins/registration.go
+++ b/src/plugins/registration.go
@@ -78,6 +78,7 @@ func (r *OneTimeRegistration) Init(pipeline core.MessagePipeInterface) {
 
 func (r *OneTimeRegistration) Close() {
 	log.Info("OneTimeRegistration is wrapping up")
+	log.Info("OneTimeRegistration is closed")
 }
 
 func (r *OneTimeRegistration) Info() *core.Info {

--- a/src/plugins/registration.go
+++ b/src/plugins/registration.go
@@ -77,7 +77,6 @@ func (r *OneTimeRegistration) Init(pipeline core.MessagePipeInterface) {
 }
 
 func (r *OneTimeRegistration) Close() {
-	log.Info("OneTimeRegistration is wrapping up")
 	log.Info("OneTimeRegistration is closed")
 }
 

--- a/test/component/nginx-app-protect/monitoring/monitoring_test.go
+++ b/test/component/nginx-app-protect/monitoring/monitoring_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/atomic"
+
 	proto "github.com/golang/protobuf/jsonpb"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
@@ -130,7 +132,7 @@ func TestNAPMonitoring(t *testing.T) {
 		return
 	}
 
-	metricsSender := plugins.NewMetricsSender(reporter)
+	metricsSender := plugins.NewMetricsSender(reporter, atomic.NewBool(false))
 
 	env := tutils.NewMockEnvironment()
 	env.On("NewHostInfo", testifyMock.Anything, testifyMock.Anything, testifyMock.Anything).Return(&sdkPb.HostInfo{

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/environment.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/environment.go
@@ -342,7 +342,6 @@ func (env *EnvironmentType) IsContainer() bool {
 	res, err, _ := singleflightGroup.Do(IsContainerKey, func() (interface{}, error) {
 		for _, filename := range []string{dockerEnv, containerEnv, k8sServiceAcct} {
 			if _, err := os.Stat(filename); err == nil {
-				log.Debugf("Is a container because (%s) exists", filename)
 				return true, nil
 			}
 		}

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/pipe.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/pipe.go
@@ -71,7 +71,7 @@ func (p *MessagePipe) Register(size int, plugins []Plugin, extensionPlugins []Ex
 	pluginsRegistered := []string{}
 	extensionPluginsRegistered := []string{}
 
-	for _, plugin := range p.plugins {
+	for _, plugin := range plugins {
 		for _, subscription := range plugin.Subscriptions() {
 			p.regMu.Lock()
 			err := p.bus.Subscribe(subscription, plugin.Process)
@@ -83,7 +83,7 @@ func (p *MessagePipe) Register(size int, plugins []Plugin, extensionPlugins []Ex
 		pluginsRegistered = append(pluginsRegistered, *plugin.Info().name)
 	}
 
-	for _, plugin := range p.extensionPlugins {
+	for _, plugin := range extensionPlugins {
 		for _, subscription := range plugin.Subscriptions() {
 			p.regMu.Lock()
 			err := p.bus.Subscribe(subscription, plugin.Process)
@@ -94,6 +94,7 @@ func (p *MessagePipe) Register(size int, plugins []Plugin, extensionPlugins []Ex
 		}
 		extensionPluginsRegistered = append(extensionPluginsRegistered, *plugin.Info().name)
 	}
+
 	log.Infof("The following core plugins have been registered: %q", pluginsRegistered)
 	log.Infof("The following extension plugins have been registered: %q", extensionPluginsRegistered)
 
@@ -127,6 +128,8 @@ func (p *MessagePipe) DeRegister(pluginNames []string) error {
 					return err
 				}
 			}
+
+			plugin = nil
 		}
 	}
 

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/pipe.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/pipe.go
@@ -128,8 +128,6 @@ func (p *MessagePipe) DeRegister(pluginNames []string) error {
 					return err
 				}
 			}
-
-			plugin = nil
 		}
 	}
 

--- a/test/performance/metrics_test.go
+++ b/test/performance/metrics_test.go
@@ -346,7 +346,7 @@ func startNginxAgent(b *testing.B) {
 		plugins.NewConfigReader(loadedConfig),
 		plugins.NewNginx(commander, binary, env, &config.Config{}, processes),
 		plugins.NewCommander(commander, loadedConfig),
-		plugins.NewMetricsSender(reporter),
+		plugins.NewMetricsSender(reporter, atomic.NewBool(false)),
 		plugins.NewOneTimeRegistration(loadedConfig, binary, env, sdkGRPC.NewMessageMeta(uuid.New().String()), processes),
 		plugins.NewMetrics(loadedConfig, env, binary, processes),
 		plugins.NewMetricsThrottle(loadedConfig, env),

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/environment.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/environment.go
@@ -342,7 +342,6 @@ func (env *EnvironmentType) IsContainer() bool {
 	res, err, _ := singleflightGroup.Do(IsContainerKey, func() (interface{}, error) {
 		for _, filename := range []string{dockerEnv, containerEnv, k8sServiceAcct} {
 			if _, err := os.Stat(filename); err == nil {
-				log.Debugf("Is a container because (%s) exists", filename)
 				return true, nil
 			}
 		}

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/collectors/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/collectors/nginx.go
@@ -29,6 +29,7 @@ type NginxCollector struct {
 }
 
 func NewNginxCollector(conf *config.Config, env core.Environment, collectorConf *metrics.NginxCollectorConfig, binary core.NginxBinary) *NginxCollector {
+	log.Debugf("Creating NGINX Collector")
 	host := env.NewHostInfo("agentVersion", &conf.Tags, conf.ConfigDirs, false)
 	dimensions := metrics.NewCommonDim(host, conf, collectorConf.NginxId)
 	dimensions.NginxConfPath = collectorConf.ConfPath
@@ -45,6 +46,7 @@ func NewNginxCollector(conf *config.Config, env core.Environment, collectorConf 
 }
 
 func buildSources(dimensions *metrics.CommonDim, binary core.NginxBinary, collectorConf *metrics.NginxCollectorConfig, conf *config.Config, env core.Environment) []metrics.NginxSource {
+	log.Debugf("Building NGINX metric sources")
 	var nginxSources []metrics.NginxSource
 	// worker metrics
 	if len(conf.Nginx.NginxCountingSocket) > 0 && conf.IsFeatureEnabled(agent_config.FeatureNginxCounting) {
@@ -68,6 +70,7 @@ func buildSources(dimensions *metrics.CommonDim, binary core.NginxBinary, collec
 			nginxSources = append(nginxSources, sources.NewNginxStatic(dimensions, sources.OSSNamespace))
 		}
 	}
+
 	return nginxSources
 }
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/nginx_plus.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/metrics/sources/nginx_plus.go
@@ -76,6 +76,7 @@ type ExtendedStats struct {
 }
 
 func NewNginxPlus(baseDimensions *metrics.CommonDim, nginxNamespace, plusNamespace, plusAPI string, clientVersion int) *NginxPlus {
+	log.Debug("Creating NGINX Plus metrics source")
 	return &NginxPlus{baseDimensions: baseDimensions, nginxNamespace: nginxNamespace, plusNamespace: plusNamespace, plusAPI: plusAPI, clientVersion: clientVersion, logger: NewMetricSourceLogger()}
 }
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/pipe.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/pipe.go
@@ -71,7 +71,7 @@ func (p *MessagePipe) Register(size int, plugins []Plugin, extensionPlugins []Ex
 	pluginsRegistered := []string{}
 	extensionPluginsRegistered := []string{}
 
-	for _, plugin := range p.plugins {
+	for _, plugin := range plugins {
 		for _, subscription := range plugin.Subscriptions() {
 			p.regMu.Lock()
 			err := p.bus.Subscribe(subscription, plugin.Process)
@@ -83,7 +83,7 @@ func (p *MessagePipe) Register(size int, plugins []Plugin, extensionPlugins []Ex
 		pluginsRegistered = append(pluginsRegistered, *plugin.Info().name)
 	}
 
-	for _, plugin := range p.extensionPlugins {
+	for _, plugin := range extensionPlugins {
 		for _, subscription := range plugin.Subscriptions() {
 			p.regMu.Lock()
 			err := p.bus.Subscribe(subscription, plugin.Process)
@@ -94,6 +94,7 @@ func (p *MessagePipe) Register(size int, plugins []Plugin, extensionPlugins []Ex
 		}
 		extensionPluginsRegistered = append(extensionPluginsRegistered, *plugin.Info().name)
 	}
+
 	log.Infof("The following core plugins have been registered: %q", pluginsRegistered)
 	log.Infof("The following extension plugins have been registered: %q", extensionPluginsRegistered)
 
@@ -127,6 +128,8 @@ func (p *MessagePipe) DeRegister(pluginNames []string) error {
 					return err
 				}
 			}
+
+			plugin = nil
 		}
 	}
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/pipe.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/pipe.go
@@ -128,8 +128,6 @@ func (p *MessagePipe) DeRegister(pluginNames []string) error {
 					return err
 				}
 			}
-
-			plugin = nil
 		}
 	}
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/agent_api.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/agent_api.go
@@ -191,6 +191,7 @@ func (a *AgentAPI) Close() {
 	if err := a.server.Shutdown(context.Background()); err != nil {
 		log.Errorf("Agent API HTTP Server Shutdown Error: %v", err)
 	}
+	log.Info("Agent API is closed")
 }
 
 func (a *AgentAPI) Process(message *core.Message) {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/commander.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/commander.go
@@ -45,7 +45,6 @@ func (c *Commander) Init(pipeline core.MessagePipeInterface) {
 }
 
 func (c *Commander) Close() {
-	log.Info("Commander is wrapping up")
 	log.Info("Commander is closed")
 }
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/commander.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/commander.go
@@ -38,14 +38,15 @@ func NewCommander(cmdr client.Commander, config *config.Config) *Commander {
 }
 
 func (c *Commander) Init(pipeline core.MessagePipeInterface) {
+	log.Info("Commander initializing")
 	c.pipeline = pipeline
 	c.ctx = pipeline.Context()
-	log.Info("Commander initializing")
 	go c.dispatchLoop()
 }
 
 func (c *Commander) Close() {
 	log.Info("Commander is wrapping up")
+	log.Info("Commander is closed")
 }
 
 func (c *Commander) Info() *core.Info {
@@ -158,7 +159,6 @@ func (c *Commander) dispatchLoop() {
 		case *proto.Command_AgentConnectRequest, *proto.Command_AgentConnectResponse:
 			topic = core.AgentConnected
 		case *proto.Command_AgentConfigRequest, *proto.Command_AgentConfig:
-			log.Debugf("agent config %T command data type received and ignored", cmd.GetData())
 			topic = core.AgentConfig
 		case *proto.Command_CmdStatus:
 			data := cmd.GetData().(*proto.Command_CmdStatus)

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/common.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/common.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nginx/agent/v2/src/core/config"
 	"github.com/nginx/agent/v2/src/extensions"
 	log "github.com/sirupsen/logrus"
+	"go.uber.org/atomic"
 
 	agent_config "github.com/nginx/agent/sdk/v2/agent/config"
 	"github.com/nginx/agent/sdk/v2/agent/events"
@@ -36,7 +37,7 @@ func LoadPlugins(commander client.Commander, binary core.NginxBinary, env core.E
 
 	if (loadedConfig.IsFeatureEnabled(agent_config.FeatureMetrics) || loadedConfig.IsFeatureEnabled(agent_config.FeatureMetricsSender)) && reporter != nil {
 		corePlugins = append(corePlugins,
-			NewMetricsSender(reporter),
+			NewMetricsSender(reporter, atomic.NewBool(false)),
 		)
 	}
 
@@ -44,7 +45,7 @@ func LoadPlugins(commander client.Commander, binary core.NginxBinary, env core.E
 		NewConfigReader(loadedConfig),
 		NewNginx(commander, binary, env, loadedConfig, processes),
 		NewExtensions(loadedConfig, env),
-		NewFeatures(commander, loadedConfig, env, binary, loadedConfig.Version, processes, agentEventsMeta),
+		NewFeatures(commander, reporter, loadedConfig, env, binary, loadedConfig.Version, processes, agentEventsMeta),
 	)
 
 	if loadedConfig.IsFeatureEnabled(agent_config.FeatureRegistration) {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/config_reader.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/config_reader.go
@@ -37,6 +37,7 @@ func NewConfigReader(config *config.Config) *ConfigReader {
 }
 
 func (r *ConfigReader) Init(pipeline core.MessagePipeInterface) {
+	log.Info("ConfigReader initializing")
 	r.messagePipeline = pipeline
 }
 
@@ -46,6 +47,7 @@ func (r *ConfigReader) Info() *core.Info {
 
 func (r *ConfigReader) Close() {
 	log.Info("ConfigReader is wrapping up")
+	log.Info("ConfigReader is closed")
 }
 
 func (r *ConfigReader) Process(msg *core.Message) {
@@ -73,8 +75,10 @@ func (r *ConfigReader) Process(msg *core.Message) {
 			// Update the agent config on disk
 			switch commandData := cmd.Data.(type) {
 			case *proto.Command_AgentConfig:
+				log.Debugf("Config reader: AgentConfig message recevied: %v, topic: %v", commandData, msg.Topic())
 				r.updateAgentConfig(commandData.AgentConfig)
 			case *proto.Command_AgentConnectResponse:
+				log.Debugf("Config reader: AgentConnectResponse message recevied: %v, topic: %v", commandData, msg.Topic())
 				r.updateAgentConfig(commandData.AgentConnectResponse.AgentConfig)
 			}
 		}
@@ -152,7 +156,7 @@ func (r *ConfigReader) updateAgentConfig(payloadAgentConfig *proto.AgentConfig) 
 		}
 
 		if synchronizeFeatures {
-			log.Debugf("Agent config features changed, synchronizing features")
+			log.Info("Agent config features changed, synchronizing features")
 			r.synchronizeFeatures(payloadAgentConfig)
 			r.config.Features = payloadAgentConfig.Details.Features
 		}

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/config_reader.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/config_reader.go
@@ -46,7 +46,6 @@ func (r *ConfigReader) Info() *core.Info {
 }
 
 func (r *ConfigReader) Close() {
-	log.Info("ConfigReader is wrapping up")
 	log.Info("ConfigReader is closed")
 }
 
@@ -186,17 +185,17 @@ func (r *ConfigReader) deRegisterPlugin(data string) {
 	if data == agent_config.FeatureFileWatcher {
 		err := r.messagePipeline.DeRegister([]string{agent_config.FeatureFileWatcher, agent_config.FeatureFileWatcherThrottle})
 		if err != nil {
-			log.Warnf("Error De-registering %v Plugin: %v", data, err)
+			log.Warnf("Error deregistering %v plugin: %v", data, err)
 		}
 	} else if data == agent_config.FeatureMetrics {
 		err := r.messagePipeline.DeRegister([]string{agent_config.FeatureMetrics, agent_config.FeatureMetricsThrottle, agent_config.FeatureMetricsSender})
 		if err != nil {
-			log.Warnf("Error De-registering %v Plugin: %v", data, err)
+			log.Warnf("Error deregistering %v plugin: %v", data, err)
 		}
 	} else {
 		err := r.messagePipeline.DeRegister([]string{data})
 		if err != nil {
-			log.Warnf("Error De-registering %v Plugin: %v", data, err)
+			log.Warnf("Error deregistering %v plugin: %v", data, err)
 		}
 	}
 }

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/dataplane_status.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/dataplane_status.go
@@ -90,6 +90,7 @@ func (dps *DataPlaneStatus) Close() {
 	dps.softwareDetailsMutex.Unlock()
 	dps.healthTicker.Stop()
 	dps.sendStatus <- true
+	log.Info("DataPlaneStatus is closed")
 }
 
 func (dps *DataPlaneStatus) Info() *core.Info {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/events.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/events.go
@@ -63,7 +63,6 @@ func (a *Events) Init(pipeline core.MessagePipeInterface) {
 }
 
 func (a *Events) Close() {
-	log.Info("Events is wrapping up")
 	log.Info("Events is closed")
 }
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/events.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/events.go
@@ -64,6 +64,7 @@ func (a *Events) Init(pipeline core.MessagePipeInterface) {
 
 func (a *Events) Close() {
 	log.Info("Events is wrapping up")
+	log.Info("Events is closed")
 }
 
 func (a *Events) Process(msg *core.Message) {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/extensions.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/extensions.go
@@ -36,7 +36,6 @@ func (e *Extensions) Init(pipeline core.MessagePipeInterface) {
 }
 
 func (e *Extensions) Close() {
-	log.Info("Extensions is wrapping up")
 	log.Info("Extensions is closed")
 }
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/extensions.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/extensions.go
@@ -37,6 +37,7 @@ func (e *Extensions) Init(pipeline core.MessagePipeInterface) {
 
 func (e *Extensions) Close() {
 	log.Info("Extensions is wrapping up")
+	log.Info("Extensions is closed")
 }
 
 func (e *Extensions) Process(msg *core.Message) {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/features.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/features.go
@@ -97,7 +97,6 @@ func (f *Features) Init(pipeline core.MessagePipeInterface) {
 }
 
 func (f *Features) Close() {
-	log.Info("Features is wrapping up")
 	log.Info("Features is closed")
 }
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/features.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/features.go
@@ -135,7 +135,7 @@ func (f *Features) Process(msg *core.Message) {
 
 func (f *Features) enableMetricsFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureMetrics) {
-
+		log.Debugf("Enabling metrics feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -154,7 +154,7 @@ func (f *Features) enableMetricsFeature(_ string) []core.Plugin {
 func (f *Features) enableMetricsCollectionFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureMetrics) &&
 		!f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureMetricsCollection) {
-
+		log.Debugf("Enabling metrics-collection feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -171,7 +171,7 @@ func (f *Features) enableMetricsCollectionFeature(_ string) []core.Plugin {
 func (f *Features) enableMetricsThrottleFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureMetrics) &&
 		!f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureMetricsThrottle) {
-
+		log.Debugf("Enabling metrics-throttle feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -188,7 +188,7 @@ func (f *Features) enableMetricsThrottleFeature(_ string) []core.Plugin {
 func (f *Features) enableMetricsSenderFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureMetrics) &&
 		!f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureMetricsSender) {
-
+		log.Debugf("Enabling metrics-sender feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -205,6 +205,7 @@ func (f *Features) enableMetricsSenderFeature(_ string) []core.Plugin {
 func (f *Features) enableAgentAPIFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureAgentAPI) {
 		conf, err := config.GetConfig(f.conf.ClientID)
+		log.Debugf("Enabling agent-api feature")
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
 		}
@@ -219,6 +220,7 @@ func (f *Features) enableAgentAPIFeature(_ string) []core.Plugin {
 
 func (f *Features) enableRegistrationFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureRegistration) {
+		log.Debugf("Enabling registration feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -234,6 +236,7 @@ func (f *Features) enableRegistrationFeature(_ string) []core.Plugin {
 
 func (f *Features) enableDataPlaneStatusFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureDataPlaneStatus) {
+		log.Debugf("Enabling dataplane-status feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -249,6 +252,7 @@ func (f *Features) enableDataPlaneStatusFeature(_ string) []core.Plugin {
 
 func (f *Features) enableProcessWatcherFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureProcessWatcher) {
+		log.Debugf("Enabling process-watcher feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -264,6 +268,7 @@ func (f *Features) enableProcessWatcherFeature(_ string) []core.Plugin {
 
 func (f *Features) enableActivityEventsFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureActivityEvents) {
+		log.Debugf("Enabling activity-events feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -279,6 +284,7 @@ func (f *Features) enableActivityEventsFeature(_ string) []core.Plugin {
 
 func (f *Features) enableFileWatcherFeature(_ string) []core.Plugin {
 	if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureFileWatcher) {
+		log.Debugf("Enabling file-watcher feature")
 		conf, err := config.GetConfig(f.conf.ClientID)
 		if err != nil {
 			log.Warnf("Unable to get agent config, %v", err)
@@ -297,6 +303,7 @@ func (f *Features) enableNginxCountingFeature(_ string) []core.Plugin {
 	countingPlugins := []core.Plugin{}
 	if len(f.conf.Nginx.NginxCountingSocket) > 0 {
 		if !f.pipeline.IsPluginAlreadyRegistered(agent_config.FeatureNginxCounting) {
+			log.Debugf("Enabling nginx-counting feature")
 			conf, err := config.GetConfig(f.conf.ClientID)
 			if err != nil {
 				log.Warnf("Unable to get agent config, %v", err)

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/file_watcher.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/file_watcher.go
@@ -104,6 +104,7 @@ func (fw *FileWatcher) Close() {
 	fw.enabled = false
 	fw.cancelFunction()
 	fw.watcher.Close()
+	log.Info("File Watcher is closed")
 }
 
 func (fw *FileWatcher) Process(message *core.Message) {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/file_watcher_throttling.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/file_watcher_throttling.go
@@ -59,12 +59,13 @@ func (fwt *FileWatchThrottle) SetStarted(newValue bool) {
 }
 
 func (fwt *FileWatchThrottle) Init(pipeline core.MessagePipeInterface) {
-	fwt.messagePipeline = pipeline
 	log.Info("FileWatchThrottle initializing")
+	fwt.messagePipeline = pipeline
 }
 
 func (fwt *FileWatchThrottle) Close() {
 	log.Info("FileWatchThrottle is wrapping up")
+	log.Info("FileWatchThrottle is closed")
 }
 
 func (fwt *FileWatchThrottle) Info() *core.Info {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/file_watcher_throttling.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/file_watcher_throttling.go
@@ -64,7 +64,6 @@ func (fwt *FileWatchThrottle) Init(pipeline core.MessagePipeInterface) {
 }
 
 func (fwt *FileWatchThrottle) Close() {
-	log.Info("FileWatchThrottle is wrapping up")
 	log.Info("FileWatchThrottle is closed")
 }
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/metrics.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/metrics.go
@@ -72,11 +72,14 @@ func (m *Metrics) Init(pipeline core.MessagePipeInterface) {
 }
 
 func (m *Metrics) Close() {
+	log.Info("Metrics is wrapping up")
 	m.collectorsMutex.Lock()
-	m.cancel()
+	if m.cancel != nil {
+		m.cancel()
+	}
 	m.collectors = nil
 	m.collectorsMutex.Unlock()
-	log.Info("Metrics is wrapping up")
+	log.Info("Metrics is closed")
 }
 
 func (m *Metrics) Process(msg *core.Message) {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/metrics.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/metrics.go
@@ -73,12 +73,24 @@ func (m *Metrics) Init(pipeline core.MessagePipeInterface) {
 
 func (m *Metrics) Close() {
 	log.Info("Metrics is wrapping up")
+
 	m.collectorsMutex.Lock()
+
 	if m.cancel != nil {
 		m.cancel()
 	}
+
+	for _, collector := range m.collectors {
+		if nginxCollector, ok := collector.(*collectors.NginxCollector); ok {
+			nginxCollector.Stop()
+			log.Debugf("Removing nginx collector for nginx id: %s", nginxCollector.GetNginxId())
+		}
+	}
+
 	m.collectors = nil
+
 	m.collectorsMutex.Unlock()
+
 	log.Info("Metrics is closed")
 }
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/nginx.go
@@ -719,7 +719,6 @@ func (n *Nginx) Info() *core.Info {
 
 // Close cleans up anything outstanding once the plugin ends
 func (n *Nginx) Close() {
-	log.Info("NginxBinary is wrapping up")
 	log.Info("NginxBinary is closed")
 }
 

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/nginx.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/nginx.go
@@ -720,6 +720,7 @@ func (n *Nginx) Info() *core.Info {
 // Close cleans up anything outstanding once the plugin ends
 func (n *Nginx) Close() {
 	log.Info("NginxBinary is wrapping up")
+	log.Info("NginxBinary is closed")
 }
 
 func (n *Nginx) syncAgentConfigChange() {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/nginx_counter.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/nginx_counter.go
@@ -107,11 +107,11 @@ func (nc *NginxCounter) recieveSocketMessage(socketListener net.Listener) {
 }
 
 func (nc *NginxCounter) Close() {
+	log.Info("NGINX Counter is wrapping up")
 	if nc.socketListener != nil {
 		nc.socketListener.Close()
 	}
 
-	log.Info("NGINX Counter is wrapping up")
 	if err := os.RemoveAll(nc.serverAddress[1]); err != nil {
 		log.Warn("Error removing socket")
 	}
@@ -119,6 +119,7 @@ func (nc *NginxCounter) Close() {
 	nc.processMutex.RLock()
 	nc.nginxes = nil
 	nc.processMutex.RUnlock()
+	log.Info("NGINX Counter is closed")
 }
 
 func (nc *NginxCounter) Info() *core.Info {
@@ -128,7 +129,7 @@ func (nc *NginxCounter) Info() *core.Info {
 func (nc *NginxCounter) Process(msg *core.Message) {
 	switch {
 	case msg.Exact(core.AgentConnected):
-		nc.connected.Toggle()
+		nc.connected.Store(true)
 	case msg.Exact(core.NginxDetailProcUpdate):
 		// get the processes from this payload
 		nc.processMutex.Lock()

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/process_watcher.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/process_watcher.go
@@ -72,12 +72,14 @@ func (pw *ProcessWatcher) Info() *core.Info {
 }
 
 func (pw *ProcessWatcher) Close() {
+	log.Info("ProcessWatcher is wrapping up")
+
 	pw.ticker.Stop()
 	pw.seenMasterProcs = nil
 	pw.seenWorkerProcs = nil
 	pw.nginxDetails = nil
 
-	log.Info("ProcessWatcher is wrapping up")
+	log.Info("ProcessWatcher is closed")
 }
 
 func (pw *ProcessWatcher) Process(message *core.Message) {}

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/registration.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/registration.go
@@ -78,6 +78,7 @@ func (r *OneTimeRegistration) Init(pipeline core.MessagePipeInterface) {
 
 func (r *OneTimeRegistration) Close() {
 	log.Info("OneTimeRegistration is wrapping up")
+	log.Info("OneTimeRegistration is closed")
 }
 
 func (r *OneTimeRegistration) Info() *core.Info {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/registration.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/registration.go
@@ -77,7 +77,6 @@ func (r *OneTimeRegistration) Init(pipeline core.MessagePipeInterface) {
 }
 
 func (r *OneTimeRegistration) Close() {
-	log.Info("OneTimeRegistration is wrapping up")
 	log.Info("OneTimeRegistration is closed")
 }
 


### PR DESCRIPTION
### Proposed changes

- Add fix that prevents the agent from starting plugins more than once when features are being enabling/disabling remotely
- Fix panic that occur when updating NGINX config
- Add more general logging to all plugins

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
