### PR TITLE
Parse NGINX Config for Valid NAP Syslog Server

### DIFF
--- a/internal/collector/otel_collector_plugin.go
+++ b/internal/collector/otel_collector_plugin.go
@@ -543,17 +543,12 @@ func (oc *Collector) updateExistingNginxOSSReceiver(
 
 func (oc *Collector) updateTcplogReceivers(nginxConfigContext *model.NginxConfigContext) bool {
 	newTcplogReceiverAdded := false
-	if nginxConfigContext.NAPSysLogServers != nil {
-	napLoop:
-		for _, napSysLogServer := range nginxConfigContext.NAPSysLogServers {
-			if oc.doesTcplogReceiverAlreadyExist(napSysLogServer) {
-				continue napLoop
-			}
-
+	if nginxConfigContext.NAPSysLogServer != "" {
+		if !oc.doesTcplogReceiverAlreadyExist(nginxConfigContext.NAPSysLogServer) {
 			oc.config.Collector.Receivers.TcplogReceivers = append(
 				oc.config.Collector.Receivers.TcplogReceivers,
 				config.TcplogReceiver{
-					ListenAddress: napSysLogServer,
+					ListenAddress: nginxConfigContext.NAPSysLogServer,
 					Operators: []config.Operator{
 						{
 							Type: "add",
@@ -621,12 +616,10 @@ func (oc *Collector) configDeletedNapReceivers(nginxConfigContext *model.NginxCo
 		elements[tcplogReceiver.ListenAddress] = true
 	}
 
-	if nginxConfigContext.NAPSysLogServers != nil {
+	if nginxConfigContext.NAPSysLogServer != "" {
 		addressesToDelete := make(map[string]bool)
-		for _, napAddress := range nginxConfigContext.NAPSysLogServers {
-			if !elements[napAddress] {
-				addressesToDelete[napAddress] = true
-			}
+		if !elements[nginxConfigContext.NAPSysLogServer] {
+			addressesToDelete[nginxConfigContext.NAPSysLogServer] = true
 		}
 
 		return addressesToDelete

--- a/internal/collector/otel_collector_plugin_test.go
+++ b/internal/collector/otel_collector_plugin_test.go
@@ -734,9 +734,7 @@ func TestCollector_updateTcplogReceivers(t *testing.T) {
 	require.NoError(t, err)
 
 	nginxConfigContext := &model.NginxConfigContext{
-		NAPSysLogServers: []string{
-			"localhost:151",
-		},
+		NAPSysLogServer: "localhost:151",
 	}
 
 	assert.Empty(t, conf.Collector.Receivers.TcplogReceivers)
@@ -767,9 +765,8 @@ func TestCollector_updateTcplogReceivers(t *testing.T) {
 	})
 
 	t.Run("Test 4: New tcplogReceiver added and deleted another", func(tt *testing.T) {
-		tcplogReceiverDeleted := collector.updateTcplogReceivers(&model.NginxConfigContext{NAPSysLogServers: []string{
-			"localhost:152",
-		}})
+		tcplogReceiverDeleted := collector.
+			updateTcplogReceivers(&model.NginxConfigContext{NAPSysLogServer: "localhost:152"})
 		assert.True(t, tcplogReceiverDeleted)
 		assert.Len(t, conf.Collector.Receivers.TcplogReceivers, 1)
 		assert.Equal(t, "localhost:152", conf.Collector.Receivers.TcplogReceivers[0].ListenAddress)

--- a/internal/datasource/config/nginx_config_parser.go
+++ b/internal/datasource/config/nginx_config_parser.go
@@ -176,7 +176,7 @@ func (ncp *NginxConfigParser) createNginxConfigContext(
 						slog.Info("args", "", directive.Args)
 						sysLogServers := ncp.findValidSysLogServers(directive.Args)
 						if len(sysLogServers) == 0 {
-							slog.WarnContext(ctx, "Could not find valid Nap Syslog server")
+							slog.WarnContext(ctx, "Could not find usable NAP syslog server, security violations will be unavailable")
 						}
 						for i := range sysLogServers {
 							sysLogServer := sysLogServers[i]
@@ -237,7 +237,7 @@ func (ncp *NginxConfigParser) parseSyslogDirective(ctx context.Context, napSyslo
 
 		return napSyslogServer
 	}
-	slog.WarnContext(ctx, "Could not find usable NAP syslog server")
+	slog.WarnContext(ctx, "Could not find usable NAP syslog server, security violations will be unavailable")
 
 	return ""
 }

--- a/internal/datasource/config/nginx_config_parser.go
+++ b/internal/datasource/config/nginx_config_parser.go
@@ -257,7 +257,13 @@ func (ncp *NginxConfigParser) findValidSysLogServers(sysLogServers []string) []s
 	for i := range sysLogServers {
 		matches := re.FindStringSubmatch(sysLogServers[i])
 		if len(matches) > 1 {
-			if strings.HasPrefix(matches[1], "localhost") || strings.HasPrefix(matches[1], "127.0.0.1") {
+			host, _, err := net.SplitHostPort(matches[1])
+			if err != nil {
+				continue
+			}
+
+			ip := net.ParseIP(host)
+			if ip.IsLoopback() || strings.EqualFold(host, "localhost") {
 				servers = append(servers, matches[1])
 			}
 		}

--- a/internal/datasource/config/nginx_config_parser.go
+++ b/internal/datasource/config/nginx_config_parser.go
@@ -175,7 +175,6 @@ func (ncp *NginxConfigParser) createNginxConfigContext(
 					}
 				case "app_protect_security_log":
 					if len(directive.Args) > 1 {
-						slog.Info("args", "", directive.Args)
 						sysLogServers := ncp.findValidSysLogServers(directive.Args)
 						if len(sysLogServers) == 0 {
 							slog.WarnContext(ctx, "Could not find usable NAP syslog server, "+

--- a/internal/datasource/config/nginx_config_parser.go
+++ b/internal/datasource/config/nginx_config_parser.go
@@ -209,8 +209,8 @@ func (ncp *NginxConfigParser) createNginxConfigContext(
 				ncp.previousNAPSysLogServer = syslogServer
 			}
 		} else if napEnabled {
-			slog.WarnContext(ctx, "Could not find usable NAP syslog server, "+
-				"security violations will be unavailable")
+			slog.WarnContext(ctx, "Could not find available local NGINX App Protect syslog server. "+
+				"Security violations will not be collected.")
 		}
 
 		fileMeta, err := files.FileMeta(conf.File)

--- a/internal/datasource/config/nginx_config_parser.go
+++ b/internal/datasource/config/nginx_config_parser.go
@@ -177,7 +177,7 @@ func (ncp *NginxConfigParser) createNginxConfigContext(
 				case "app_protect_security_log":
 					if len(directive.Args) > 1 {
 						napEnabled = true
-						sysLogServer := ncp.findValidSysLogServers(directive.Args[1])
+						sysLogServer := ncp.findLocalSysLogServers(directive.Args[1])
 						if sysLogServer != "" && !napSyslogServersFound[sysLogServer] {
 							napSyslogServersFound[sysLogServer] = true
 							slog.DebugContext(ctx, "Found NAP syslog server", "address", sysLogServer)
@@ -203,7 +203,7 @@ func (ncp *NginxConfigParser) createNginxConfigContext(
 		}
 
 		if len(napSyslogServersFound) > 0 {
-			syslogServer := ncp.parseSyslogDirective(ctx, napSyslogServersFound)
+			syslogServer := ncp.findAvailableSyslogServers(ctx, napSyslogServersFound)
 			if syslogServer != "" {
 				nginxConfigContext.NAPSysLogServer = syslogServer
 				ncp.previousNAPSysLogServer = syslogServer
@@ -224,7 +224,7 @@ func (ncp *NginxConfigParser) createNginxConfigContext(
 	return nginxConfigContext, nil
 }
 
-func (ncp *NginxConfigParser) parseSyslogDirective(ctx context.Context, napSyslogServers map[string]bool) string {
+func (ncp *NginxConfigParser) findAvailableSyslogServers(ctx context.Context, napSyslogServers map[string]bool) string {
 	if ncp.previousNAPSysLogServer != "" {
 		if _, ok := napSyslogServers[ncp.previousNAPSysLogServer]; ok {
 			return ncp.previousNAPSysLogServer
@@ -249,7 +249,7 @@ func (ncp *NginxConfigParser) parseSyslogDirective(ctx context.Context, napSyslo
 	return ""
 }
 
-func (ncp *NginxConfigParser) findValidSysLogServers(sysLogServer string) string {
+func (ncp *NginxConfigParser) findLocalSysLogServers(sysLogServer string) string {
 	re := regexp.MustCompile(`syslog:server=([\S]+)`)
 	matches := re.FindStringSubmatch(sysLogServer)
 	if len(matches) > 1 {

--- a/internal/datasource/config/nginx_config_parser.go
+++ b/internal/datasource/config/nginx_config_parser.go
@@ -109,6 +109,7 @@ func (ncp *NginxConfigParser) createNginxConfigContext(
 	payload *crossplane.Payload,
 ) (*model.NginxConfigContext, error) {
 	napSyslogServersFound := make(map[string]bool)
+	napEnabled := false
 
 	nginxConfigContext := &model.NginxConfigContext{
 		InstanceID: instance.GetInstanceMeta().GetInstanceId(),
@@ -175,17 +176,11 @@ func (ncp *NginxConfigParser) createNginxConfigContext(
 					}
 				case "app_protect_security_log":
 					if len(directive.Args) > 1 {
-						sysLogServers := ncp.findValidSysLogServers(directive.Args)
-						if len(sysLogServers) == 0 {
-							slog.WarnContext(ctx, "Could not find usable NAP syslog server, "+
-								"security violations will be unavailable")
-						}
-						for i := range sysLogServers {
-							sysLogServer := sysLogServers[i]
-							if !napSyslogServersFound[sysLogServer] {
-								napSyslogServersFound[sysLogServer] = true
-								slog.DebugContext(ctx, "Found NAP syslog server", "address", sysLogServer)
-							}
+						napEnabled = true
+						sysLogServer := ncp.findValidSysLogServers(directive.Args[1])
+						if sysLogServer != "" && !napSyslogServersFound[sysLogServer] {
+							napSyslogServersFound[sysLogServer] = true
+							slog.DebugContext(ctx, "Found NAP syslog server", "address", sysLogServer)
 						}
 					}
 				}
@@ -213,6 +208,9 @@ func (ncp *NginxConfigParser) createNginxConfigContext(
 				nginxConfigContext.NAPSysLogServer = syslogServer
 				ncp.previousNAPSysLogServer = syslogServer
 			}
+		} else if napEnabled {
+			slog.WarnContext(ctx, "Could not find usable NAP syslog server, "+
+				"security violations will be unavailable")
 		}
 
 		fileMeta, err := files.FileMeta(conf.File)
@@ -236,40 +234,37 @@ func (ncp *NginxConfigParser) parseSyslogDirective(ctx context.Context, napSyslo
 	for napSyslogServer := range napSyslogServers {
 		ln, err := net.Listen("tcp", napSyslogServer)
 		if err != nil {
-			slog.WarnContext(ctx, "NAP syslog server is not reachable", "address", napSyslogServer,
+			slog.DebugContext(ctx, "NAP syslog server is not reachable", "address", napSyslogServer,
 				"error", err)
 
 			continue
 		}
 		ln.Close()
+
 		slog.DebugContext(ctx, "Found valid NAP syslog server", "address", napSyslogServer)
 
 		return napSyslogServer
 	}
-	slog.WarnContext(ctx, "Could not find usable NAP syslog server, security violations will be unavailable")
 
 	return ""
 }
 
-func (ncp *NginxConfigParser) findValidSysLogServers(sysLogServers []string) []string {
+func (ncp *NginxConfigParser) findValidSysLogServers(sysLogServer string) string {
 	re := regexp.MustCompile(`syslog:server=([\S]+)`)
-	var servers []string
-	for i := range sysLogServers {
-		matches := re.FindStringSubmatch(sysLogServers[i])
-		if len(matches) > 1 {
-			host, _, err := net.SplitHostPort(matches[1])
-			if err != nil {
-				continue
-			}
+	matches := re.FindStringSubmatch(sysLogServer)
+	if len(matches) > 1 {
+		host, _, err := net.SplitHostPort(matches[1])
+		if err != nil {
+			return ""
+		}
 
-			ip := net.ParseIP(host)
-			if ip.IsLoopback() || strings.EqualFold(host, "localhost") {
-				servers = append(servers, matches[1])
-			}
+		ip := net.ParseIP(host)
+		if ip.IsLoopback() || strings.EqualFold(host, "localhost") {
+			return matches[1]
 		}
 	}
 
-	return servers
+	return ""
 }
 
 func (ncp *NginxConfigParser) parseIncludeDirective(directive *crossplane.Directive) string {

--- a/internal/datasource/config/nginx_config_parser_test.go
+++ b/internal/datasource/config/nginx_config_parser_test.go
@@ -621,7 +621,7 @@ func TestNginxConfigParser_SyslogServerParse(t *testing.T) {
 			expectedSyslogServers: "",
 			content: testconfig.NginxConfigWithMultipleSysLogs(errorLog.Name(), accessLog.Name(),
 				"random.domain:1515", "192.168.12.34:1517", "my.domain.com:1517"),
-			expectedLog: "Could not find valid Nap Syslog server",
+			expectedLog: "Could not find usable NAP syslog server, security violations will be unavailable",
 			portInUse:   false,
 		},
 		{
@@ -629,7 +629,7 @@ func TestNginxConfigParser_SyslogServerParse(t *testing.T) {
 			expectedSyslogServers: "localhost:1516",
 			content: testconfig.NginxConfigWithMultipleSysLogs(errorLog.Name(), accessLog.Name(),
 				"192.168.12.34:1517", "127.0.0.1:1515", "localhost:1516"),
-			expectedLog: "NAP syslog server is not reachable",
+			expectedLog: "\"Found valid NAP syslog server\" address=localhost:1516",
 			portInUse:   true,
 		},
 		{

--- a/internal/datasource/config/nginx_config_parser_test.go
+++ b/internal/datasource/config/nginx_config_parser_test.go
@@ -532,7 +532,8 @@ func TestNginxConfigParser_Parse(t *testing.T) {
 				"",
 			),
 			allowedDirectories: []string{dir},
-			expectedLog:        "Could not find usable NAP syslog server, security violations will be unavailable",
+			expectedLog: "Could not find available local NGINX App Protect syslog server. " +
+				"Security violations will not be collected.",
 		},
 	}
 
@@ -649,8 +650,9 @@ func TestNginxConfigParser_SyslogServerParse(t *testing.T) {
 			expectedSyslogServers: "",
 			content: testconfig.NginxConfigWithMultipleSysLogs(errorLog.Name(), accessLog.Name(),
 				"random.domain:1515", "192.168.12.34:1517", "my.domain.com:1517"),
-			expectedLog: "Could not find usable NAP syslog server, security violations will be unavailable",
-			portInUse:   false,
+			expectedLog: "Could not find available local NGINX App Protect syslog server. " +
+				"Security violations will not be collected.",
+			portInUse: false,
 		},
 		{
 			name:                  "Test 3: Port unavailable, use next valid sever",

--- a/internal/datasource/config/nginx_config_parser_test.go
+++ b/internal/datasource/config/nginx_config_parser_test.go
@@ -719,7 +719,7 @@ func TestNginxConfigParser_findValidSysLogServers(t *testing.T) {
 	ncp := NewNginxConfigParser(types.AgentConfig())
 
 	for i, server := range servers {
-		result := ncp.findValidSysLogServers(server)
+		result := ncp.findLocalSysLogServers(server)
 
 		assert.Equal(t, expected[i], result)
 	}

--- a/internal/datasource/config/nginx_config_parser_test.go
+++ b/internal/datasource/config/nginx_config_parser_test.go
@@ -688,8 +688,9 @@ func TestNginxConfigParser_findValidSysLogServers(t *testing.T) {
 		"app_protect_security_log", "/etc/app_protect/conf/log_default1.json", "syslog:server=my.domain.com:1517",
 		"app_protect_security_log", "/etc/app_protect/conf/log_default2.json", "syslog:server=127.0.0.1:1515",
 		"app_protect_security_log", "/etc/app_protect/conf/log_default3.json", "syslog:server=localhost:1516",
+		"app_protect_security_log\", \"/etc/app_protect/conf/log_default3.json\", \"syslog:server=127.255.255.255:1517",
 	}
-	expected := []string{"127.0.0.1:1515", "localhost:1516"}
+	expected := []string{"127.0.0.1:1515", "localhost:1516", "127.255.255.255:1517"}
 	ncp := NewNginxConfigParser(types.AgentConfig())
 	result := ncp.findValidSysLogServers(servers)
 

--- a/internal/datasource/config/nginx_config_parser_test.go
+++ b/internal/datasource/config/nginx_config_parser_test.go
@@ -1181,7 +1181,6 @@ func TestNginxConfigParser_pingAPIEndpoint_PlusAPI(t *testing.T) {
 	})
 
 	fakeServer := httptest.NewServer(handler)
-	t.Logf(fakeServer.URL)
 	defer fakeServer.Close()
 
 	nginxConfigParser := NewNginxConfigParser(types.AgentConfig())

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -12,14 +12,14 @@ import (
 )
 
 type NginxConfigContext struct {
-	StubStatus       *APIDetails
-	PlusAPI          *APIDetails
-	InstanceID       string
-	Files            []*v1.File
-	AccessLogs       []*AccessLog
-	ErrorLogs        []*ErrorLog
-	NAPSysLogServers []string
-	Includes         []string
+	StubStatus      *APIDetails
+	PlusAPI         *APIDetails
+	InstanceID      string
+	Files           []*v1.File
+	AccessLogs      []*AccessLog
+	ErrorLogs       []*ErrorLog
+	NAPSysLogServer string
+	Includes        []string
 }
 
 type APIDetails struct {
@@ -113,7 +113,7 @@ func (ncc *NginxConfigContext) Equal(otherNginxConfigContext *NginxConfigContext
 		return false
 	}
 
-	if !reflect.DeepEqual(ncc.NAPSysLogServers, otherNginxConfigContext.NAPSysLogServers) {
+	if !reflect.DeepEqual(ncc.NAPSysLogServer, otherNginxConfigContext.NAPSysLogServer) {
 		return false
 	}
 

--- a/internal/resource/resource_service_test.go
+++ b/internal/resource/resource_service_test.go
@@ -336,13 +336,13 @@ func TestResourceService_ApplyConfig(t *testing.T) {
 			nginxParser := instancefakes.FakeNginxConfigParser{}
 
 			nginxParser.ParseReturns(&model.NginxConfigContext{
-				StubStatus:       &model.APIDetails{},
-				PlusAPI:          &model.APIDetails{},
-				InstanceID:       test.instanceID,
-				Files:            nil,
-				AccessLogs:       nil,
-				ErrorLogs:        nil,
-				NAPSysLogServers: nil,
+				StubStatus:      &model.APIDetails{},
+				PlusAPI:         &model.APIDetails{},
+				InstanceID:      test.instanceID,
+				Files:           nil,
+				AccessLogs:      nil,
+				ErrorLogs:       nil,
+				NAPSysLogServer: "",
 			}, nil)
 
 			resourceService := NewResourceService(ctx, types.AgentConfig())

--- a/test/config/nginx/nginx-with-multiple-syslog-servers.conf
+++ b/test/config/nginx/nginx-with-multiple-syslog-servers.conf
@@ -19,17 +19,6 @@ http {
 }
 
 http {
-    log_format ltsv "time:$time_local"
-            "\thost:$remote_addr"
-            "\tmethod:$request_method"
-            "\turi:$request_uri"
-            "\tprotocol:$server_protocol"
-            "\tstatus:$status"
-            "\tsize:$body_bytes_sent"
-            "\treferer:$http_referer"
-            "\tua:$http_user_agent"
-            "\treqtime:$request_time"
-            "\tapptime:$upstream_response_time";
 
     server {
       listen 9093;
@@ -42,9 +31,9 @@ http {
    
     server {
         
-        app_protect_security_log "/etc/app_protect/conf/log_default.json" syslog:server=%s
-        app_protect_security_log "/etc/app_protect/conf/log_default1.json" syslog:server=%s
-        app_protect_security_log "/etc/app_protect/conf/log_default2.json" syslog:server=%s
-        app_protect_security_log "/etc/app_protect/conf/log_default3.json" syslog:server=%s
+        app_protect_security_log "/etc/app_protect/conf/log_default.json" syslog:server=%s;
+        app_protect_security_log "/etc/app_protect/conf/log_default1.json" syslog:server=%s;
+        app_protect_security_log "/etc/app_protect/conf/log_default2.json" syslog:server=%s;
+        app_protect_security_log "/etc/app_protect/conf/log_default3.json" syslog:server=%s;
     }
 } 

--- a/test/config/nginx/nginx-with-multiple-syslog-servers.conf
+++ b/test/config/nginx/nginx-with-multiple-syslog-servers.conf
@@ -1,0 +1,50 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  %s notice;
+pid        /var/run/nginx.pid;
+
+load_module modules/ngx_http_app_protect_module.so;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    log_format upstream_time '$remote_addr - $remote_user [$time_local]';
+
+    server {
+        access_log %s upstream_time;
+    }
+}
+
+http {
+    log_format ltsv "time:$time_local"
+            "\thost:$remote_addr"
+            "\tmethod:$request_method"
+            "\turi:$request_uri"
+            "\tprotocol:$server_protocol"
+            "\tstatus:$status"
+            "\tsize:$body_bytes_sent"
+            "\treferer:$http_referer"
+            "\tua:$http_user_agent"
+            "\treqtime:$request_time"
+            "\tapptime:$upstream_response_time";
+
+    server {
+      listen 9093;
+      server_name lua.example.com;
+    
+      ssl_certificate_by_lua_block {
+        print("Test lua block")
+      }
+    }
+   
+    server {
+        
+        app_protect_security_log "/etc/app_protect/conf/log_default.json" syslog:server=%s
+        app_protect_security_log "/etc/app_protect/conf/log_default1.json" syslog:server=%s
+        app_protect_security_log "/etc/app_protect/conf/log_default2.json" syslog:server=%s
+        app_protect_security_log "/etc/app_protect/conf/log_default3.json" syslog:server=%s
+    }
+} 

--- a/test/config/nginx_config.go
+++ b/test/config/nginx_config.go
@@ -13,6 +13,9 @@ import (
 //go:embed nginx/nginx-with-multiple-access-logs.conf
 var embedNginxConfWithMultipleAccessLogs string
 
+//go:embed nginx/nginx-with-multiple-syslog-servers.conf
+var embedNginxConfWithMultipleSysLogs string
+
 //go:embed nginx/nginx-not-allowed-dir.conf
 var embedNginxConfWithNotAllowedDir string
 
@@ -43,6 +46,23 @@ func NginxConfigWithMultipleAccessLogs(
 		accessLogName,
 		combinedAccessLogName,
 		ltsvAccessLogName,
+	)
+}
+
+func NginxConfigWithMultipleSysLogs(
+	errorLogName,
+	accessLogName,
+	syslogServer,
+	syslogServer3,
+	syslogServer4 string,
+) string {
+	return fmt.Sprintf(
+		embedNginxConfWithMultipleSysLogs,
+		errorLogName,
+		accessLogName,
+		syslogServer,
+		syslogServer3,
+		syslogServer4,
 	)
 }
 

--- a/test/model/config.go
+++ b/test/model/config.go
@@ -29,7 +29,7 @@ func ConfigContextWithNames(
 	ltsvAccessLogName,
 	errorLogName string,
 	instanceID string,
-	syslogServers []string,
+	syslogServers string,
 ) *model.NginxConfigContext {
 	return &model.NginxConfigContext{
 		StubStatus: &model.APIDetails{
@@ -71,8 +71,8 @@ func ConfigContextWithNames(
 				Permissions: "0600",
 			},
 		},
-		InstanceID:       instanceID,
-		NAPSysLogServers: syslogServers,
+		InstanceID:      instanceID,
+		NAPSysLogServer: syslogServers,
 	}
 }
 
@@ -81,7 +81,7 @@ func ConfigContextWithoutErrorLog(
 	combinedAccessLogName,
 	ltsvAccessLogName,
 	instanceID string,
-	syslogServers []string,
+	syslogServers string,
 ) *model.NginxConfigContext {
 	return &model.NginxConfigContext{
 		StubStatus: &model.APIDetails{
@@ -115,8 +115,8 @@ func ConfigContextWithoutErrorLog(
 				Permissions: "0600",
 			},
 		},
-		InstanceID:       instanceID,
-		NAPSysLogServers: syslogServers,
+		InstanceID:      instanceID,
+		NAPSysLogServer: syslogServers,
 	}
 }
 
@@ -125,7 +125,7 @@ func ConfigContextWithFiles(
 	errorLogName string,
 	files []*mpi.File,
 	instanceID string,
-	syslogServers []string,
+	syslogServers string,
 ) *model.NginxConfigContext {
 	return &model.NginxConfigContext{
 		StubStatus: &model.APIDetails{
@@ -156,7 +156,7 @@ func ConfigContextWithFiles(
 				Permissions: "0600",
 			},
 		},
-		InstanceID:       instanceID,
-		NAPSysLogServers: syslogServers,
+		InstanceID:      instanceID,
+		NAPSysLogServer: syslogServers,
 	}
 }

--- a/test/model/config.go
+++ b/test/model/config.go
@@ -160,3 +160,41 @@ func ConfigContextWithFiles(
 		NAPSysLogServer: syslogServers,
 	}
 }
+
+func ConfigContextWithSysLog(
+	accessLogName,
+	errorLogName string,
+	instanceID string,
+	syslogServers string,
+) *model.NginxConfigContext {
+	return &model.NginxConfigContext{
+		StubStatus: &model.APIDetails{
+			URL:      "",
+			Listen:   "",
+			Location: "",
+		},
+		PlusAPI: &model.APIDetails{
+			URL:      "",
+			Listen:   "",
+			Location: "",
+		},
+		AccessLogs: []*model.AccessLog{
+			{
+				Name:        accessLogName,
+				Format:      "$remote_addr - $remote_user [$time_local]",
+				Readable:    true,
+				Permissions: "0600",
+			},
+		},
+		ErrorLogs: []*model.ErrorLog{
+			{
+				Name:        errorLogName,
+				Readable:    true,
+				LogLevel:    "notice",
+				Permissions: "0600",
+			},
+		},
+		InstanceID:      instanceID,
+		NAPSysLogServer: syslogServers,
+	}
+}


### PR DESCRIPTION
### Proposed changes

- If syslog server is not "localhost" or "127.0.0.0" ignore it 
- If a syslog server is not valid if multiple are configured try the next
- Check if port is already in use 
- Only allow one syslog server for NAP

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
