### PR TITLE
Add nil check to OTel bootup 

### DIFF
--- a/internal/collector/otel_collector_plugin.go
+++ b/internal/collector/otel_collector_plugin.go
@@ -160,11 +160,16 @@ func (oc *Collector) processReceivers(ctx context.Context, receivers []config.Ot
 	}
 }
 
+// nolint: revive, cyclop
 func (oc *Collector) bootup(ctx context.Context) error {
 	slog.InfoContext(ctx, "Starting OTel collector")
 	errChan := make(chan error)
 
 	go func() {
+		if oc.service == nil {
+			errChan <- fmt.Errorf("unable to start OTel collector: service is nil")
+		}
+
 		appErr := oc.service.Run(ctx)
 		if appErr != nil {
 			errChan <- appErr


### PR DESCRIPTION
### Proposed changes
Added nil check to otel collector bootup to check service isnt nill before calling Run 
### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
