### PR TITLE
Update credential watcher to allow second credential watcher

### DIFF
--- a/internal/watcher/credentials/credential_watcher_service.go
+++ b/internal/watcher/credentials/credential_watcher_service.go
@@ -13,6 +13,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/nginx/agent/v3/internal/command"
+	"github.com/nginx/agent/v3/internal/grpc"
+
 	"github.com/fsnotify/fsnotify"
 	"github.com/nginx/agent/v3/internal/config"
 	"github.com/nginx/agent/v3/internal/logger"
@@ -29,6 +32,8 @@ var emptyEvent = fsnotify.Event{
 
 type CredentialUpdateMessage struct {
 	CorrelationID slog.Attr
+	Conn          *grpc.GrpcConnection
+	SeverType     command.ServerType
 }
 
 type CredentialWatcherService struct {
@@ -36,9 +41,11 @@ type CredentialWatcherService struct {
 	watcher           *fsnotify.Watcher
 	filesBeingWatched *sync.Map
 	filesChanged      *atomic.Bool
+	serverType        command.ServerType
+	watcherMutex      sync.Mutex
 }
 
-func NewCredentialWatcherService(agentConfig *config.Config) *CredentialWatcherService {
+func NewCredentialWatcherService(agentConfig *config.Config, serverType command.ServerType) *CredentialWatcherService {
 	filesChanged := &atomic.Bool{}
 	filesChanged.Store(false)
 
@@ -46,38 +53,53 @@ func NewCredentialWatcherService(agentConfig *config.Config) *CredentialWatcherS
 		agentConfig:       agentConfig,
 		filesBeingWatched: &sync.Map{},
 		filesChanged:      filesChanged,
+		serverType:        serverType,
+		watcherMutex:      sync.Mutex{},
 	}
 }
 
 func (cws *CredentialWatcherService) Watch(ctx context.Context, ch chan<- CredentialUpdateMessage) {
-	slog.DebugContext(ctx, "Starting credential watcher monitoring")
+	newCtx := context.WithValue(
+		ctx,
+		logger.ServerTypeContextKey,
+		slog.Any(logger.ServerTypeKey, cws.serverType.String()),
+	)
+	slog.DebugContext(newCtx, "Starting credential watcher monitoring")
 
 	ticker := time.NewTicker(monitoringInterval)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		slog.ErrorContext(ctx, "Failed to create credential watcher", "error", err)
+		slog.ErrorContext(newCtx, "Failed to create credential watcher", "error", err)
 		return
 	}
 
 	cws.watcher = watcher
 
-	cws.watchFiles(ctx, credentialPaths(cws.agentConfig))
+	cws.watcherMutex.Lock()
+	commandSever := cws.agentConfig.Command
+
+	if cws.serverType == command.Auxiliary {
+		commandSever = cws.agentConfig.AuxiliaryCommand
+	}
+
+	cws.watchFiles(newCtx, credentialPaths(commandSever))
+	cws.watcherMutex.Unlock()
 
 	for {
 		select {
-		case <-ctx.Done():
+		case <-newCtx.Done():
 			closeError := cws.watcher.Close()
 			if closeError != nil {
-				slog.ErrorContext(ctx, "Unable to close credential watcher", "error", closeError)
+				slog.ErrorContext(newCtx, "Unable to close credential watcher", "error", closeError)
 			}
 
 			return
 		case event := <-cws.watcher.Events:
-			cws.handleEvent(ctx, event)
+			cws.handleEvent(newCtx, event)
 		case <-ticker.C:
-			cws.checkForUpdates(ctx, ch)
+			cws.checkForUpdates(newCtx, ch)
 		case watcherError := <-cws.watcher.Errors:
-			slog.ErrorContext(ctx, "Unexpected error in credential watcher", "error", watcherError)
+			slog.ErrorContext(newCtx, "Unexpected error in credential watcher", "error", watcherError)
 		}
 	}
 }
@@ -146,31 +168,49 @@ func (cws *CredentialWatcherService) checkForUpdates(ctx context.Context, ch cha
 			slog.Any(logger.CorrelationIDKey, logger.GenerateCorrelationID()),
 		)
 
+		cws.watcherMutex.Lock()
+		defer cws.watcherMutex.Unlock()
+
+		commandSever := cws.agentConfig.Command
+		if cws.serverType == command.Auxiliary {
+			commandSever = cws.agentConfig.AuxiliaryCommand
+		}
+
+		conn, err := grpc.NewGrpcConnection(newCtx, cws.agentConfig, commandSever)
+		if err != nil {
+			slog.ErrorContext(newCtx, "Unable to create new grpc connection", "error", err)
+			cws.filesChanged.Store(false)
+
+			return
+		}
 		slog.DebugContext(ctx, "Credential watcher has detected changes")
-		ch <- CredentialUpdateMessage{CorrelationID: logger.CorrelationIDAttr(newCtx)}
+		ch <- CredentialUpdateMessage{
+			CorrelationID: logger.CorrelationIDAttr(newCtx),
+			SeverType:     cws.serverType, Conn: conn,
+		}
 		cws.filesChanged.Store(false)
 	}
 }
 
