### PR TITLE
Fix how NAP syslog servers are discovered

### DIFF
--- a/internal/collector/otel_collector_plugin.go
+++ b/internal/collector/otel_collector_plugin.go
@@ -555,8 +555,6 @@ func (oc *Collector) updateNginxAppProtectTcplogReceivers(nginxConfigContext *mo
 
 	napSysLogServer := oc.findAvailableSyslogServers(nginxConfigContext.NAPSysLogServers)
 
-	slog.Error("Updating NAP SysLog Server list", "list", napSysLogServer)
-
 	if napSysLogServer != "" {
 		if !oc.doesTcplogReceiverAlreadyExist(napSysLogServer) {
 			oc.config.Collector.Receivers.TcplogReceivers["nginx_app_protect"] = &config.TcplogReceiver{

--- a/internal/collector/otel_collector_plugin.go
+++ b/internal/collector/otel_collector_plugin.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"strings"
 	"sync"
@@ -46,11 +47,12 @@ const (
 type (
 	// Collector The OTel collector plugin start an embedded OTel collector for metrics collection in the OTel format.
 	Collector struct {
-		service types.CollectorInterface
-		cancel  context.CancelFunc
-		config  *config.Config
-		mu      *sync.Mutex
-		stopped bool
+		service                 types.CollectorInterface
+		config                  *config.Config
+		mu                      *sync.Mutex
+		cancel                  context.CancelFunc
+		previousNAPSysLogServer string
+		stopped                 bool
 	}
 )
 
@@ -86,10 +88,11 @@ func NewCollector(conf *config.Config) (*Collector, error) {
 	}
 
 	return &Collector{
-		config:  conf,
-		service: oTelCollector,
-		stopped: true,
-		mu:      &sync.Mutex{},
+		config:                  conf,
+		service:                 oTelCollector,
+		stopped:                 true,
+		mu:                      &sync.Mutex{},
+		previousNAPSysLogServer: "",
 	}, nil
 }
 
@@ -550,10 +553,14 @@ func (oc *Collector) updateNginxAppProtectTcplogReceivers(nginxConfigContext *mo
 		oc.config.Collector.Receivers.TcplogReceivers = make(map[string]*config.TcplogReceiver)
 	}
 
-	if nginxConfigContext.NAPSysLogServer != "" {
-		if !oc.doesTcplogReceiverAlreadyExist(nginxConfigContext.NAPSysLogServer) {
+	napSysLogServer := oc.findAvailableSyslogServers(nginxConfigContext.NAPSysLogServers)
+
+	slog.Error("Updating NAP SysLog Server list", "list", napSysLogServer)
+
+	if napSysLogServer != "" {
+		if !oc.doesTcplogReceiverAlreadyExist(napSysLogServer) {
 			oc.config.Collector.Receivers.TcplogReceivers["nginx_app_protect"] = &config.TcplogReceiver{
-				ListenAddress: nginxConfigContext.NAPSysLogServer,
+				ListenAddress: napSysLogServer,
 				Operators: []config.Operator{
 					// regex captures the priority number from the log line
 					{
@@ -606,13 +613,13 @@ func (oc *Collector) updateNginxAppProtectTcplogReceivers(nginxConfigContext *mo
 		}
 	}
 
-	tcplogReceiverDeleted := oc.areNapReceiversDeleted(nginxConfigContext)
+	tcplogReceiverDeleted := oc.areNapReceiversDeleted(napSysLogServer)
 
 	return newTcplogReceiverAdded || tcplogReceiverDeleted
 }
 
-func (oc *Collector) areNapReceiversDeleted(nginxConfigContext *model.NginxConfigContext) bool {
-	listenAddressesToBeDeleted := oc.configDeletedNapReceivers(nginxConfigContext)
+func (oc *Collector) areNapReceiversDeleted(napSysLogServer string) bool {
+	listenAddressesToBeDeleted := oc.configDeletedNapReceivers(napSysLogServer)
 	if len(listenAddressesToBeDeleted) != 0 {
 		delete(oc.config.Collector.Receivers.TcplogReceivers, "nginx_app_protect")
 		return true
@@ -621,17 +628,17 @@ func (oc *Collector) areNapReceiversDeleted(nginxConfigContext *model.NginxConfi
 	return false
 }
 
-func (oc *Collector) configDeletedNapReceivers(nginxConfigContext *model.NginxConfigContext) map[string]bool {
+func (oc *Collector) configDeletedNapReceivers(napSysLogServer string) map[string]bool {
 	elements := make(map[string]bool)
 
 	for _, tcplogReceiver := range oc.config.Collector.Receivers.TcplogReceivers {
 		elements[tcplogReceiver.ListenAddress] = true
 	}
 
-	if nginxConfigContext.NAPSysLogServer != "" {
+	if napSysLogServer != "" {
 		addressesToDelete := make(map[string]bool)
-		if !elements[nginxConfigContext.NAPSysLogServer] {
-			addressesToDelete[nginxConfigContext.NAPSysLogServer] = true
+		if !elements[napSysLogServer] {
+			addressesToDelete[napSysLogServer] = true
 		}
 
 		return addressesToDelete
@@ -673,6 +680,39 @@ func (oc *Collector) updateResourceAttributes(
 	}
 
 	return actionUpdated
+}
+
+func (oc *Collector) findAvailableSyslogServers(napSyslogServers []string) string {
+	napSyslogServersMap := make(map[string]bool)
+	for _, server := range napSyslogServers {
+		napSyslogServersMap[server] = true
+	}
+
+	if oc.previousNAPSysLogServer != "" {
+		if _, ok := napSyslogServersMap[oc.previousNAPSysLogServer]; ok {
+			return oc.previousNAPSysLogServer
+		}
+	}
+
+	for _, napSyslogServer := range napSyslogServers {
+		ln, err := net.Listen("tcp", napSyslogServer)
+		if err != nil {
+			slog.Debug("NAP syslog server is not reachable", "address", napSyslogServer,
+				"error", err)
+
+			continue
+		}
+		closeError := ln.Close()
+		if closeError != nil {
+			slog.Debug("Failed to close syslog server", "address", napSyslogServer, "error", closeError)
+		}
+
+		slog.Debug("Found valid NAP syslog server", "address", napSyslogServer)
+
+		return napSyslogServer
+	}
+
+	return ""
 }
 
 func isOSSReceiverChanged(nginxReceiver config.NginxReceiver, nginxConfigContext *model.NginxConfigContext) bool {

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -12,14 +12,14 @@ import (
 )
 
 type NginxConfigContext struct {
-	StubStatus      *APIDetails
-	PlusAPI         *APIDetails
-	InstanceID      string
-	Files           []*v1.File
-	AccessLogs      []*AccessLog
-	ErrorLogs       []*ErrorLog
-	NAPSysLogServer string
-	Includes        []string
+	StubStatus       *APIDetails
+	PlusAPI          *APIDetails
+	InstanceID       string
+	Files            []*v1.File
+	AccessLogs       []*AccessLog
+	ErrorLogs        []*ErrorLog
+	NAPSysLogServers []string
+	Includes         []string
 }
 
 type APIDetails struct {
@@ -114,7 +114,7 @@ func (ncc *NginxConfigContext) Equal(otherNginxConfigContext *NginxConfigContext
 		return false
 	}
 
-	if !reflect.DeepEqual(ncc.NAPSysLogServer, otherNginxConfigContext.NAPSysLogServer) {
+	if !reflect.DeepEqual(ncc.NAPSysLogServers, otherNginxConfigContext.NAPSysLogServers) {
 		return false
 	}
 

--- a/internal/resource/resource_service_test.go
+++ b/internal/resource/resource_service_test.go
@@ -365,13 +365,13 @@ func TestResourceService_ApplyConfig(t *testing.T) {
 			nginxParser := instancefakes.FakeNginxConfigParser{}
 
 			nginxParser.ParseReturns(&model.NginxConfigContext{
-				StubStatus:      &model.APIDetails{},
-				PlusAPI:         &model.APIDetails{},
-				InstanceID:      test.instanceID,
-				Files:           nil,
-				AccessLogs:      nil,
-				ErrorLogs:       nil,
-				NAPSysLogServer: "",
+				StubStatus:       &model.APIDetails{},
+				PlusAPI:          &model.APIDetails{},
+				InstanceID:       test.instanceID,
+				Files:            nil,
+				AccessLogs:       nil,
+				ErrorLogs:        nil,
+				NAPSysLogServers: []string{},
 			}, nil)
 
 			resourceService := NewResourceService(ctx, types.AgentConfig())

--- a/test/model/config.go
+++ b/test/model/config.go
@@ -29,7 +29,7 @@ func ConfigContextWithNames(
 	ltsvAccessLogName,
 	errorLogName string,
 	instanceID string,
-	syslogServers string,
+	syslogServers []string,
 ) *model.NginxConfigContext {
 	return &model.NginxConfigContext{
 		StubStatus: &model.APIDetails{
@@ -71,8 +71,8 @@ func ConfigContextWithNames(
 				Permissions: "0600",
 			},
 		},
-		InstanceID:      instanceID,
-		NAPSysLogServer: syslogServers,
+		InstanceID:       instanceID,
+		NAPSysLogServers: syslogServers,
 	}
 }
 
@@ -81,7 +81,7 @@ func ConfigContextWithoutErrorLog(
 	combinedAccessLogName,
 	ltsvAccessLogName,
 	instanceID string,
-	syslogServers string,
+	syslogServers []string,
 ) *model.NginxConfigContext {
 	return &model.NginxConfigContext{
 		StubStatus: &model.APIDetails{
@@ -115,8 +115,8 @@ func ConfigContextWithoutErrorLog(
 				Permissions: "0600",
 			},
 		},
-		InstanceID:      instanceID,
-		NAPSysLogServer: syslogServers,
+		InstanceID:       instanceID,
+		NAPSysLogServers: syslogServers,
 	}
 }
 
@@ -125,7 +125,7 @@ func ConfigContextWithFiles(
 	errorLogName string,
 	files []*mpi.File,
 	instanceID string,
-	syslogServers string,
+	syslogServers []string,
 ) *model.NginxConfigContext {
 	return &model.NginxConfigContext{
 		StubStatus: &model.APIDetails{
@@ -156,8 +156,8 @@ func ConfigContextWithFiles(
 				Permissions: "0600",
 			},
 		},
-		InstanceID:      instanceID,
-		NAPSysLogServer: syslogServers,
+		InstanceID:       instanceID,
+		NAPSysLogServers: syslogServers,
 	}
 }
 
@@ -165,7 +165,7 @@ func ConfigContextWithSysLog(
 	accessLogName,
 	errorLogName string,
 	instanceID string,
-	syslogServers string,
+	syslogServers []string,
 ) *model.NginxConfigContext {
 	return &model.NginxConfigContext{
 		StubStatus: &model.APIDetails{
@@ -194,7 +194,7 @@ func ConfigContextWithSysLog(
 				Permissions: "0600",
 			},
 		},
-		InstanceID:      instanceID,
-		NAPSysLogServer: syslogServers,
+		InstanceID:       instanceID,
+		NAPSysLogServers: syslogServers,
 	}
 }


### PR DESCRIPTION
### Proposed changes

Fix how NAP syslog servers are discovered

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
