### PR TITLE
Add multi management plane integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ integration-test: $(SELECTED_PACKAGE) build-mock-management-plane-grpc
 	TEST_ENV="Container" CONTAINER_OS_TYPE=$(CONTAINER_OS_TYPE) BUILD_TARGET="install-agent-local" CONTAINER_NGINX_IMAGE_REGISTRY=${CONTAINER_NGINX_IMAGE_REGISTRY} \
 	PACKAGES_REPO=$(OSS_PACKAGES_REPO) PACKAGE_NAME=$(PACKAGE_NAME) BASE_IMAGE=$(BASE_IMAGE) DOCKERFILE_PATH=$(DOCKERFILE_PATH) IMAGE_PATH=$(IMAGE_PATH) TAG=${IMAGE_TAG} \
 	OS_VERSION=$(OS_VERSION) OS_RELEASE=$(OS_RELEASE) \
-	go test -v ./test/integration/auxiliarycommandserver
+	go test -v ./test/integration/installuninstall ./test/integration/managementplane ./test/integration/auxiliarycommandserver ./test/integration/nginxless
 	
 official-image-integration-test: $(SELECTED_PACKAGE) build-mock-management-plane-grpc
 	TEST_ENV="Container" CONTAINER_OS_TYPE=$(CONTAINER_OS_TYPE) CONTAINER_NGINX_IMAGE_REGISTRY=${CONTAINER_NGINX_IMAGE_REGISTRY} BUILD_TARGET="install" \

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ integration-test: $(SELECTED_PACKAGE) build-mock-management-plane-grpc
 	TEST_ENV="Container" CONTAINER_OS_TYPE=$(CONTAINER_OS_TYPE) BUILD_TARGET="install-agent-local" CONTAINER_NGINX_IMAGE_REGISTRY=${CONTAINER_NGINX_IMAGE_REGISTRY} \
 	PACKAGES_REPO=$(OSS_PACKAGES_REPO) PACKAGE_NAME=$(PACKAGE_NAME) BASE_IMAGE=$(BASE_IMAGE) DOCKERFILE_PATH=$(DOCKERFILE_PATH) IMAGE_PATH=$(IMAGE_PATH) TAG=${IMAGE_TAG} \
 	OS_VERSION=$(OS_VERSION) OS_RELEASE=$(OS_RELEASE) \
-	go test -v ./test/integration/installuninstall ./test/integration/managementplane ./test/integration/nginxless
+	go test -v ./test/integration/auxiliarycommandserver
 	
 official-image-integration-test: $(SELECTED_PACKAGE) build-mock-management-plane-grpc
 	TEST_ENV="Container" CONTAINER_OS_TYPE=$(CONTAINER_OS_TYPE) CONTAINER_NGINX_IMAGE_REGISTRY=${CONTAINER_NGINX_IMAGE_REGISTRY} BUILD_TARGET="install" \

--- a/test/config/agent/nginx-agent-with-auxiliary-command.conf
+++ b/test/config/agent/nginx-agent-with-auxiliary-command.conf
@@ -1,0 +1,26 @@
+#
+# /etc/nginx-agent/nginx-agent.conf
+#
+# Configuration file for NGINX Agent.
+#
+
+log:
+  level: debug
+
+command:
+  server:
+    host: managementPlane
+    port: 9092
+    type: grpc
+    
+auxiliary_command:
+    server:
+        host: managementPlaneAuxiliary
+        port: 9095
+        type: grpc  
+
+
+allowed_directories: 
+  - /etc/nginx
+  - /usr/local/etc/nginx
+  - /usr/share/nginx/modules

--- a/test/helpers/test_containers_utils.go
+++ b/test/helpers/test_containers_utils.go
@@ -263,6 +263,39 @@ func StartMockManagementPlaneGrpcContainer(
 	return container
 }
 
