### PR TITLE
disable jobs which require secrets when PR is a dependabot update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
   proxy-sanity-check:
     name: Proxy Sanity Check
     runs-on: ubuntu-22.04
-    if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.ref_name, 'dependabot-') }}
+    if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.head_ref, 'dependabot-') }}
     env:
       GOPROXY: "https://${{ secrets.ARTIFACTORY_USER }}:${{ secrets.ARTIFACTORY_TOKEN }}@azr.artifactory.f5net.com/artifactory/api/go/f5-nginx-go-dev"
     steps:
@@ -145,7 +145,7 @@ jobs:
   official-oss-image-integration-tests:
     name: Integration Tests - Official OSS Images
     needs: build-unsigned-snapshot
-    if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.ref_name, 'dependabot-') }}
+    if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.head_ref, 'dependabot-') }}
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -184,7 +184,7 @@ jobs:
   official-plus-image-integration-tests:
     name: Integration Tests - Official Plus Images
     needs: build-unsigned-snapshot
-    if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.ref_name, 'dependabot-') }}
+    if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.head_ref, 'dependabot-') }}
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -265,7 +265,7 @@ jobs:
         run: git push 'https://github-actions:${{ secrets.GITHUB_TOKEN }}@github.com/nginx/agent.git' benchmark-results:benchmark-results
   load-tests:
     name: Load Tests
-    if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.ref_name, 'dependabot-') }}
+    if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.head_ref, 'dependabot-') }}
     permissions:
       contents: write
     runs-on: ubuntu-22.04

--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -25,7 +25,11 @@ permissions:
 
 jobs:
   mend:
-    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event_name == 'push' && github.event.repository.fork == false) }}
+    if: >-
+      ${{ 
+        (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && !startsWith(github.head_ref, 'dependabot-')) ||
+        (github.event_name == 'push' && !github.event.repository.fork)
+      }}
     uses: nginxinc/compliance-rules/.github/workflows/mend.yml@a27656f8f9a8748085b434ebe007f5b572709aad # v0.2
     secrets: inherit
     with:


### PR DESCRIPTION
### Proposed changes

Disables jobs that require secrets during a dependabot update PR

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
