### PR TITLE
Pin all base images in Dockerfiles to SHA256 digests

### DIFF
--- a/scripts/packages/packager/Dockerfile
+++ b/scripts/packages/packager/Dockerfile
@@ -1,6 +1,6 @@
 ARG package_type
 
-FROM docker.io/golang:1.24-bullseye AS base
+FROM docker.io/golang@sha256:62ba6b19de03e891f7fa1001326bd48411f2626ff35e7ba5b9d890711ce581d9 AS base
 
 ARG PKG_VER="1.17.5"
 ARG PKG_DIR="/tmp/pkg"

--- a/test/docker/load/Dockerfile
+++ b/test/docker/load/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04 as base
+FROM ubuntu@sha256:a08e551cb33850e4740772b38217fc1796a66da2506d312abe51acda354ff061 AS base
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 # https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai

--- a/test/integration/auxiliarycommandserver/Dockerfile
+++ b/test/integration/auxiliarycommandserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:buster-slim@sha256:bb3dc79fddbca7e8903248ab916bb775c96ec61014b3d02b4f06043b604726dc
 
 WORKDIR /mock-management-plane-grpc
 COPY ./build/mock-management-plane-grpc ./

--- a/test/mock/collector/mock-collector/Dockerfile
+++ b/test/mock/collector/mock-collector/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:bookworm
+FROM golang:bookworm@sha256:ef8c5c733079ac219c77edab604c425d748c740d8699530ea6aced9de79aea40
 
 WORKDIR /mock-management-otel-collector
 COPY ./build/mock-management-otel-collector ./

--- a/test/mock/grpc/Dockerfile
+++ b/test/mock/grpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:buster-slim@sha256:bb3dc79fddbca7e8903248ab916bb775c96ec61014b3d02b4f06043b604726dc
 
 WORKDIR /mock-management-plane-grpc
 COPY ./build/mock-management-plane-grpc ./


### PR DESCRIPTION
### Proposed changes

pins all base images in Dockerfiles to their SHA256 digests, addressing supply chain security concerns and remediating the "containerImage not pinned by hash" Scorecard alert. This ensures that builds use immutable, verified images and reduces the risk of upstream image changes or attacks.



### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
