### PR TITLE
Changed README to reflect new community forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ TBD
 
 ## Community
 
-- Our [Slack channel #nginx-agent](https://nginxcommunity.slack.com/), is the go-to place to start asking questions and sharing your thoughts.
+- Our [NGINX Community Forum ](https://community.nginx.org/tag/agent) is the go-to place to ask questions and share your thoughts.
 
 - Our [GitHub issues page](https://github.com/nginx/agent/issues) offers space for a more technical discussion at your own pace.
 


### PR DESCRIPTION
Since we have discontinued the Slack NGINX community, I have updated the README to point to the NGINX Community Forum and specifically to the "Agent" tag section

### Proposed changes

Updated to remove Slack reference and replace with Forum

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
