### PR TITLE
[CI/CD] add missing key generation

### DIFF
--- a/Makefile.packaging
+++ b/Makefile.packaging
@@ -35,7 +35,7 @@ $(PACKAGES_DIR):
 	@mkdir -p $(PACKAGES_DIR)/deb && mkdir -p $(PACKAGES_DIR)/rpm && mkdir -p $(PACKAGES_DIR)/apk
 
 .PHONY: package
-package: $(PACKAGES_DIR) #### Create final packages for all supported distros
+package: gpg-key $(PACKAGES_DIR) #### Create final packages for all supported distros
 	# Create deb packages
 	@for arch in $(DEB_ARCHS); do \
 		GOWORK=off CGO_ENABLED=0 GOARCH=$${arch} GOOS=linux go build -pgo=auto -ldflags=${LDFLAGS} -o $(BINARY_PATH) $(PROJECT_DIR)/$(PROJECT_FILE); \


### PR DESCRIPTION
### Proposed changes

Adds back the `gpg-key` job to run as part of the `package` make target.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