+func StartAuxiliaryMockManagementPlaneGrpcContainer(ctx context.Context, tb testing.TB,
+	containerNetwork *testcontainers.DockerNetwork,
+) testcontainers.Container {
+	tb.Helper()
+	req := testcontainers.ContainerRequest{
+		FromDockerfile: testcontainers.FromDockerfile{
+			Context:       "../../../",
+			Dockerfile:    "./test/integration/auxiliarycommandserver/Dockerfile",
+			KeepImage:     false,
+			PrintBuildLog: true,
+		},
+		ExposedPorts: []string{"9095/tcp", "9096/tcp"},
+		Networks: []string{
+			containerNetwork.Name,
+		},
+		NetworkAliases: map[string][]string{
+			containerNetwork.Name: {
+				"managementPlaneAuxiliary",
+			},
+		},
+		WaitingFor: wait.ForLog("Starting mock management plane gRPC server"),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+
+	require.NoError(tb, err)
+
+	return container
+}
+
 func ToPtr[T any](value T) *T {
 	return &value
 }
@@ -274,6 +307,7 @@ func LogAndTerminateContainers(
 	mockManagementPlaneContainer testcontainers.Container,
 	agentContainer testcontainers.Container,
 	expectNoErrorsInLogs bool,
+	auxiliaryMockManagementPlaneContainer testcontainers.Container,
 ) {
 	tb.Helper()
 
@@ -305,6 +339,21 @@ func LogAndTerminateContainers(
 		tb.Log(logs)
 
 		err = mockManagementPlaneContainer.Terminate(ctx)
+		require.NoError(tb, err)
+	}
+
+	if auxiliaryMockManagementPlaneContainer != nil {
+		tb.Log("======================== Logging Auxiliary Mock Management Container Logs ========================")
+		logReader, err = auxiliaryMockManagementPlaneContainer.Logs(ctx)
+		require.NoError(tb, err)
+
+		buf, err = io.ReadAll(logReader)
+		require.NoError(tb, err)
+		logs = string(buf)
+
+		tb.Log(logs)
+
+		err = auxiliaryMockManagementPlaneContainer.Terminate(ctx)
 		require.NoError(tb, err)
 	}
 }

--- a/test/integration/auxiliarycommandserver/Dockerfile
+++ b/test/integration/auxiliarycommandserver/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:buster-slim
+
+WORKDIR /mock-management-plane-grpc
+COPY ./build/mock-management-plane-grpc ./
+
+RUN mkdir config/
+
+CMD ["/mock-management-plane-grpc/server", "--grpcAddress", "0.0.0.0:9095", "--apiAddress", "0.0.0.0:9096", "--configDirectory", "/mock-management-plane-grpc/config", "--logLevel", "DEBUG"]

--- a/test/integration/auxiliarycommandserver/connection_test.go
+++ b/test/integration/auxiliarycommandserver/connection_test.go
@@ -6,23 +6,192 @@
 package auxiliarycommandserver
 
 import (
-	"testing"
-
+	"context"
+	"fmt"
+	"github.com/go-resty/resty/v2"
+	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
 	"github.com/nginx/agent/v3/test/integration/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"net"
+	"net/http"
+	"testing"
+	"time"
 )
 
-func TestAuxiliary_StartUp(t *testing.T) {
-	teardownTest := utils.SetupConnectionTest(t, true, false, true,
-		"../../config/agent/nginx-agent-with-auxiliary-command.conf")
-
-	defer teardownTest(t)
-
-	utils.VerifyConnection(t, 2, utils.MockManagementPlaneAPIAddress)
-	assert.False(t, t.Failed())
-	utils.VerifyUpdateDataPlaneHealth(t, utils.MockManagementPlaneAPIAddress)
-
-	utils.VerifyConnection(t, 2, utils.AuxiliaryMockManagementPlaneAPIAddress)
-	assert.False(t, t.Failed())
-	utils.VerifyUpdateDataPlaneHealth(t, utils.AuxiliaryMockManagementPlaneAPIAddress)
+type AuxiliaryTestSuite struct {
+	suite.Suite
+	teardownTest func(tb testing.TB)
+	instanceID   string
 }
+
+func (s *AuxiliaryTestSuite) SetupSuite() {
+	t := s.T()
+	// Expect errors in logs should be false for recconnection tests
+	// For now for these test we will skip checking the logs for errors
+	s.teardownTest = utils.SetupConnectionTest(t, false, false, true,
+		"../../config/agent/nginx-agent-with-auxiliary-command.conf")
+}
+
+func (s *AuxiliaryTestSuite) TearDownSuite() {
+
+	s.teardownTest(s.T())
+}
+
+func TestSuite(t *testing.T) {
+	suite.Run(t, new(AuxiliaryTestSuite))
+}
+
+func (s *AuxiliaryTestSuite) TestAuxiliary_Connection() {
+
+	s.instanceID = utils.VerifyConnection(s.T(), 2, utils.MockManagementPlaneAPIAddress)
+	assert.False(s.T(), s.T().Failed())
+	utils.VerifyUpdateDataPlaneHealth(s.T(), utils.MockManagementPlaneAPIAddress)
+
+	utils.VerifyConnection(s.T(), 2, utils.AuxiliaryMockManagementPlaneAPIAddress)
+	assert.False(s.T(), s.T().Failed())
+	utils.VerifyUpdateDataPlaneHealth(s.T(), utils.AuxiliaryMockManagementPlaneAPIAddress)
+
+}
+
+func (s *AuxiliaryTestSuite) TestAuxiliary_Reconnection() {
+	ctx := context.Background()
+	timeout := 15 * time.Second
+
+	originalID := utils.VerifyConnection(s.T(), 2, utils.AuxiliaryMockManagementPlaneAPIAddress)
+	stopErr := utils.AuxiliaryMockManagementPlaneGrpcContainer.Stop(context.Background(), &timeout)
+
+	require.NoError(s.T(), stopErr)
+
+	utils.VerifyConnection(s.T(), 2, utils.MockManagementPlaneAPIAddress)
+	assert.False(s.T(), s.T().Failed())
+
+	startErr := utils.AuxiliaryMockManagementPlaneGrpcContainer.Start(ctx)
+	require.NoError(s.T(), startErr)
+
+	ipAddress, err := utils.AuxiliaryMockManagementPlaneGrpcContainer.Host(ctx)
+	require.NoError(s.T(), err)
+	ports, err := utils.AuxiliaryMockManagementPlaneGrpcContainer.Ports(ctx)
+	require.NoError(s.T(), err)
+	utils.AuxiliaryMockManagementPlaneAPIAddress = net.JoinHostPort(ipAddress, ports["9096/tcp"][0].HostPort)
+
+	currentID := utils.VerifyConnection(s.T(), 2, utils.AuxiliaryMockManagementPlaneAPIAddress)
+	assert.Equal(s.T(), originalID, currentID)
+}
+
+func (s *AuxiliaryTestSuite) TestAuxiliary_DataplaneHealthRequest() {
+
+	utils.ClearManagementPlaneResponses(s.T(), utils.MockManagementPlaneAPIAddress)
+	utils.ClearManagementPlaneResponses(s.T(), utils.AuxiliaryMockManagementPlaneAPIAddress)
+
+	request := `{
+			"message_meta": {
+				"message_id": "5d0fa83e-351c-4009-90cd-1f2acce2d184",
+				"correlation_id": "79794c1c-8e91-47c1-a92c-b9a0c3f1a263",
+				"timestamp": "2023-01-15T01:30:15.01Z"
+			},
+			"health_request": {}
+		}`
+
+	client := resty.New()
+	client.SetRetryCount(utils.RetryCount).SetRetryWaitTime(utils.RetryWaitTime).SetRetryMaxWaitTime(
+		utils.RetryMaxWaitTime)
+
+	url := fmt.Sprintf("http://%s/api/v1/requests", utils.MockManagementPlaneAPIAddress)
+	resp, err := client.R().EnableTrace().SetBody(request).Post(url)
+
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), http.StatusOK, resp.StatusCode())
+
+	// Check command server has 2 ManagementPlaneResponses as it has sent the request
+	commandResponses := utils.ManagementPlaneResponses(s.T(), 1, utils.MockManagementPlaneAPIAddress)
+	assert.Equal(s.T(), mpi.CommandResponse_COMMAND_STATUS_OK, commandResponses[0].GetCommandResponse().GetStatus())
+	assert.Equal(s.T(), "Successfully sent health status update", commandResponses[0].GetCommandResponse().GetMessage())
+	assert.False(s.T(), s.T().Failed())
+
+	// Check auxiliary server still only has 1 ManagementPlaneResponses as it didn't sent the request
+	utils.ManagementPlaneResponses(s.T(), 0, utils.AuxiliaryMockManagementPlaneAPIAddress)
+	assert.False(s.T(), s.T().Failed())
+}
+
+func (s *AuxiliaryTestSuite) TestAuxiliary_FileWatcher() {
+	// Clear any previous responses from previous tests
+	utils.ClearManagementPlaneResponses(s.T(), utils.MockManagementPlaneAPIAddress)
+	utils.ClearManagementPlaneResponses(s.T(), utils.AuxiliaryMockManagementPlaneAPIAddress)
+	ctx := context.Background()
+
+	err := utils.Container.CopyFileToContainer(
+		ctx,
+		"../../config/nginx/nginx-with-server-block-access-log.conf",
+		"/etc/nginx/nginx.conf",
+		0o666,
+	)
+	require.NoError(s.T(), err)
+
+	// Check command server has 2 ManagementPlaneResponses from updating a file on disk
+	commandResponses := utils.ManagementPlaneResponses(s.T(), 1, utils.MockManagementPlaneAPIAddress)
+	assert.Equal(s.T(), mpi.CommandResponse_COMMAND_STATUS_OK, commandResponses[0].GetCommandResponse().GetStatus())
+	assert.Equal(s.T(), "Successfully updated all files", commandResponses[0].GetCommandResponse().GetMessage())
+
+	// Check auxiliary server has 2 ManagementPlaneResponses from updating a file on disk
+	auxResponses := utils.ManagementPlaneResponses(s.T(), 1, utils.AuxiliaryMockManagementPlaneAPIAddress)
+	assert.Equal(s.T(), mpi.CommandResponse_COMMAND_STATUS_OK, auxResponses[0].GetCommandResponse().GetStatus())
+	assert.Equal(s.T(), "Successfully updated all files", auxResponses[0].GetCommandResponse().GetMessage())
+}
+
+//func (s *AuxiliaryTestSuite) TestAuxiliary_ConfigApply() {
+//	s.instanceID = utils.VerifyConnection(s.T(), 2, utils.MockManagementPlaneAPIAddress)
+//	// Perform config apply
+//	// Check new config is in both Mocks
+//	// Check using hash with new API endpoint which was added to get the file overview
+//	utils.ClearManagementPlaneResponses(s.T(), utils.MockManagementPlaneAPIAddress)
+//	utils.ClearManagementPlaneResponses(s.T(), utils.AuxiliaryMockManagementPlaneAPIAddress)
+//
+//	ctx := context.Background()
+//
+//	newConfigFile := "../../config/nginx/nginx-with-test-location.conf"
+//
+//	if os.Getenv("IMAGE_PATH") == "/nginx-plus/agent" {
+//		newConfigFile = "../../config/nginx/nginx-plus-with-test-location.conf"
+//	}
+//
+//	err := utils.MockManagementPlaneGrpcContainer.CopyFileToContainer(
+//		ctx,
+//		newConfigFile,
+//		fmt.Sprintf("/mock-management-plane-grpc/config/%s/etc/nginx/nginx.conf", s.instanceID),
+//		0o666,
+//	)
+//
+//	require.NoError(s.T(), err)
+//
+//	utils.PerformConfigApply(s.T(), s.instanceID, utils.MockManagementPlaneAPIAddress)
+//
+//	commandResponses := utils.ManagementPlaneResponses(s.T(), 2, utils.MockManagementPlaneAPIAddress)
+//
+//	sort.Slice(commandResponses, func(i, j int) bool {
+//		return commandResponses[i].GetCommandResponse().GetMessage() < commandResponses[j].GetCommandResponse().GetMessage()
+//	})
+//
+//	assert.Equal(s.T(), mpi.CommandResponse_COMMAND_STATUS_OK, commandResponses[0].GetCommandResponse().GetStatus())
+//	assert.Equal(s.T(), "Config apply successful", commandResponses[0].GetCommandResponse().GetMessage())
+//	assert.Equal(s.T(), mpi.CommandResponse_COMMAND_STATUS_OK, commandResponses[1].GetCommandResponse().GetStatus())
+//	assert.Equal(s.T(), "Successfully updated all files", commandResponses[1].GetCommandResponse().GetMessage())
+//
+//	auxResponses := utils.ManagementPlaneResponses(s.T(), 1, utils.AuxiliaryMockManagementPlaneAPIAddress)
+//	assert.Equal(s.T(), mpi.CommandResponse_COMMAND_STATUS_OK, auxResponses[1].GetCommandResponse().GetStatus())
+//	assert.Equal(s.T(), "Successfully updated all files", auxResponses[1].GetCommandResponse().GetMessage())
+//
+//	overview := utils.CurrentFileOverview(s.T(), s.instanceID, utils.MockManagementPlaneAPIAddress)
+//	overview2 := utils.CurrentFileOverview(s.T(), s.instanceID, utils.AuxiliaryMockManagementPlaneAPIAddress)
+//	s.T().Logf("Overview: %v", overview.ConfigVersion)
+//	s.T().Logf("Overview 2: %v", overview2.ConfigVersion)
+//}
+
+//
+//func (s *AuxiliaryTestSuite) TestAuxiliary_ConfigApplyInvalid() {
+//	// Perform config apply with aux
+//	// Check new config is broken
+//	// Check using hash with new API endpoint which was added to get the file overview
+//
+//}

