### PR TITLE
Update cert utils

### DIFF
--- a/test/helpers/cert_utils.go
+++ b/test/helpers/cert_utils.go
@@ -30,7 +30,7 @@ const (
 	permission          = 0o600
 	serialNumber        = 123123
 	years, months, days = 5, 0, 0
-	bits                = 1024
+	bits                = 2048
 )
 
 func GenerateSelfSignedCert(t testing.TB) (keyBytes, certBytes []byte) {


### PR DESCRIPTION
Potential fix for [https://github.com/nginx/agent/security/code-scanning/164](https://github.com/nginx/agent/security/code-scanning/164)

To fix the issue, the `bits` constant should be updated to use a secure key size of at least 2048 bits. This change ensures compliance with modern cryptographic standards and mitigates the risk of brute-force attacks. The fix involves modifying the `bits` constant definition and ensuring that the updated value is used in the `rsa.GenerateKey` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
