### PR TITLE
Fix debug log format

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -55,8 +56,9 @@ func New(logPath, level string) *slog.Logger {
 			if a.Key == slog.SourceKey {
 				source, ok := a.Value.Any().(*slog.Source)
 				if ok {
-					relativeFilePath := strings.Split(source.File, "/agent/")[1]
-					a.Value = slog.StringValue(relativeFilePath + ":" + strconv.Itoa(source.Line))
+					directory := filepath.Dir(source.File)
+					relativePath := path.Join(filepath.Base(directory), filepath.Base(source.File))
+					a.Value = slog.StringValue(relativePath + ":" + strconv.Itoa(source.Line))
 				}
 			}
 


### PR DESCRIPTION
### Proposed changes

Fix debug log format.

Example log line:
```
2025-06-13 11:13:33 time=2025-06-13T10:13:33.917Z level=DEBUG source=resource/resource_plugin.go:54 msg="Starting resource plugin"
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
