### PR TITLE
Add mutex lock to nginxConfigCache in instance watcher service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	go.opentelemetry.io/collector/processor v1.30.0
 	go.opentelemetry.io/collector/processor/batchprocessor v0.124.0
 	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.124.0
+	go.opentelemetry.io/collector/processor/processortest v0.124.0
 	go.opentelemetry.io/collector/receiver v1.30.0
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.124.0
 	go.opentelemetry.io/collector/receiver/receivertest v0.124.0
@@ -74,6 +75,7 @@ require (
 	go.opentelemetry.io/collector/scraper/scrapertest v0.124.0
 	go.opentelemetry.io/otel v1.35.0
 	go.uber.org/goleak v1.3.0
+	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/mod v0.23.0
 	golang.org/x/sync v0.13.0
@@ -260,7 +262,6 @@ require (
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.124.0 // indirect
 	go.opentelemetry.io/collector/processor/processorhelper v0.124.0 // indirect
 	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.124.0 // indirect
-	go.opentelemetry.io/collector/processor/processortest v0.124.0 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.124.0 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.124.0 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.124.0 // indirect
@@ -289,7 +290,6 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.11.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/arch v0.12.0 // indirect
 	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac // indirect
 	golang.org/x/tools v0.30.0 // indirect

--- a/internal/watcher/instance/instance_watcher_service.go
+++ b/internal/watcher/instance/instance_watcher_service.go
@@ -218,10 +218,10 @@ func (iw *InstanceWatcherService) checkForUpdates(
 					"error", parseErr,
 				)
 			} else {
+				iw.cacheMutex.Lock()
 				iw.sendNginxConfigContextUpdate(newCtx, nginxConfigContext)
 				proto.UpdateNginxInstanceRuntime(newInstance, nginxConfigContext)
 
-				iw.cacheMutex.Lock()
 				iw.nginxConfigCache[nginxConfigContext.InstanceID] = nginxConfigContext
 				iw.instanceCache[newInstance.GetInstanceMeta().GetInstanceId()] = newInstance
 				iw.cacheMutex.Unlock()

--- a/internal/watcher/instance/instance_watcher_service.go
+++ b/internal/watcher/instance/instance_watcher_service.go
@@ -219,9 +219,10 @@ func (iw *InstanceWatcherService) checkForUpdates(
 				)
 			} else {
 				iw.sendNginxConfigContextUpdate(newCtx, nginxConfigContext)
-				iw.nginxConfigCache[nginxConfigContext.InstanceID] = nginxConfigContext
 				proto.UpdateNginxInstanceRuntime(newInstance, nginxConfigContext)
+
 				iw.cacheMutex.Lock()
+				iw.nginxConfigCache[nginxConfigContext.InstanceID] = nginxConfigContext
 				iw.instanceCache[newInstance.GetInstanceMeta().GetInstanceId()] = newInstance
 				iw.cacheMutex.Unlock()
 			}


### PR DESCRIPTION
### Proposed changes

Add mutex lock to nginxConfigCache in instance watcher service.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
