### PR TITLE
Ensure that a file overview update is performed even if the initial create connection request takes a long time

### DIFF
--- a/internal/file/file_manager_service.go
+++ b/internal/file/file_manager_service.go
@@ -244,6 +244,7 @@ func (fms *FileManagerService) ConfigUpdate(ctx context.Context,
 			"error", err,
 		)
 	}
+	slog.InfoContext(ctx, "Finished updating file overview")
 }
 
 func (fms *FileManagerService) ConfigUpload(ctx context.Context, configUploadRequest *mpi.ConfigUploadRequest) error {

--- a/internal/file/file_service_operator.go
+++ b/internal/file/file_service_operator.go
@@ -131,9 +131,25 @@ func (fso *FileServiceOperator) UpdateOverview(
 			ConfigPath: configPath,
 		},
 	}
+	backoffSettings := fso.agentConfig.Client.Backoff
 
-	backOffCtx, backoffCancel := context.WithTimeout(newCtx, fso.agentConfig.Client.Backoff.MaxElapsedTime)
-	defer backoffCancel()
+	// If the create connection takes a long time that we wait indefinitely to do
+	// the initial file overview update to ensure that the management plane has a file overview
+	// on agent startup.
+	if !fso.isConnected.Load() {
+		slog.DebugContext(
+			newCtx,
+			"Not connected to management plane yet, "+
+				"retrying indefinitely to update file overview until connection is created",
+		)
+		backoffSettings = &config.BackOff{
+			InitialInterval:     fso.agentConfig.Client.Backoff.InitialInterval,
+			MaxInterval:         fso.agentConfig.Client.Backoff.MaxInterval,
+			MaxElapsedTime:      0,
+			RandomizationFactor: fso.agentConfig.Client.Backoff.RandomizationFactor,
+			Multiplier:          fso.agentConfig.Client.Backoff.Multiplier,
+		}
+	}
 
 	sendUpdateOverview := func() (*mpi.UpdateOverviewResponse, error) {
 		if fso.fileServiceClient == nil {
@@ -162,10 +178,9 @@ func (fso *FileServiceOperator) UpdateOverview(
 		return response, nil
 	}
 
-	backoffSettings := fso.agentConfig.Client.Backoff
 	response, err := backoff.RetryWithData(
 		sendUpdateOverview,
-		backoffHelpers.Context(backOffCtx, backoffSettings),
+		backoffHelpers.Context(newCtx, backoffSettings),
 	)
 	if err != nil {
 		return err
@@ -174,13 +189,13 @@ func (fso *FileServiceOperator) UpdateOverview(
 	slog.DebugContext(newCtx, "UpdateOverview response", "response", response)
 
 	if response.GetOverview() == nil {
-		slog.DebugContext(ctx, "UpdateOverview response is empty")
+		slog.DebugContext(newCtx, "UpdateOverview response is empty")
 		return nil
 	}
 	delta := files.ConvertToMapOfFiles(response.GetOverview().GetFiles())
 
 	if len(delta) != 0 {
-		return fso.updateFiles(ctx, delta, instanceID, configPath, iteration)
+		return fso.updateFiles(newCtx, delta, instanceID, configPath, iteration)
 	}
 
 	return err

--- a/internal/file/file_service_operator_test.go
+++ b/internal/file/file_service_operator_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	mpi "github.com/nginx/agent/v3/api/grpc/mpi/v1"
 	"github.com/nginx/agent/v3/api/grpc/mpi/v1/v1fakes"
@@ -95,6 +96,30 @@ func TestFileServiceOperator_UpdateOverview_MaxIterations(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Equal(t, "too many UpdateOverview attempts", err.Error())
+}
+
+func TestFileServiceOperator_UpdateOverview_NoConnection(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+
+	filePath := filepath.Join(t.TempDir(), "nginx.conf")
+	fileMeta := protos.FileMeta(filePath, "")
+
+	fakeFileServiceClient := &v1fakes.FakeFileServiceClient{}
+
+	agentConfig := types.AgentConfig()
+	agentConfig.Client.Backoff.MaxElapsedTime = 200 * time.Millisecond
+
+	fileServiceOperator := NewFileServiceOperator(types.AgentConfig(), fakeFileServiceClient, &sync.RWMutex{})
+	fileServiceOperator.SetIsConnected(false)
+
+	err := fileServiceOperator.UpdateOverview(ctx, "123", []*mpi.File{
+		{
+			FileMeta: fileMeta,
+		},
+	}, filePath, 0)
+
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestFileManagerService_UpdateFile(t *testing.T) {


### PR DESCRIPTION
### Proposed changes

If agent is not connected yet set the max elapsed time to 0 so that agent retries indefinitely on startup to send the initial file overview update.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