--- a/test/integration/auxiliarycommandserver/connection_test.go
+++ b/test/integration/auxiliarycommandserver/connection_test.go
@@ -127,7 +127,7 @@ func (s *AuxiliaryTestSuite) TestAuxiliary_FileWatcher() {
 	// Check command server has 2 ManagementPlaneResponses from updating a file on disk
 	commandResponses := utils.ManagementPlaneResponses(s.T(), 1, utils.MockManagementPlaneAPIAddress)
 	s.Equal(mpi.CommandResponse_COMMAND_STATUS_OK, commandResponses[0].GetCommandResponse().GetStatus())
-	git s.Equal("Successfully updated all files", commandResponses[0].GetCommandResponse().GetMessage())
+	s.Equal("Successfully updated all files", commandResponses[0].GetCommandResponse().GetMessage())
 
 	// Check auxiliary server has 2 ManagementPlaneResponses from updating a file on disk
 	auxResponses := utils.ManagementPlaneResponses(s.T(), 1, utils.AuxiliaryMockManagementPlaneAPIAddress)

--- a/test/integration/auxiliarycommandserver/connection_test.go
+++ b/test/integration/auxiliarycommandserver/connection_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) F5, Inc.
+//
+// This source code is licensed under the Apache License, Version 2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+
+package auxiliarycommandserver
+
+import (
+	"testing"
+
+	"github.com/nginx/agent/v3/test/integration/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuxiliary_StartUp(t *testing.T) {
+	teardownTest := utils.SetupConnectionTest(t, true, false, true,
+		"../../config/agent/nginx-agent-with-auxiliary-command.conf")
+
+	defer teardownTest(t)
+
+	utils.VerifyConnection(t, 2, utils.MockManagementPlaneAPIAddress)
+	assert.False(t, t.Failed())
+	utils.VerifyUpdateDataPlaneHealth(t, utils.MockManagementPlaneAPIAddress)
+
+	utils.VerifyConnection(t, 2, utils.AuxiliaryMockManagementPlaneAPIAddress)
+	assert.False(t, t.Failed())
+	utils.VerifyUpdateDataPlaneHealth(t, utils.AuxiliaryMockManagementPlaneAPIAddress)
+}

