### PR TITLE
Fix IP Address value in cert metadata

### DIFF
--- a/pkg/files/file_helpers.go
+++ b/pkg/files/file_helpers.go
@@ -89,7 +89,7 @@ func FileMetaWithCertificate(filePath string) (*mpi.FileMeta, error) {
 			},
 			Sans: &mpi.SubjectAlternativeNames{
 				DnsNames:    loadedCert.DNSNames,
-				IpAddresses: convertIPBytes(loadedCert.IPAddresses),
+				IpAddresses: convertIPToString(loadedCert.IPAddresses),
 			},
 			Dates: &mpi.CertificateDates{
 				NotBefore: loadedCert.NotBefore.Unix(),
@@ -153,14 +153,14 @@ func ConvertToMapOfFiles(files []*mpi.File) map[string]*mpi.File {
 	return filesMap
 }
 
-func convertIPBytes(ips []net.IP) []string {
-	stringArray := make([]string, len(ips))
+func convertIPToString(ips []net.IP) []string {
+	ipArray := make([]string, len(ips))
 
-	for i, byteArray := range ips {
-		stringArray[i] = string(byteArray)
+	for i, ip := range ips {
+		ipArray[i] = ip.String()
 	}
 
-	return stringArray
+	return ipArray
 }
 
 func convertX509SignatureAlgorithm(alg x509.SignatureAlgorithm) mpi.SignatureAlgorithm {

--- a/pkg/files/file_helpers_test.go
+++ b/pkg/files/file_helpers_test.go
@@ -168,7 +168,7 @@ func TestGenerateHash(t *testing.T) {
 	}
 }
 
-func TestConvertIpBytes(t *testing.T) {
+func TestConvertIpToString(t *testing.T) {
 	tests := []struct {
 		input    []net.IP
 		expected []string
@@ -176,13 +176,13 @@ func TestConvertIpBytes(t *testing.T) {
 		{
 			input: []net.IP{net.IPv4(192, 168, 0, 1), net.IPv4(10, 0, 0, 1)},
 			expected: []string{
-				"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\xc0\xa8\x00\x01",
-				"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x00\x00\x01",
+				"192.168.0.1",
+				"10.0.0.1",
 			},
 		},
 		{
 			input:    []net.IP{net.ParseIP("2001:0db8::68")},
-			expected: []string{" \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00h"},
+			expected: []string{"2001:db8::68"},
 		},
 		{
 			input:    []net.IP{},
@@ -191,7 +191,7 @@ func TestConvertIpBytes(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result := convertIPBytes(test.input)
+		result := convertIPToString(test.input)
 		for i := range result {
 			assert.Equal(t, test.expected[i], result[i])
 		}


### PR DESCRIPTION
### Proposed changes

Fixed IP Addresses value in Cert Metadata 
`\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\xc0\xa8\x00\x01` ->  `192.168.0.1`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
