### PR TITLE
Set OTel Collector Log Level To Match Agent

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,6 +106,10 @@ func ResolveConfig() (*Config, error) {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 
+	if !viperInstance.IsSet(CollectorLogLevelKey) && strings.ToLower(log.Level) == "debug" {
+		collector.Log.Level = "DEBUG"
+	}
+
 	config := &Config{
 		UUID:               viperInstance.GetString(UUIDKey),
 		Version:            viperInstance.GetString(VersionKey),
@@ -1168,10 +1172,12 @@ func isHealthExtensionSet() bool {
 }
 
 func resolveCollectorLog() *Log {
-	return &Log{
+	log := &Log{
 		Level: viperInstance.GetString(CollectorLogLevelKey),
 		Path:  viperInstance.GetString(CollectorLogPathKey),
 	}
+
+	return log
 }
 
 func resolveCommand() *Command {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,10 +106,6 @@ func ResolveConfig() (*Config, error) {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 
-	if !viperInstance.IsSet(CollectorLogLevelKey) && strings.ToLower(log.Level) == "debug" {
-		collector.Log.Level = "DEBUG"
-	}
-
 	config := &Config{
 		UUID:               viperInstance.GetString(UUIDKey),
 		Version:            viperInstance.GetString(VersionKey),
@@ -1175,6 +1171,10 @@ func resolveCollectorLog() *Log {
 	log := &Log{
 		Level: viperInstance.GetString(CollectorLogLevelKey),
 		Path:  viperInstance.GetString(CollectorLogPathKey),
+	}
+
+	if !viperInstance.IsSet(CollectorLogLevelKey) {
+		log.Level = viperInstance.GetString(LogLevelKey)
 	}
 
 	return log

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -789,8 +789,16 @@ func normalizeFunc(f *flag.FlagSet, name string) flag.NormalizedName {
 }
 
 func resolveLog() *Log {
+	logLevel := strings.ToLower(viperInstance.GetString(LogLevelKey))
+	validLevels := []string{"debug", "info", "warn", "error"}
+
+	if !slices.Contains(validLevels, logLevel) {
+		slog.Warn("Invalid log level set, defaulting to 'info'", "log_level", logLevel)
+		logLevel = "info"
+	}
+
 	return &Log{
-		Level: viperInstance.GetString(LogLevelKey),
+		Level: logLevel,
 		Path:  viperInstance.GetString(LogPathKey),
 	}
 }
@@ -1173,7 +1181,7 @@ func resolveCollectorLog() *Log {
 		Path:  viperInstance.GetString(CollectorLogPathKey),
 	}
 
-	if !viperInstance.IsSet(CollectorLogLevelKey) {
+	if !viperInstance.IsSet(CollectorLogLevelKey) && strings.ToLower(viperInstance.GetString(LogLevelKey)) != "warn" {
 		log.Level = viperInstance.GetString(LogLevelKey)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -794,11 +794,11 @@ func resolveLog() *Log {
 
 	if !slices.Contains(validLevels, logLevel) {
 		slog.Warn("Invalid log level set, defaulting to 'info'", "log_level", logLevel)
-		logLevel = "info"
+		viperInstance.Set(LogLevelKey, "info")
 	}
 
 	return &Log{
-		Level: logLevel,
+		Level: viperInstance.GetString(LogLevelKey),
 		Path:  viperInstance.GetString(LogPathKey),
 	}
 }
@@ -1176,16 +1176,14 @@ func isHealthExtensionSet() bool {
 }
 
 func resolveCollectorLog() *Log {
-	log := &Log{
+	if !viperInstance.IsSet(CollectorLogLevelKey) {
+		viperInstance.Set(CollectorLogLevelKey, strings.ToUpper(viperInstance.GetString(LogLevelKey)))
+	}
+
+	return &Log{
 		Level: viperInstance.GetString(CollectorLogLevelKey),
 		Path:  viperInstance.GetString(CollectorLogPathKey),
 	}
-
-	if !viperInstance.IsSet(CollectorLogLevelKey) && strings.ToLower(viperInstance.GetString(LogLevelKey)) != "warn" {
-		log.Level = viperInstance.GetString(LogLevelKey)
-	}
-
-	return log
 }
 
 func resolveCommand() *Command {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -298,6 +298,32 @@ func TestResolveCollector(t *testing.T) {
 	})
 }
 
+func TestResolveCollectorLog(t *testing.T) {
+	t.Run("Test 1: OTel Log Level Set In Config", func(t *testing.T) {
+		viperInstance = viper.NewWithOptions(viper.KeyDelimiter(KeyDelimiter))
+
+		viperInstance.Set(CollectorLogLevelKey, "info")
+		viperInstance.Set(CollectorLogPathKey, "/tmp/collector.log")
+		viperInstance.Set(LogLevelKey, "debug")
+
+		log := resolveCollectorLog()
+
+		// Check
+		assert.Equal(t, "info", log.Level)
+		assert.Equal(t, "/tmp/collector.log", log.Path)
+	})
+
+	t.Run("Test 2: OTel Log Level Not Set In Config", func(t *testing.T) {
+		viperInstance = viper.NewWithOptions(viper.KeyDelimiter(KeyDelimiter))
+		viperInstance.Set(LogLevelKey, "debug")
+		viperInstance.Set(CollectorLogPathKey, "/tmp/collector.log")
+
+		log := resolveCollectorLog()
+		assert.Equal(t, "debug", log.Level)
+		assert.Equal(t, "/tmp/collector.log", log.Path)
+	})
+}
+
 func TestCommand(t *testing.T) {
 	viperInstance = viper.NewWithOptions(viper.KeyDelimiter(KeyDelimiter))
 	expected := agentConfig().Command

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -277,7 +277,7 @@ func TestResolveLog(t *testing.T) {
 			logLevel:         "DEBUG",
 			logPath:          "./logs/nginx.log",
 			expectedLogPath:  "./logs/nginx.log",
-			expectedLogLevel: "debug",
+			expectedLogLevel: "DEBUG",
 		},
 	}
 
@@ -341,8 +341,6 @@ func TestResolveCollector(t *testing.T) {
 }
 
 func TestResolveCollectorLog(t *testing.T) {
-	viperInstance = viper.NewWithOptions(viper.KeyDelimiter(KeyDelimiter))
-	viperInstance.SetDefault(CollectorLogLevelKey, DefCollectorLogLevel)
 	tests := []struct {
 		name             string
 		logLevel         string
@@ -357,7 +355,7 @@ func TestResolveCollectorLog(t *testing.T) {
 			logPath:          "/tmp/collector.log",
 			agentLogLevel:    "debug",
 			expectedLogPath:  "/tmp/collector.log",
-			expectedLogLevel: "debug",
+			expectedLogLevel: "DEBUG",
 		},
 		{
 			name:             "Test 2: Agent Log Level is Warn",
@@ -365,7 +363,7 @@ func TestResolveCollectorLog(t *testing.T) {
 			logPath:          "/tmp/collector.log",
 			agentLogLevel:    "warn",
 			expectedLogPath:  "/tmp/collector.log",
-			expectedLogLevel: "INFO",
+			expectedLogLevel: "WARN",
 		},
 		{
 			name:             "Test 3: OTel Log Level Set In Config",
@@ -379,6 +377,7 @@ func TestResolveCollectorLog(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			viperInstance = viper.NewWithOptions(viper.KeyDelimiter(KeyDelimiter))
 			viperInstance.Set(CollectorLogPathKey, test.logPath)
 			viperInstance.Set(LogLevelKey, test.agentLogLevel)
 


### PR DESCRIPTION
### Proposed changes
If the log level of the the OTel collector is not set in `nginx-agent.conf` set the log level to match that of the Agent log level unless the log level is unsupported by OTel. 

Add validation when setting agent log is "error", "warn", "info" or "debug"
### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