--- a/test/integration/installuninstall/install_uninstall_test.go
+++ b/test/integration/installuninstall/install_uninstall_test.go
@@ -66,6 +66,7 @@ func installUninstallSetup(tb testing.TB, expectNoErrorsInLogs bool) (testcontai
 			nil,
 			testContainer,
 			expectNoErrorsInLogs,
+			nil,
 		)
 	}
 }

--- a/test/integration/managementplane/config_apply_test.go
+++ b/test/integration/managementplane/config_apply_test.go
@@ -26,11 +26,11 @@ const (
 
 func TestGrpc_ConfigApply(t *testing.T) {
 	ctx := context.Background()
-	teardownTest := utils.SetupConnectionTest(t, false, false,
+	teardownTest := utils.SetupConnectionTest(t, false, false, false,
 		"../../config/agent/nginx-config-with-grpc-client.conf")
 	defer teardownTest(t)
 
-	nginxInstanceID := utils.VerifyConnection(t, 2)
+	nginxInstanceID := utils.VerifyConnection(t, 2, utils.MockManagementPlaneAPIAddress)
 
 	responses := utils.ManagementPlaneResponses(t, 1)
 	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
@@ -119,11 +119,11 @@ func TestGrpc_ConfigApply(t *testing.T) {
 
 func TestGrpc_ConfigApply_Chunking(t *testing.T) {
 	ctx := context.Background()
-	teardownTest := utils.SetupConnectionTest(t, false, false,
+	teardownTest := utils.SetupConnectionTest(t, false, false, false,
 		"../../config/agent/nginx-config-with-max-file-size.conf")
 	defer teardownTest(t)
 
-	nginxInstanceID := utils.VerifyConnection(t, 2)
+	nginxInstanceID := utils.VerifyConnection(t, 2, utils.MockManagementPlaneAPIAddress)
 
 	responses := utils.ManagementPlaneResponses(t, 1)
 	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())

--- a/test/integration/managementplane/config_apply_test.go
+++ b/test/integration/managementplane/config_apply_test.go
@@ -32,14 +32,14 @@ func TestGrpc_ConfigApply(t *testing.T) {
 
 	nginxInstanceID := utils.VerifyConnection(t, 2, utils.MockManagementPlaneAPIAddress)
 
-	responses := utils.ManagementPlaneResponses(t, 1)
+	responses := utils.ManagementPlaneResponses(t, 1, utils.MockManagementPlaneAPIAddress)
 	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
 	assert.Equal(t, "Successfully updated all files", responses[0].GetCommandResponse().GetMessage())
 
 	t.Run("Test 1: No config changes", func(t *testing.T) {
-		utils.ClearManagementPlaneResponses(t)
-		utils.PerformConfigApply(t, nginxInstanceID)
-		responses = utils.ManagementPlaneResponses(t, 1)
+		utils.ClearManagementPlaneResponses(t, utils.MockManagementPlaneAPIAddress)
+		utils.PerformConfigApply(t, nginxInstanceID, utils.MockManagementPlaneAPIAddress)
+		responses = utils.ManagementPlaneResponses(t, 1, utils.MockManagementPlaneAPIAddress)
 		t.Logf("Config apply responses: %v", responses)
 
 		assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
@@ -47,7 +47,7 @@ func TestGrpc_ConfigApply(t *testing.T) {
 	})
 
 	t.Run("Test 2: Valid config", func(t *testing.T) {
-		utils.ClearManagementPlaneResponses(t)
+		utils.ClearManagementPlaneResponses(t, utils.MockManagementPlaneAPIAddress)
 		newConfigFile := "../../config/nginx/nginx-with-test-location.conf"
 
 		if os.Getenv("IMAGE_PATH") == "/nginx-plus/agent" {
@@ -62,9 +62,9 @@ func TestGrpc_ConfigApply(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		utils.PerformConfigApply(t, nginxInstanceID)
+		utils.PerformConfigApply(t, nginxInstanceID, utils.MockManagementPlaneAPIAddress)
 
-		responses = utils.ManagementPlaneResponses(t, 2)
+		responses = utils.ManagementPlaneResponses(t, 2, utils.MockManagementPlaneAPIAddress)
 		t.Logf("Config apply responses: %v", responses)
 
 		sort.Slice(responses, func(i, j int) bool {
@@ -78,7 +78,7 @@ func TestGrpc_ConfigApply(t *testing.T) {
 	})
 
 	t.Run("Test 3: Invalid config", func(t *testing.T) {
-		utils.ClearManagementPlaneResponses(t)
+		utils.ClearManagementPlaneResponses(t, utils.MockManagementPlaneAPIAddress)
 		err := utils.MockManagementPlaneGrpcContainer.CopyFileToContainer(
 			ctx,
 			"../../config/nginx/invalid-nginx.conf",
@@ -87,9 +87,9 @@ func TestGrpc_ConfigApply(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		utils.PerformConfigApply(t, nginxInstanceID)
+		utils.PerformConfigApply(t, nginxInstanceID, utils.MockManagementPlaneAPIAddress)
 
-		responses = utils.ManagementPlaneResponses(t, 2)
+		responses = utils.ManagementPlaneResponses(t, 2, utils.MockManagementPlaneAPIAddress)
 		t.Logf("Config apply responses: %v", responses)
 
 		assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_ERROR, responses[0].GetCommandResponse().GetStatus())
@@ -101,10 +101,10 @@ func TestGrpc_ConfigApply(t *testing.T) {
 	})
 
 	t.Run("Test 4: File not in allowed directory", func(t *testing.T) {
-		utils.ClearManagementPlaneResponses(t)
+		utils.ClearManagementPlaneResponses(t, utils.MockManagementPlaneAPIAddress)
 		utils.PerformInvalidConfigApply(t, nginxInstanceID)
 
-		responses = utils.ManagementPlaneResponses(t, 1)
+		responses = utils.ManagementPlaneResponses(t, 1, utils.MockManagementPlaneAPIAddress)
 		t.Logf("Config apply responses: %v", responses)
 
 		assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_FAILURE, responses[0].GetCommandResponse().GetStatus())
@@ -125,11 +125,11 @@ func TestGrpc_ConfigApply_Chunking(t *testing.T) {
 
 	nginxInstanceID := utils.VerifyConnection(t, 2, utils.MockManagementPlaneAPIAddress)
 
-	responses := utils.ManagementPlaneResponses(t, 1)
+	responses := utils.ManagementPlaneResponses(t, 1, utils.MockManagementPlaneAPIAddress)
 	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
 	assert.Equal(t, "Successfully updated all files", responses[0].GetCommandResponse().GetMessage())
 
-	utils.ClearManagementPlaneResponses(t)
+	utils.ClearManagementPlaneResponses(t, utils.MockManagementPlaneAPIAddress)
 
 	newConfigFile := "../../config/nginx/nginx-1mb-file.conf"
 
@@ -141,9 +141,9 @@ func TestGrpc_ConfigApply_Chunking(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	utils.PerformConfigApply(t, nginxInstanceID)
+	utils.PerformConfigApply(t, nginxInstanceID, utils.MockManagementPlaneAPIAddress)
 
-	responses = utils.ManagementPlaneResponses(t, 2)
+	responses = utils.ManagementPlaneResponses(t, 2, utils.MockManagementPlaneAPIAddress)
 	t.Logf("Config apply responses: %v", responses)
 
 	sort.Slice(responses, func(i, j int) bool {

--- a/test/integration/managementplane/config_upload_test.go
+++ b/test/integration/managementplane/config_upload_test.go
@@ -19,11 +19,11 @@ import (
 )
 
 func TestGrpc_ConfigUpload(t *testing.T) {
-	teardownTest := utils.SetupConnectionTest(t, true, false,
+	teardownTest := utils.SetupConnectionTest(t, true, false, false,
 		"../../config/agent/nginx-config-with-grpc-client.conf")
 	defer teardownTest(t)
 
-	nginxInstanceID := utils.VerifyConnection(t, 2)
+	nginxInstanceID := utils.VerifyConnection(t, 2, utils.MockManagementPlaneAPIAddress)
 	assert.False(t, t.Failed())
 
 	responses := utils.ManagementPlaneResponses(t, 1)

--- a/test/integration/managementplane/config_upload_test.go
+++ b/test/integration/managementplane/config_upload_test.go
@@ -26,7 +26,7 @@ func TestGrpc_ConfigUpload(t *testing.T) {
 	nginxInstanceID := utils.VerifyConnection(t, 2, utils.MockManagementPlaneAPIAddress)
 	assert.False(t, t.Failed())
 
-	responses := utils.ManagementPlaneResponses(t, 1)
+	responses := utils.ManagementPlaneResponses(t, 1, utils.MockManagementPlaneAPIAddress)
 
 	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
 	assert.Equal(t, "Successfully updated all files", responses[0].GetCommandResponse().GetMessage())
@@ -58,7 +58,7 @@ func TestGrpc_ConfigUpload(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode())
 
-	responses = utils.ManagementPlaneResponses(t, 2)
+	responses = utils.ManagementPlaneResponses(t, 2, utils.MockManagementPlaneAPIAddress)
 
 	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
 	assert.Equal(t, "Successfully updated all files", responses[0].GetCommandResponse().GetMessage())

--- a/test/integration/managementplane/file_watcher_test.go
+++ b/test/integration/managementplane/file_watcher_test.go
@@ -33,11 +33,11 @@ func TestGrpc_FileWatcher(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	responses := utils.ManagementPlaneResponses(t, 2)
+	responses := utils.ManagementPlaneResponses(t, 2, utils.MockManagementPlaneAPIAddress)
 	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
 	assert.Equal(t, "Successfully updated all files", responses[0].GetCommandResponse().GetMessage())
 	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[1].GetCommandResponse().GetStatus())
 	assert.Equal(t, "Successfully updated all files", responses[1].GetCommandResponse().GetMessage())
 
-	utils.VerifyUpdateDataPlaneStatus(t)
+	utils.VerifyUpdateDataPlaneStatus(t, utils.MockManagementPlaneAPIAddress)
 }

--- a/test/integration/managementplane/file_watcher_test.go
+++ b/test/integration/managementplane/file_watcher_test.go
@@ -18,11 +18,11 @@ import (
 
 func TestGrpc_FileWatcher(t *testing.T) {
 	ctx := context.Background()
-	teardownTest := utils.SetupConnectionTest(t, true, false,
+	teardownTest := utils.SetupConnectionTest(t, true, false, false,
 		"../../config/agent/nginx-config-with-grpc-client.conf")
 	defer teardownTest(t)
 
-	utils.VerifyConnection(t, 2)
+	utils.VerifyConnection(t, 2, utils.MockManagementPlaneAPIAddress)
 	assert.False(t, t.Failed())
 
 	err := utils.Container.CopyFileToContainer(

--- a/test/integration/managementplane/grpc_management_plane_api_test.go
+++ b/test/integration/managementplane/grpc_management_plane_api_test.go
@@ -66,7 +66,7 @@ func TestGrpc_DataplaneHealthRequest(t *testing.T) {
 
 	utils.VerifyConnection(t, 2, utils.MockManagementPlaneAPIAddress)
 
-	responses := utils.ManagementPlaneResponses(t, 1)
+	responses := utils.ManagementPlaneResponses(t, 1, utils.MockManagementPlaneAPIAddress)
 	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())
 	assert.Equal(t, "Successfully updated all files", responses[0].GetCommandResponse().GetMessage())
 
@@ -91,7 +91,7 @@ func TestGrpc_DataplaneHealthRequest(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode())
 
-	responses = utils.ManagementPlaneResponses(t, 2)
+	responses = utils.ManagementPlaneResponses(t, 2, utils.MockManagementPlaneAPIAddress)
 
 	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[1].GetCommandResponse().GetStatus())
 	assert.Equal(t, "Successfully sent health status update", responses[1].GetCommandResponse().GetMessage())

--- a/test/integration/managementplane/grpc_management_plane_api_test.go
+++ b/test/integration/managementplane/grpc_management_plane_api_test.go
@@ -23,13 +23,13 @@ import (
 
 func TestGrpc_Reconnection(t *testing.T) {
 	ctx := context.Background()
-	teardownTest := utils.SetupConnectionTest(t, false, false,
+	teardownTest := utils.SetupConnectionTest(t, false, false, false,
 		"../../config/agent/nginx-config-with-grpc-client.conf")
 	defer teardownTest(t)
 
 	timeout := 15 * time.Second
 
-	originalID := utils.VerifyConnection(t, 2)
+	originalID := utils.VerifyConnection(t, 2, utils.MockManagementPlaneAPIAddress)
 
 	stopErr := utils.MockManagementPlaneGrpcContainer.Stop(ctx, &timeout)
 
@@ -44,27 +44,27 @@ func TestGrpc_Reconnection(t *testing.T) {
 	require.NoError(t, err)
 	utils.MockManagementPlaneAPIAddress = net.JoinHostPort(ipAddress, ports["9093/tcp"][0].HostPort)
 
-	currentID := utils.VerifyConnection(t, 2)
+	currentID := utils.VerifyConnection(t, 2, utils.MockManagementPlaneAPIAddress)
 	assert.Equal(t, originalID, currentID)
 }
 
 // Verify that the agent sends a connection request and an update data plane status request
 func TestGrpc_StartUp(t *testing.T) {
-	teardownTest := utils.SetupConnectionTest(t, true, false,
+	teardownTest := utils.SetupConnectionTest(t, true, false, false,
 		"../../config/agent/nginx-config-with-grpc-client.conf")
 	defer teardownTest(t)
 
-	utils.VerifyConnection(t, 2)
+	utils.VerifyConnection(t, 2, utils.MockManagementPlaneAPIAddress)
 	assert.False(t, t.Failed())
-	utils.VerifyUpdateDataPlaneHealth(t)
+	utils.VerifyUpdateDataPlaneHealth(t, utils.MockManagementPlaneAPIAddress)
 }
 
 func TestGrpc_DataplaneHealthRequest(t *testing.T) {
-	teardownTest := utils.SetupConnectionTest(t, true, false,
+	teardownTest := utils.SetupConnectionTest(t, true, false, false,
 		"../../config/agent/nginx-config-with-grpc-client.conf")
 	defer teardownTest(t)
 
-	utils.VerifyConnection(t, 2)
+	utils.VerifyConnection(t, 2, utils.MockManagementPlaneAPIAddress)
 
 	responses := utils.ManagementPlaneResponses(t, 1)
 	assert.Equal(t, mpi.CommandResponse_COMMAND_STATUS_OK, responses[0].GetCommandResponse().GetStatus())

--- a/test/integration/nginxless/nginx_less_mpi_connection_test.go
+++ b/test/integration/nginxless/nginx_less_mpi_connection_test.go
@@ -15,10 +15,10 @@ import (
 
 // Verify that the agent sends a connection request to Management Plane even when Nginx is not present
 func TestNginxLessGrpc_Connection(t *testing.T) {
-	teardownTest := utils.SetupConnectionTest(t, true, true,
+	teardownTest := utils.SetupConnectionTest(t, true, true, false,
 		"../../config/agent/nginx-config-with-grpc-client.conf")
 	defer teardownTest(t)
 
-	utils.VerifyConnection(t, 1)
+	utils.VerifyConnection(t, 1, utils.MockManagementPlaneAPIAddress)
 	assert.False(t, t.Failed())
 }

--- a/test/integration/utils/config_apply_utils.go
+++ b/test/integration/utils/config_apply_utils.go
@@ -22,7 +22,10 @@ const (
 	RetryMaxWaitTime = 6 * time.Second
 )
 
-var MockManagementPlaneAPIAddress string
+var (
+	MockManagementPlaneAPIAddress          string
+	AuxiliaryMockManagementPlaneAPIAddress string
+)
 
 func PerformConfigApply(t *testing.T, nginxInstanceID string) {
 	t.Helper()

--- a/test/integration/utils/config_apply_utils.go
+++ b/test/integration/utils/config_apply_utils.go
@@ -58,13 +58,13 @@ func CurrentFileOverview(t *testing.T, nginxInstanceID, mockManagementPlaneAPIAd
 
 	responseData := resp.Body()
 
-	overview := mpi.FileOverview{}
+	overview := mpi.GetOverviewResponse{}
 
 	pb := protojson.UnmarshalOptions{DiscardUnknown: true}
 	unmarshalErr := pb.Unmarshal(responseData, &overview)
 	require.NoError(t, unmarshalErr)
 
-	return &overview
+	return overview.GetOverview()
 }
 
 func PerformInvalidConfigApply(t *testing.T, nginxInstanceID string) {

--- a/test/integration/utils/config_apply_utils.go
+++ b/test/integration/utils/config_apply_utils.go
@@ -7,11 +7,12 @@ package utils
 
 import (
 	"fmt"
-	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
-	"google.golang.org/protobuf/encoding/protojson"
 	"net/http"
 	"testing"
 	"time"
+
+	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/stretchr/testify/assert"
@@ -29,7 +30,7 @@ var (
 	AuxiliaryMockManagementPlaneAPIAddress string
 )
 
-func PerformConfigApply(t *testing.T, nginxInstanceID string, mockManagementPlaneAPIAddress string) {
+func PerformConfigApply(t *testing.T, nginxInstanceID, mockManagementPlaneAPIAddress string) {
 	t.Helper()
 
 	client := resty.New()
@@ -43,7 +44,7 @@ func PerformConfigApply(t *testing.T, nginxInstanceID string, mockManagementPlan
 	assert.Equal(t, http.StatusOK, resp.StatusCode())
 }
 
-func CurrentFileOverview(t *testing.T, nginxInstanceID string, mockManagementPlaneAPIAddress string) *mpi.FileOverview {
+func CurrentFileOverview(t *testing.T, nginxInstanceID, mockManagementPlaneAPIAddress string) *mpi.FileOverview {
 	t.Helper()
 
 	client := resty.New()

--- a/test/integration/utils/grpc_management_plane_utils.go
+++ b/test/integration/utils/grpc_management_plane_utils.go
@@ -215,7 +215,9 @@ func setupLocalEnvironment(tb testing.TB) {
 	}(tb)
 }
 
-func ManagementPlaneResponses(t *testing.T, numberOfExpectedResponses int, mockManagementPlaneAPIAddress string) []*mpi.DataPlaneResponse {
+func ManagementPlaneResponses(t *testing.T, numberOfExpectedResponses int,
+	mockManagementPlaneAPIAddress string,
+) []*mpi.DataPlaneResponse {
 	t.Helper()
 
 	client := resty.New()

--- a/test/integration/utils/grpc_management_plane_utils.go
+++ b/test/integration/utils/grpc_management_plane_utils.go
@@ -215,7 +215,7 @@ func setupLocalEnvironment(tb testing.TB) {
 	}(tb)
 }
 
-func ManagementPlaneResponses(t *testing.T, numberOfExpectedResponses int) []*mpi.DataPlaneResponse {
+func ManagementPlaneResponses(t *testing.T, numberOfExpectedResponses int, mockManagementPlaneAPIAddress string) []*mpi.DataPlaneResponse {
 	t.Helper()
 
 	client := resty.New()
@@ -233,7 +233,7 @@ func ManagementPlaneResponses(t *testing.T, numberOfExpectedResponses int) []*mp
 		},
 	)
 
-	url := fmt.Sprintf("http://%s/api/v1/responses", MockManagementPlaneAPIAddress)
+	url := fmt.Sprintf("http://%s/api/v1/responses", mockManagementPlaneAPIAddress)
 	resp, err := client.R().EnableTrace().Get(url)
 
 	require.NoError(t, err)
@@ -256,12 +256,12 @@ func ManagementPlaneResponses(t *testing.T, numberOfExpectedResponses int) []*mp
 	return response
 }
 
-func ClearManagementPlaneResponses(t *testing.T) {
+func ClearManagementPlaneResponses(t *testing.T, mockManagementPlaneAPIAddress string) {
 	t.Helper()
 
 	client := resty.New()
 
-	url := fmt.Sprintf("http://%s/api/v1/responses", MockManagementPlaneAPIAddress)
+	url := fmt.Sprintf("http://%s/api/v1/responses", mockManagementPlaneAPIAddress)
 	resp, err := client.R().EnableTrace().Delete(url)
 
 	require.NoError(t, err)
@@ -422,14 +422,14 @@ func VerifyUpdateDataPlaneHealth(t *testing.T, mockManagementPlaneAPIAddress str
 	assert.Equal(t, mpi.InstanceHealth_INSTANCE_HEALTH_STATUS_HEALTHY, healths[0].GetInstanceHealthStatus())
 }
 
-func VerifyUpdateDataPlaneStatus(t *testing.T) {
+func VerifyUpdateDataPlaneStatus(t *testing.T, mockManagementPlaneAPIAddress string) {
 	t.Helper()
 
 	client := resty.New()
 
 	client.SetRetryCount(statusRetryCount).SetRetryWaitTime(retryWait).SetRetryMaxWaitTime(retryMaxWait)
 
-	url := fmt.Sprintf("http://%s/api/v1/status", MockManagementPlaneAPIAddress)
+	url := fmt.Sprintf("http://%s/api/v1/status", mockManagementPlaneAPIAddress)
 
 	resp, err := client.R().EnableTrace().Get(url)
 

--- a/test/integration/utils/grpc_management_plane_utils.go
+++ b/test/integration/utils/grpc_management_plane_utils.go
@@ -31,9 +31,11 @@ import (
 )
 
 var (
-	Container                        testcontainers.Container
-	MockManagementPlaneGrpcContainer testcontainers.Container
-	MockManagementPlaneGrpcAddress   string
+	Container                                 testcontainers.Container
+	MockManagementPlaneGrpcContainer          testcontainers.Container
+	AuxiliaryMockManagementPlaneGrpcContainer testcontainers.Container
+	MockManagementPlaneGrpcAddress            string
+	AuxiliaryMockManagementPlaneGrpcAddress   string
 )
 
 const (
@@ -60,12 +62,14 @@ type (
 	}
 )
 
-func SetupConnectionTest(tb testing.TB, expectNoErrorsInLogs, nginxless bool, agentConfig string) func(tb testing.TB) {
+func SetupConnectionTest(tb testing.TB, expectNoErrorsInLogs, nginxless, auxiliaryServer bool,
+	agentConfig string,
+) func(tb testing.TB) {
 	tb.Helper()
 	ctx := context.Background()
 
 	if os.Getenv("TEST_ENV") == "Container" {
-		setupContainerEnvironment(ctx, tb, nginxless, agentConfig)
+		setupContainerEnvironment(ctx, tb, nginxless, auxiliaryServer, agentConfig)
 	} else {
 		setupLocalEnvironment(tb)
 	}
@@ -80,18 +84,25 @@ func SetupConnectionTest(tb testing.TB, expectNoErrorsInLogs, nginxless bool, ag
 				MockManagementPlaneGrpcContainer,
 				Container,
 				expectNoErrorsInLogs,
+				AuxiliaryMockManagementPlaneGrpcContainer,
 			)
 		}
 	}
 }
 
 // setupContainerEnvironment sets up the container environment for testing.
-func setupContainerEnvironment(ctx context.Context, tb testing.TB, nginxless bool, agentConfig string) {
+// nolint: revive
+func setupContainerEnvironment(ctx context.Context, tb testing.TB, nginxless, auxiliaryServer bool,
+	agentConfig string,
+) {
 	tb.Helper()
 	tb.Log("Running tests in a container environment")
 
 	containerNetwork := createContainerNetwork(ctx, tb)
 	setupMockManagementPlaneGrpc(ctx, tb, containerNetwork)
+	if auxiliaryServer {
+		setupAuxiliaryMockManagementPlaneGrpc(ctx, tb, containerNetwork)
+	}
 
 	params := &helpers.Parameters{
 		NginxAgentConfigPath: agentConfig,
@@ -132,6 +143,24 @@ func setupMockManagementPlaneGrpc(ctx context.Context, tb testing.TB, containerN
 
 	MockManagementPlaneAPIAddress = net.JoinHostPort(ipAddress, ports["9093/tcp"][0].HostPort)
 	tb.Logf("Mock management API server running on %s", MockManagementPlaneAPIAddress)
+}
+
+func setupAuxiliaryMockManagementPlaneGrpc(ctx context.Context, tb testing.TB,
+	containerNetwork *testcontainers.DockerNetwork,
+) {
+	tb.Helper()
+	AuxiliaryMockManagementPlaneGrpcContainer = helpers.StartAuxiliaryMockManagementPlaneGrpcContainer(ctx,
+		tb, containerNetwork)
+	AuxiliaryMockManagementPlaneGrpcAddress = "managementPlaneAuxiliary:9095"
+	tb.Logf("Auxiliary mock management gRPC server running on %s", AuxiliaryMockManagementPlaneGrpcAddress)
+
+	ipAddress, err := AuxiliaryMockManagementPlaneGrpcContainer.Host(ctx)
+	require.NoError(tb, err)
+	ports, err := AuxiliaryMockManagementPlaneGrpcContainer.Ports(ctx)
+	require.NoError(tb, err)
+
+	AuxiliaryMockManagementPlaneAPIAddress = net.JoinHostPort(ipAddress, ports["9096/tcp"][0].HostPort)
+	tb.Logf("Auxiliary mock management API server running on %s", AuxiliaryMockManagementPlaneAPIAddress)
 }
 
 // setupNginxContainer configures and starts the NGINX container.
@@ -239,7 +268,7 @@ func ClearManagementPlaneResponses(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode())
 }
 
-func VerifyConnection(t *testing.T, instancesLength int) string {
+func VerifyConnection(t *testing.T, instancesLength int, mockManagementPlaneAPIAddress string) string {
 	t.Helper()
 
 	client := resty.New()
@@ -255,7 +284,7 @@ func VerifyConnection(t *testing.T, instancesLength int) string {
 			return r.StatusCode() == http.StatusNotFound || unmarshalErr != nil
 		},
 	)
-	url := fmt.Sprintf("http://%s/api/v1/connection", MockManagementPlaneAPIAddress)
+	url := fmt.Sprintf("http://%s/api/v1/connection", mockManagementPlaneAPIAddress)
 	t.Logf("Connecting to %s", url)
 	resp, err := client.R().EnableTrace().Get(url)
 
@@ -332,7 +361,7 @@ func VerifyConnection(t *testing.T, instancesLength int) string {
 	return nginxInstanceID
 }
 
-func VerifyUpdateDataPlaneHealth(t *testing.T) {
+func VerifyUpdateDataPlaneHealth(t *testing.T, mockManagementPlaneAPIAddress string) {
 	t.Helper()
 
 	client := resty.New()
@@ -346,7 +375,7 @@ func VerifyUpdateDataPlaneHealth(t *testing.T) {
 		},
 	)
 
-	url := fmt.Sprintf("http://%s/api/v1/health", MockManagementPlaneAPIAddress)
+	url := fmt.Sprintf("http://%s/api/v1/health", mockManagementPlaneAPIAddress)
 
 	resp, err := client.R().EnableTrace().Get(url)
 


### PR DESCRIPTION
### Proposed changes

Added integration tests with multiple management planes for: m
- connection
- reconnection 
- file watcher 
- health request 
- config apply 
- invalid config apply from aux 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