-func credentialPaths(agentConfig *config.Config) []string {
+func credentialPaths(agentConfig *config.Command) []string {
 	var paths []string
 
-	if agentConfig.Command.Auth != nil {
-		if agentConfig.Command.Auth.TokenPath != "" {
-			paths = append(paths, agentConfig.Command.Auth.TokenPath)
+	if agentConfig.Auth != nil {
+		if agentConfig.Auth.TokenPath != "" {
+			paths = append(paths, agentConfig.Auth.TokenPath)
 		}
 	}
 
 	// agent's tls certs
-	if agentConfig.Command.TLS != nil {
-		if agentConfig.Command.TLS.Ca != "" {
-			paths = append(paths, agentConfig.Command.TLS.Ca)
+	if agentConfig.TLS != nil {
+		if agentConfig.TLS.Ca != "" {
+			paths = append(paths, agentConfig.TLS.Ca)
 		}
-		if agentConfig.Command.TLS.Cert != "" {
-			paths = append(paths, agentConfig.Command.TLS.Cert)
+		if agentConfig.TLS.Cert != "" {
+			paths = append(paths, agentConfig.TLS.Cert)
 		}
-		if agentConfig.Command.TLS.Key != "" {
-			paths = append(paths, agentConfig.Command.TLS.Key)
+		if agentConfig.TLS.Key != "" {
+			paths = append(paths, agentConfig.TLS.Key)
 		}
 	}
 

--- a/internal/watcher/credentials/credential_watcher_service_test.go
+++ b/internal/watcher/credentials/credential_watcher_service_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nginx/agent/v3/internal/command"
+
 	"github.com/nginx/agent/v3/internal/config"
 
 	"github.com/fsnotify/fsnotify"
@@ -22,7 +24,7 @@ import (
 )
 
 func TestCredentialWatcherService_TestNewCredentialWatcherService(t *testing.T) {
-	credentialWatcherService := NewCredentialWatcherService(types.AgentConfig())
+	credentialWatcherService := NewCredentialWatcherService(types.AgentConfig(), command.Command)
 
 	assert.Empty(t, credentialWatcherService.filesBeingWatched)
 	assert.False(t, credentialWatcherService.filesChanged.Load())
@@ -30,7 +32,7 @@ func TestCredentialWatcherService_TestNewCredentialWatcherService(t *testing.T) 
 
 func TestCredentialWatcherService_Watch(t *testing.T) {
 	ctx := context.Background()
-	cws := NewCredentialWatcherService(types.AgentConfig())
+	cws := NewCredentialWatcherService(types.AgentConfig(), command.Command)
 	watcher, err := fsnotify.NewWatcher()
 	require.NoError(t, err)
 	cws.watcher = watcher
@@ -61,7 +63,7 @@ func TestCredentialWatcherService_Watch(t *testing.T) {
 }
 
 func TestCredentialWatcherService_isWatching(t *testing.T) {
-	cws := NewCredentialWatcherService(types.AgentConfig())
+	cws := NewCredentialWatcherService(types.AgentConfig(), command.Command)
 	assert.False(t, cws.isWatching("test-file"))
 	cws.filesBeingWatched.Store("test-file", true)
 	assert.True(t, cws.isWatching("test-file"))
@@ -80,7 +82,7 @@ func TestCredentialWatcherService_isEventSkippable(t *testing.T) {
 
 func TestCredentialWatcherService_addWatcher(t *testing.T) {
 	ctx := context.Background()
-	cws := NewCredentialWatcherService(types.AgentConfig())
+	cws := NewCredentialWatcherService(types.AgentConfig(), command.Command)
 	watcher, err := fsnotify.NewWatcher()
 	require.NoError(t, err)
 	cws.watcher = watcher
@@ -105,7 +107,7 @@ func TestCredentialWatcherService_watchFiles(t *testing.T) {
 	var files []string
 
 	ctx := context.Background()
-	cws := NewCredentialWatcherService(types.AgentConfig())
+	cws := NewCredentialWatcherService(types.AgentConfig(), command.Command)
 	watcher, err := fsnotify.NewWatcher()
 	require.NoError(t, err)
 	cws.watcher = watcher
@@ -137,7 +139,7 @@ func TestCredentialWatcherService_watchFiles(t *testing.T) {
 
 func TestCredentialWatcherService_checkForUpdates(t *testing.T) {
 	ctx := context.Background()
-	cws := NewCredentialWatcherService(types.AgentConfig())
+	cws := NewCredentialWatcherService(types.AgentConfig(), command.Command)
 	watcher, err := fsnotify.NewWatcher()
 	require.NoError(t, err)
 	cws.watcher = watcher
@@ -164,7 +166,7 @@ func TestCredentialWatcherService_checkForUpdates(t *testing.T) {
 
 func TestCredentialWatcherService_handleEvent(t *testing.T) {
 	ctx := context.Background()
-	cws := NewCredentialWatcherService(types.AgentConfig())
+	cws := NewCredentialWatcherService(types.AgentConfig(), command.Command)
 	watcher, err := fsnotify.NewWatcher()
 	require.NoError(t, err)
 	cws.watcher = watcher
@@ -232,7 +234,7 @@ func Test_credentialPaths(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, credentialPaths(tt.agentConfig), "credentialPaths(%v)", tt.agentConfig)
+			assert.Equalf(t, tt.want, credentialPaths(tt.agentConfig.Command), "credentialPaths(%v)", tt.agentConfig)
 		})
 	}
 }


### PR DESCRIPTION
### Proposed changes

Updated credential watcher to allow a second credential watcher to be started to monitor auxiliary command sever.
- Credential watcher now takes a sever type to be used to determine if it is aux or command sever
- Removed sending of CredentialUpdatedTopic from watcher plugin
- Moved creation of new GRPC connection from watcher plugin into credential watcher when update is detected 
- CredentialUpdateMessage now has Server Type and GRPC connection 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
