### PR TITLE
[CI/CD] fix variable check when setting up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,18 +20,20 @@ permissions:
 
 env:
   NFPM_VERSION: 'v2.35.3'
-  GOPROXY: "https://${{ secrets.ARTIFACTORY_USER }}:${{ secrets.ARTIFACTORY_TOKEN }}@azr.artifactory.f5net.com/artifactory/api/go/f5-nginx-go-dev"
+  GOPROXY_DEV: "azr.artifactory.f5net.com/artifactory/api/go/f5-nginx-go-dev"
+  GOPROXY: "direct"
 
 jobs:
-  set-vars:
+
+  vars:
+    name: Set Workflow Variables
     runs-on: ubuntu-22.04
+    if: ${{ ! github.event.pull_request.head.repo.fork }}
     steps:
-      - name: Set Variables
+      - name: Set GOPROXY
         run: |
-          if  [[ -z ${{ secrets.ARTIFACTORY_USER }} ]] || 
-              [[ -z ${{ secrets.ARTIFACTORY_TOKEN }} ]] ||
-              ${{ github.event.pull_request.head.repo.fork }}; then
-          echo "GOPROXY=direct" >> $GITHUB_ENV
+          if [[ ! -z ${{ secrets.ARTIFACTORY_USER }} ]] && [[ ! -z ${{ secrets.ARTIFACTORY_TOKEN }} ]]; then
+            echo "GOPROXY=https://${{ secrets.ARTIFACTORY_USER }}:${{ secrets.ARTIFACTORY_TOKEN }}@${{ env.GOPROXY_DEV }}" >> $GITHUB_ENV
           fi
 
   lint:


### PR DESCRIPTION
### Proposed changes

Sets the GOPROXY variable based on the following condition:
- repository is not a fork, and both artifactory credentials are set

If not met the proxy defaults to `direct`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
