### PR TITLE
Revert runner back to public

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -31,7 +31,7 @@ jobs:
       contents: write
       pull-requests: write
     name: Update Release
-    runs-on: ubuntu-22.04-amd64
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
@@ -184,7 +184,7 @@ jobs:
         if: ${{ inputs.publishPackages == true }}
         env:
           TOKEN: ${{ inputs.uploadJWT }}
-          UPLOAD_URL: ${{ secrets.UPLOAD_URL }}
+          UPLOAD_URL: "https://up-ap-tmp.nginx.com"
         run: |
           make release
       - name: Publish Github Release


### PR DESCRIPTION
### Proposed changes

Reverts the change to self-hosted runner and change the upload url.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
