### PR TITLE
run mend on dev-v2 branch

### DIFF
--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - release-*
+      - dev-v2
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
     paths-ignore:


### PR DESCRIPTION
### Proposed changes

After this PR is merged Mend scanner will run on `dev-v2` branch.
This means both security scanning tools: CodeQL and Mend will cover the same branches: `main`, `release-*` and `dev-v2`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
