### PR TITLE
Update file watcher to only monitor directories referenced in the nginx configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/nginxinc/nginx-plus-go-client/v2 v2.0.1
 	github.com/nginxinc/nginx-prometheus-exporter v1.3.0
@@ -132,6 +133,7 @@ require (
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/hashicorp/consul/api v1.30.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -278,6 +278,7 @@ github.com/hashicorp/consul/api v1.30.0 h1:ArHVMMILb1nQv8vZSGIwwQd2gtc+oSQZ6Caly
 github.com/hashicorp/consul/api v1.30.0/go.mod h1:B2uGchvaXVW2JhFoS8nqTxMD5PBykr4ebY4JWHTTeLM=
 github.com/hashicorp/cronexpr v1.1.2 h1:wG/ZYIKT+RT3QkOdgYc+xsKWVRgnxJ1OJtjjy84fJ9A=
 github.com/hashicorp/cronexpr v1.1.2/go.mod h1:P4wA0KBl9C5q2hABiMO7cp6jcIg96CDh1Efb3g1PWA4=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=

--- a/internal/collector/containermetricsreceiver/internal/scraper/cpuscraper/internal/cgroup/cpu_test.go
+++ b/internal/collector/containermetricsreceiver/internal/scraper/cpuscraper/internal/cgroup/cpu_test.go
@@ -6,11 +6,14 @@
 package cgroup
 
 import (
+	"errors"
 	"os"
 	"path"
 	"runtime"
 	"strconv"
 	"testing"
+
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -76,7 +79,16 @@ func TestCollectCPUStats(t *testing.T) {
 			cpuStat, err := cgroupCPUSource.collectCPUStats()
 
 			// Assert error
-			assert.IsType(tt, test.errorType, err)
+			if err != nil {
+				var multiError *multierror.Error
+				if errors.As(err, &multiError) {
+					assert.IsType(tt, test.errorType, multiError.Errors[0])
+				} else {
+					assert.IsType(tt, test.errorType, err)
+				}
+			} else {
+				assert.IsType(tt, test.errorType, err)
+			}
 
 			// Assert result
 			assert.Equal(tt, test.cpuStat, cpuStat)

--- a/internal/collector/containermetricsreceiver/internal/scraper/memoryscraper/internal/cgroup/memory_test.go
+++ b/internal/collector/containermetricsreceiver/internal/scraper/memoryscraper/internal/cgroup/memory_test.go
@@ -7,11 +7,14 @@ package cgroup
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path"
 	"runtime"
 	"strconv"
 	"testing"
+
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/shirou/gopsutil/v4/mem"
 	"github.com/stretchr/testify/assert"
@@ -115,7 +118,16 @@ func TestVirtualMemoryStat(t *testing.T) {
 			virtualMemoryStat, err := cgroupCPUSource.VirtualMemoryStat()
 
 			// Assert error
-			assert.IsType(tt, test.errorType, err)
+			if err != nil {
+				var multiError *multierror.Error
+				if errors.As(err, &multiError) {
+					assert.IsType(tt, test.errorType, multiError.Errors[0])
+				} else {
+					assert.IsType(tt, test.errorType, err)
+				}
+			} else {
+				assert.IsType(tt, test.errorType, err)
+			}
 
 			// Assert result
 			assert.Equal(tt, test.virtualMemoryStat, *virtualMemoryStat)

--- a/internal/collector/containermetricsreceiver/internal/utils.go
+++ b/internal/collector/containermetricsreceiver/internal/utils.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/go-multierror"
 )
 
 type Source interface {
@@ -22,12 +24,18 @@ func ReadLines(filename string) ([]string, error) {
 }
 
 // nolint: revive
-func ReadLinesOffsetN(filename string, offset uint, n int) ([]string, error) {
+func ReadLinesOffsetN(filename string, offset uint, n int) (lines []string, err error) {
 	f, err := os.Open(filename)
+	defer func() {
+		closeErr := f.Close()
+		if closeErr != nil {
+			err = multierror.Append(err, closeErr)
+		}
+	}()
+
 	if err != nil {
 		return []string{}, err
 	}
-	defer f.Close()
 
 	var ret []string
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -412,6 +412,10 @@ func (c *Config) AreReceiversConfigured() bool {
 }
 
 func isAllowedDir(dir string, allowedDirs []string) bool {
+	if !strings.HasSuffix(dir, "/") && filepath.Ext(dir) == "" {
+		dir += "/"
+	}
+
 	for _, allowedDirectory := range allowedDirs {
 		if strings.HasPrefix(dir, allowedDirectory) {
 			return true

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -25,10 +25,10 @@ func TestTypes_IsDirectoryAllowed(t *testing.T) {
 			allowed: true,
 			allowedDirs: []string{
 				AgentDirName,
-				"/etc/nginx",
+				"/etc/nginx/",
 				"/var/log/nginx/",
 			},
-			fileDir: "/etc/nginx/nginx.conf",
+			fileDir: "/etc/nginx",
 		},
 		{
 			name:    "Test 2: directory not allowed",

--- a/internal/datasource/host/info.go
+++ b/internal/datasource/host/info.go
@@ -205,15 +205,16 @@ func (i *Info) containerID() string {
 // mountInfo is the path: "/proc/self/mountinfo"
 func containerIDFromMountInfo(mountInfo string) (string, error) {
 	mInfoFile, err := os.Open(mountInfo)
-	if err != nil {
-		return "", fmt.Errorf("could not read %s: %w", mountInfo, err)
-	}
 	defer func(f *os.File, fileName string) {
 		closeErr := f.Close()
 		if closeErr != nil {
 			slog.Error("Unable to close file", "file", fileName, "error", closeErr)
 		}
 	}(mInfoFile, mountInfo)
+
+	if err != nil {
+		return "", fmt.Errorf("could not read %s: %w", mountInfo, err)
+	}
 
 	fileScanner := bufio.NewScanner(mInfoFile)
 	fileScanner.Split(bufio.ScanLines)
@@ -308,15 +309,15 @@ func (i *Info) releaseInfo(ctx context.Context, osReleaseLocation string) (relea
 
 func readOsRelease(path string) (map[string]string, error) {
 	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("release file %s is unreadable: %w", path, err)
-	}
 	defer func(f *os.File, fileName string) {
 		closeErr := f.Close()
 		if closeErr != nil {
 			slog.Error("Unable to close file", "file", fileName, "error", closeErr)
 		}
 	}(f, path)
+	if err != nil {
+		return nil, fmt.Errorf("release file %s is unreadable: %w", path, err)
+	}
 
 	info, err := parseOsReleaseFile(f)
 	if err != nil {

--- a/internal/file/file_manager_service.go
+++ b/internal/file/file_manager_service.go
@@ -854,14 +854,15 @@ func (fms *FileManagerService) writeManifestFile(updatedFiles map[string]*model.
 
 	// 0600 ensures only root can read/write
 	newFile, err := os.OpenFile(fms.manifestFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, filePerm)
-	if err != nil {
-		return fmt.Errorf("failed to read manifest file: %w", err)
-	}
 	defer func() {
 		if closeErr := newFile.Close(); closeErr != nil {
 			writeError = closeErr
 		}
 	}()
+
+	if err != nil {
+		return fmt.Errorf("failed to read manifest file: %w", err)
+	}
 
 	_, err = newFile.Write(manifestJSON)
 	if err != nil {

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -19,6 +19,7 @@ type NginxConfigContext struct {
 	AccessLogs       []*AccessLog
 	ErrorLogs        []*ErrorLog
 	NAPSysLogServers []string
+	Includes         []string
 }
 
 type APIDetails struct {

--- a/internal/watcher/file/file_watcher_service_test.go
+++ b/internal/watcher/file/file_watcher_service_test.go
@@ -10,13 +10,17 @@ import (
 	"context"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
+
+	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
 
 	"github.com/nginx/agent/v3/test/helpers"
 	"github.com/nginx/agent/v3/test/stub"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/nginx/agent/v3/internal/model"
 	"github.com/nginx/agent/v3/test/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,6 +34,7 @@ func TestFileWatcherService_NewFileWatcherService(t *testing.T) {
 	fileWatcherService := NewFileWatcherService(types.AgentConfig())
 
 	assert.Empty(t, fileWatcherService.directoriesBeingWatched)
+	assert.Empty(t, fileWatcherService.directoriesThatDontExistYet)
 	assert.True(t, fileWatcherService.enabled.Load())
 	assert.False(t, fileWatcherService.filesChanged.Load())
 }
@@ -52,22 +57,16 @@ func TestFileWatcherService_addWatcher(t *testing.T) {
 	require.NoError(t, err)
 	fileWatcherService.watcher = watcher
 
-	tempDir := os.TempDir()
+	tempDir := t.TempDir()
 	testDirectory := path.Join(tempDir, "test_dir")
 	err = os.Mkdir(testDirectory, directoryPermissions)
 	require.NoError(t, err)
 	defer os.Remove(testDirectory)
 
-	info, err := os.Stat(testDirectory)
-	require.NoError(t, err)
+	fileWatcherService.addWatcher(ctx, testDirectory)
 
-	fileWatcherService.addWatcher(ctx, testDirectory, info)
-
-	value, ok := fileWatcherService.directoriesBeingWatched.Load(testDirectory)
+	_, ok := fileWatcherService.directoriesBeingWatched.Load(testDirectory)
 	assert.True(t, ok)
-	boolValue, ok := value.(bool)
-	assert.True(t, ok)
-	assert.True(t, boolValue)
 }
 
 func TestFileWatcherService_addWatcher_Error(t *testing.T) {
@@ -77,25 +76,14 @@ func TestFileWatcherService_addWatcher_Error(t *testing.T) {
 	require.NoError(t, err)
 	fileWatcherService.watcher = watcher
 
-	tempDir := os.TempDir()
+	tempDir := t.TempDir()
 	testDirectory := path.Join(tempDir, "test_dir")
-	err = os.Mkdir(testDirectory, directoryPermissions)
-	require.NoError(t, err)
-	info, err := os.Stat(testDirectory)
-	require.NoError(t, err)
 
-	// Delete directory to cause the addWatcher function to fail
-	err = os.Remove(testDirectory)
-	require.NoError(t, err)
+	success := fileWatcherService.addWatcher(ctx, testDirectory)
+	assert.False(t, success)
 
-	fileWatcherService.addWatcher(ctx, testDirectory, info)
-
-	value, ok := fileWatcherService.directoriesBeingWatched.Load(testDirectory)
-	assert.True(t, ok)
-	boolValue, ok := value.(bool)
-	assert.True(t, ok)
-	assert.False(t, boolValue)
-	assert.True(t, ok)
+	_, ok := fileWatcherService.directoriesBeingWatched.Load(testDirectory)
+	assert.False(t, ok)
 }
 
 func TestFileWatcherService_removeWatcher(t *testing.T) {
@@ -105,7 +93,7 @@ func TestFileWatcherService_removeWatcher(t *testing.T) {
 	require.NoError(t, err)
 	fileWatcherService.watcher = watcher
 
-	tempDir := os.TempDir()
+	tempDir := t.TempDir()
 	testDirectory := path.Join(tempDir, "test_dir")
 	err = os.Mkdir(testDirectory, directoryPermissions)
 	require.NoError(t, err)
@@ -113,23 +101,16 @@ func TestFileWatcherService_removeWatcher(t *testing.T) {
 
 	err = fileWatcherService.watcher.Add(testDirectory)
 	require.NoError(t, err)
-	fileWatcherService.directoriesBeingWatched.Store(testDirectory, true)
 
 	fileWatcherService.removeWatcher(ctx, testDirectory)
 
-	value, ok := fileWatcherService.directoriesBeingWatched.Load(testDirectory)
-	assert.Nil(t, value)
-	assert.False(t, ok)
-
 	logBuf := &bytes.Buffer{}
+	defer logBuf.Reset()
 	stub.StubLoggerWith(logBuf)
 
-	fileWatcherService.directoriesBeingWatched.Store(testDirectory, true)
 	fileWatcherService.removeWatcher(ctx, testDirectory)
 
 	helpers.ValidateLog(t, "Failed to remove file watcher", logBuf)
-
-	logBuf.Reset()
 }
 
 func TestFileWatcherService_isEventSkippable(t *testing.T) {
@@ -156,13 +137,87 @@ func TestFileWatcherService_isExcludedFile(t *testing.T) {
 	assert.False(t, isExcludedFile("/var/log/accesslog", excludeFiles))
 }
 
+func TestFileWatcherService_Update(t *testing.T) {
+	ctx := context.Background()
+
+	tempDir := t.TempDir()
+	testDirectory := path.Join(tempDir, "test_dir")
+	err := os.Mkdir(testDirectory, directoryPermissions)
+	require.NoError(t, err)
+	defer os.RemoveAll(testDirectory)
+
+	agentConfig := types.AgentConfig()
+	agentConfig.Watchers.FileWatcher.MonitoringFrequency = 100 * time.Millisecond
+	agentConfig.AllowedDirectories = []string{testDirectory, "/unknown/directory"}
+
+	fileWatcherService := NewFileWatcherService(agentConfig)
+
+	t.Run("Test 1: watcher not initialized yet", func(t *testing.T) {
+		fileWatcherService.Update(ctx, &model.NginxConfigContext{
+			Includes: []string{filepath.Join(testDirectory, "*.conf")},
+		})
+
+		_, ok := fileWatcherService.directoriesThatDontExistYet.Load(testDirectory)
+		assert.True(t, ok)
+
+		_, ok = fileWatcherService.directoriesBeingWatched.Load(testDirectory)
+		assert.False(t, ok)
+	})
+
+	t.Run("Test 2: watcher initialized", func(t *testing.T) {
+		watcher, newWatcherError := fsnotify.NewWatcher()
+		require.NoError(t, newWatcherError)
+
+		fileWatcherService.watcher = watcher
+
+		fileWatcherService.Update(ctx, &model.NginxConfigContext{
+			Includes: []string{filepath.Join(testDirectory, "*.conf")},
+		})
+
+		_, ok := fileWatcherService.directoriesThatDontExistYet.Load(testDirectory)
+		assert.False(t, ok)
+
+		_, ok = fileWatcherService.directoriesBeingWatched.Load(testDirectory)
+		assert.True(t, ok)
+	})
+
+	t.Run("Test 3: remove watchers", func(t *testing.T) {
+		fileWatcherService.Update(ctx, &model.NginxConfigContext{
+			Includes: []string{},
+		})
+
+		_, ok := fileWatcherService.directoriesThatDontExistYet.Load(testDirectory)
+		assert.False(t, ok)
+
+		_, ok = fileWatcherService.directoriesBeingWatched.Load(testDirectory)
+		assert.False(t, ok)
+	})
+
+	t.Run("Test 4: not allowed directory", func(t *testing.T) {
+		fileWatcherService.Update(ctx, &model.NginxConfigContext{
+			Files: []*mpi.File{
+				{
+					FileMeta: &mpi.FileMeta{
+						Name: "/unknown/location/test.conf",
+					},
+				},
+			},
+		})
+
+		_, ok := fileWatcherService.directoriesThatDontExistYet.Load("/unknown/location/test.conf")
+		assert.False(t, ok)
+
+		_, ok = fileWatcherService.directoriesBeingWatched.Load("/unknown/location/test.conf")
+		assert.False(t, ok)
+	})
+}
+
 func TestFileWatcherService_Watch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	tempDir := os.TempDir()
+	tempDir := t.TempDir()
 	testDirectory := path.Join(tempDir, "test_dir")
-	os.RemoveAll(testDirectory)
 	err := os.Mkdir(testDirectory, directoryPermissions)
 	require.NoError(t, err)
 	defer os.RemoveAll(testDirectory)
@@ -178,13 +233,32 @@ func TestFileWatcherService_Watch(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
+	fileWatcherService.Update(ctx, &model.NginxConfigContext{
+		Includes: []string{filepath.Join(testDirectory, "*.conf")},
+	})
+
 	file, err := os.CreateTemp(testDirectory, "test.conf")
 	require.NoError(t, err)
 	defer os.Remove(file.Name())
 
 	t.Run("Test 1: File updated", func(t *testing.T) {
-		fileUpdate := <-channel
-		assert.NotNil(t, fileUpdate.CorrelationID)
+		// Check that directory is being watched
+		assert.Eventually(t, func() bool {
+			_, ok := fileWatcherService.directoriesThatDontExistYet.Load(testDirectory)
+			return !ok
+		}, 1*time.Second, 100*time.Millisecond)
+
+		assert.Eventually(t, func() bool {
+			_, ok := fileWatcherService.directoriesBeingWatched.Load(testDirectory)
+			return ok
+		}, 1*time.Second, 100*time.Millisecond)
+
+		select {
+		case fileUpdate := <-channel:
+			assert.NotNil(t, fileUpdate.CorrelationID)
+		case <-time.After(150 * time.Millisecond):
+			t.Fatalf("Expected file update event")
+		}
 	})
 
 	t.Run("Test 2: Skippable file updated", func(t *testing.T) {
@@ -199,4 +273,52 @@ func TestFileWatcherService_Watch(t *testing.T) {
 			return
 		}
 	})
+
+	t.Run("Test 3: Directory deleted", func(t *testing.T) {
+		dirDeleteError := os.RemoveAll(testDirectory)
+		require.NoError(t, dirDeleteError)
+
+		// Check that directory is no longer being watched
+		assert.Eventually(t, func() bool {
+			_, ok := fileWatcherService.directoriesThatDontExistYet.Load(testDirectory)
+			return ok
+		}, 1*time.Second, 100*time.Millisecond)
+
+		assert.Eventually(t, func() bool {
+			_, ok := fileWatcherService.directoriesBeingWatched.Load(testDirectory)
+			return !ok
+		}, 1*time.Second, 100*time.Millisecond)
+	})
+}
+
+func TestFileWatcherService_checkForUpdates(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tempDir := t.TempDir()
+	testDirectory := path.Join(tempDir, "test_dir")
+	err := os.Mkdir(testDirectory, directoryPermissions)
+	require.NoError(t, err)
+	defer os.RemoveAll(testDirectory)
+
+	agentConfig := types.AgentConfig()
+	agentConfig.Watchers.FileWatcher.MonitoringFrequency = 100 * time.Millisecond
+	agentConfig.AllowedDirectories = []string{testDirectory, "/unknown/directory"}
+
+	channel := make(chan FileUpdateMessage)
+
+	fileWatcherService := NewFileWatcherService(agentConfig)
+	fileWatcherService.filesChanged.Store(true)
+	assert.Nil(t, fileWatcherService.watcher)
+
+	go fileWatcherService.checkForUpdates(ctx, channel)
+
+	select {
+	case fileUpdate := <-channel:
+		assert.NotNil(t, fileUpdate.CorrelationID)
+		assert.NotNil(t, fileWatcherService.watcher)
+		assert.False(t, fileWatcherService.filesChanged.Load())
+	case <-time.After(150 * time.Millisecond):
+		t.Fatalf("Expected file update event")
+	}
 }

--- a/internal/watcher/watcher_plugin.go
+++ b/internal/watcher/watcher_plugin.go
@@ -282,6 +282,7 @@ func (w *Watcher) monitorWatchers(ctx context.Context) {
 		case message := <-w.nginxConfigContextChannel:
 			newCtx := context.WithValue(ctx, logger.CorrelationIDContextKey, message.CorrelationID)
 			w.watcherMutex.Lock()
+
 			if !slices.Contains(w.instancesWithConfigApplyInProgress, message.NginxConfigContext.InstanceID) {
 				slog.DebugContext(
 					newCtx,
@@ -300,6 +301,9 @@ func (w *Watcher) monitorWatchers(ctx context.Context) {
 					"nginx_config_context", message.NginxConfigContext,
 				)
 			}
+
+			w.fileWatcherService.Update(ctx, message.NginxConfigContext)
+
 			w.watcherMutex.Unlock()
 		case message := <-w.instanceHealthChannel:
 			newCtx := context.WithValue(ctx, logger.CorrelationIDContextKey, message.CorrelationID)

--- a/test/config/nginx/empty-nginx.conf
+++ b/test/config/nginx/empty-nginx.conf
@@ -1,0 +1,1 @@
+# Empty config

--- a/test/config/nginx/nginx-with-server-block-access-log.conf
+++ b/test/config/nginx/nginx-with-server-block-access-log.conf
@@ -51,4 +51,6 @@ http {
             root   /usr/share/nginx/html;
         }
     }
+    
+	include /etc/nginx/test/*;
 }

--- a/test/integration/managementplane/file_watcher_test.go
+++ b/test/integration/managementplane/file_watcher_test.go
@@ -25,19 +25,51 @@ func TestGrpc_FileWatcher(t *testing.T) {
 	utils.VerifyConnection(t, 2)
 	assert.False(t, t.Failed())
 
-	err := utils.Container.CopyFileToContainer(
-		ctx,
-		"../../config/nginx/nginx-with-server-block-access-log.conf",
-		"/etc/nginx/nginx.conf",
-		0o666,
-	)
-	require.NoError(t, err)
+	t.Run("Test 1: update nginx config file on data plane", func(t *testing.T) {
+		err := utils.Container.CopyFileToContainer(
+			ctx,
+			"../../config/nginx/nginx-with-server-block-access-log.conf",
+			"/etc/nginx/nginx.conf",
+			0o666,
+		)
+		require.NoError(t, err)
 
-	responses := utils.ManagementPlaneResponses(t, 2)
-	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
-	assert.Equal(t, "Successfully updated all files", responses[0].GetCommandResponse().GetMessage())
-	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[1].GetCommandResponse().GetStatus())
-	assert.Equal(t, "Successfully updated all files", responses[1].GetCommandResponse().GetMessage())
+		responses := utils.ManagementPlaneResponses(t, 2)
+		assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
+		assert.Equal(t, "Successfully updated all files", responses[0].GetCommandResponse().GetMessage())
+		assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[1].GetCommandResponse().GetStatus())
+		assert.Equal(t, "Successfully updated all files", responses[1].GetCommandResponse().GetMessage())
 
-	utils.VerifyUpdateDataPlaneStatus(t)
+		utils.VerifyUpdateDataPlaneStatus(t)
+	})
+
+	t.Run("Test 2: create new nginx config file", func(t *testing.T) {
+		err := utils.Container.CopyFileToContainer(
+			ctx,
+			"../../config/nginx/empty-nginx.conf",
+			"/etc/nginx/test/test.conf",
+			0o666,
+		)
+		require.NoError(t, err)
+
+		responses := utils.ManagementPlaneResponses(t, 3)
+		assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[2].GetCommandResponse().GetStatus())
+		assert.Equal(t, "Successfully updated all files", responses[2].GetCommandResponse().GetMessage())
+
+		utils.VerifyUpdateDataPlaneStatus(t)
+	})
+
+	t.Run("Test 3: delete nginx config file", func(t *testing.T) {
+		_, _, err := utils.Container.Exec(
+			ctx,
+			[]string{"rm", "-rf", "/etc/nginx/test"},
+		)
+		require.NoError(t, err)
+
+		responses := utils.ManagementPlaneResponses(t, 4)
+		assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[3].GetCommandResponse().GetStatus())
+		assert.Equal(t, "Successfully updated all files", responses[3].GetCommandResponse().GetMessage())
+
+		utils.VerifyUpdateDataPlaneStatus(t)
+	})
 }


### PR DESCRIPTION
### Proposed changes

- Update file watcher to only monitor directories referenced in the nginx configuration.
- Ensure that any opened files are closed correctly.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
