### PR TITLE
Allow only CA cert to be set in command server TLS settings

### DIFF
--- a/internal/grpc/grpc.go
+++ b/internal/grpc/grpc.go
@@ -382,14 +382,12 @@ func getTLSConfigForCredentials(c *config.TLSConfig) (*tls.Config, error) {
 		InsecureSkipVerify: c.SkipVerify,
 	}
 
-	err := appendRootCAs(tlsConfig, c.Ca)
-	if err != nil {
-		slog.Debug("Unable to append root CA", "error", err)
+	if err := appendRootCAs(tlsConfig, c.Ca); err != nil {
+		return nil, fmt.Errorf("invalid CA cert while building transport credentials: %w", err)
 	}
 
-	err = appendCertKeyPair(tlsConfig, c.Cert, c.Key)
-	if err != nil {
-		return nil, fmt.Errorf("append cert and key pair failed: %w", err)
+	if err := appendCertKeyPair(tlsConfig, c.Cert, c.Key); err != nil {
+		return nil, fmt.Errorf("invalid client cert while building transport credentials: %w", err)
 	}
 
 	return tlsConfig, nil

--- a/internal/grpc/grpc.go
+++ b/internal/grpc/grpc.go
@@ -363,30 +363,34 @@ func getTransportCredentials(agentConfig *config.Config) (credentials.TransportC
 	if agentConfig.Command.TLS == nil {
 		return defaultCredentials, nil
 	}
+	tlsConfig, err := getTLSConfigForCredentials(agentConfig.Command.TLS)
+	if err != nil {
+		return nil, err
+	}
 
-	if agentConfig.Command.TLS.SkipVerify {
+	return credentials.NewTLS(tlsConfig), nil
+}
+
+func getTLSConfigForCredentials(c *config.TLSConfig) (*tls.Config, error) {
+	if c.SkipVerify {
 		slog.Warn("Verification of the server's certificate chain and host name is disabled")
 	}
 
 	tlsConfig := &tls.Config{
 		MinVersion:         tls.VersionTLS12,
-		ServerName:         agentConfig.Command.TLS.ServerName,
-		InsecureSkipVerify: agentConfig.Command.TLS.SkipVerify,
+		ServerName:         c.ServerName,
+		InsecureSkipVerify: c.SkipVerify,
 	}
 
-	if agentConfig.Command.TLS.Key == "" {
-		return credentials.NewTLS(tlsConfig), nil
-	}
-
-	err := appendCertKeyPair(tlsConfig, agentConfig.Command.TLS.Cert, agentConfig.Command.TLS.Key)
-	if err != nil {
-		return nil, fmt.Errorf("append cert and key pair failed: %w", err)
-	}
-
-	err = appendRootCAs(tlsConfig, agentConfig.Command.TLS.Ca)
+	err := appendRootCAs(tlsConfig, c.Ca)
 	if err != nil {
 		slog.Debug("Unable to append root CA", "error", err)
 	}
 
-	return credentials.NewTLS(tlsConfig), nil
+	err = appendCertKeyPair(tlsConfig, c.Cert, c.Key)
+	if err != nil {
+		return nil, fmt.Errorf("append cert and key pair failed: %w", err)
+	}
+
+	return tlsConfig, nil
 }

--- a/internal/grpc/grpc_test.go
+++ b/internal/grpc/grpc_test.go
@@ -103,7 +103,7 @@ func Test_GetDialOptions(t *testing.T) {
 		{
 			name:        "Test 2: DialOptions mTLS",
 			agentConfig: types.AgentConfig(),
-			expected:    7,
+			expected:    8,
 			createCerts: true,
 		},
 		{
@@ -171,8 +171,8 @@ func Test_GetDialOptions(t *testing.T) {
 				key, cert := helpers.GenerateSelfSignedCert(t)
 				_, ca := helpers.GenerateSelfSignedCert(t)
 
-				keyContents := helpers.Cert{Name: keyFileName, Type: certificateType, Contents: key}
-				certContents := helpers.Cert{Name: certFileName, Type: privateKeyType, Contents: cert}
+				keyContents := helpers.Cert{Name: keyFileName, Type: privateKeyType, Contents: key}
+				certContents := helpers.Cert{Name: certFileName, Type: certificateType, Contents: cert}
 				caContents := helpers.Cert{Name: caFileName, Type: certificateType, Contents: ca}
 
 				helpers.WriteCertFiles(t, tmpDir, keyContents)

--- a/internal/grpc/grpc_test.go
+++ b/internal/grpc/grpc_test.go
@@ -447,14 +447,11 @@ func Test_getTLSConfig(t *testing.T) {
 				require.False(t, c.InsecureSkipVerify, "InsecureSkipVerify should not be set")
 			},
 		},
-		"Test 3: incorrect CA should not error": { // REALLY ?!
+		"Test 3: incorrect CA should not error": {
 			conf: &config.TLSConfig{
 				Ca: "customca.pem",
 			},
-			wantErr: false,
-			verify: func(t require.TestingT, c *tls.Config) {
-				require.Nil(t, c.RootCAs, "RootCAs should be nil to use system")
-			},
+			wantErr: true,
 		},
 		"Test 4: incorrect key path should error": {
 			conf: &config.TLSConfig{

--- a/test/helpers/cert_utils.go
+++ b/test/helpers/cert_utils.go
@@ -11,10 +11,9 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"fmt"
 	"math/big"
 	"os"
-	"strings"
+	"path"
 	"testing"
 	"time"
 
@@ -73,12 +72,7 @@ func WriteCertFiles(t *testing.T, location string, cert Cert) string {
 		Bytes: cert.Contents,
 	})
 
-	var certFile string
-	if strings.HasSuffix(location, string(os.PathSeparator)) {
-		certFile = fmt.Sprintf("%s%s", location, cert.Name)
-	} else {
-		certFile = fmt.Sprintf("%s%s%s", location, string(os.PathSeparator), cert.Name)
-	}
+	certFile := path.Join(location, cert.Name)
 
 	err := os.WriteFile(certFile, pemContents, permission)
 	require.NoError(t, err)

--- a/test/helpers/cert_utils.go
+++ b/test/helpers/cert_utils.go
@@ -31,7 +31,7 @@ const (
 	permission          = 0o600
 	serialNumber        = 123123
 	years, months, days = 5, 0, 0
-	bits                = 4096
+	bits                = 1024
 )
 
 func GenerateSelfSignedCert(t testing.TB) (keyBytes, certBytes []byte) {


### PR DESCRIPTION
This is a duplicate of https://github.com/nginx/agent/pull/1079

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
