### PR TITLE
Fix version for snapshot builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       steps:
           - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
             with:
-              fetch-tags: 'true'
+              fetch-tags: true
           - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
             with:
                 go-version-file: 'go.mod'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
       runs-on: ubuntu-22.04
       steps:
           - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+            with:
+              fetch-tags: 'true'
           - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
             with:
                 go-version-file: 'go.mod'

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
-          fetch-tags: 'true'
+          fetch-tags: true
           ref: ${{ inputs.releaseBranch }}
 
       - name: Setup go

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -215,6 +215,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
+          fetch-tags: 'true'
           ref: ${{ inputs.releaseBranch }}
 
       - name: Setup go

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ MANIFEST_DIR	?= /var/lib/nginx-agent
 DIRS            = $(BUILD_DIR) $(TEST_BUILD_DIR) $(BUILD_DIR)/$(DOCS_DIR) $(BUILD_DIR)/$(DOCS_DIR)/$(PROTO_DIR)
 $(shell mkdir -p $(DIRS))
 
-VERSION 		?= "v3.0.0"
+VERSION 		?= $(shell git describe --tags --abbrev=0)
 COMMIT  		= $(shell git rev-parse --short HEAD)
 DATE    		= $(shell date +%F_%H-%M-%S)
 LDFLAGS 		= "-s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"


### PR DESCRIPTION
### Proposed changes

The version number when building local snapshots incorrectly appears as the default value `3.0.0`. This change will allow us to collect the version number by checking `git describe` for the last available tag instead.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
