### PR TITLE
Ensure tools are installed in sanity check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
             cache: false
       - name: run goproxy-sanity-check
         run: |
+          make install-tools
           make build
 
   lint:

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -228,7 +228,7 @@ jobs:
           go install github.com/goreleaser/nfpm/v2/cmd/nfpm@${{ env.NFPM_VERSION }}
           sudo apt-get update
           sudo apt-get install -y gpgv1 monkeysphere
-          make install-tools
+          make install-build-tools
           export PATH=$PATH:~/go/bin
           nfpm --version
 

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -10,18 +10,27 @@ BENCHSTAT       = golang.org/x/perf/cmd/benchstat@v0.0.0-20240404204407-f3e401e0
 BUF             = github.com/bufbuild/buf/cmd/buf@v1.30.1
 PROMTAIL	    = github.com/prometheus/promtail/cmd/promtail@v2.10.0
 
-install-tools: ## Install tool dependencies
-	@echo "Installing Tools"
-	
-	@$(GOINST) $(OAPICODEGEN)
-	@$(GOINST) $(LEFTHOOK)
+install-test-tools: ## Install tool dependencies for testing
+	@echo "Installing Test Tools"
 	@$(GOINST) $(GOLANGCILINT)
-	@$(GOINST) $(PROTOCGENGO)
 	@$(GOINST) $(GOFUMPT)
-	@$(GOINST) $(COUNTERFEITER)
-	@$(GOINST) $(NFPM)
 	@$(GOINST) $(GOTESTCOVERAGE)
 	@$(GOINST) $(BENCHSTAT)
+	@$(GOINST) $(COUNTERFEITER)
 	@$(GOINST) $(BUF)
-	@$(GOINST) $(PROMTAIL)
+	@$(GOINST) $(LEFTHOOK)
 	@$(GORUN) $(LEFTHOOK) install
+
+install-build-tools: ## Install tool dependencies for building
+	@echo "Installing Build Tools"
+	@$(GOINST) $(NFPM)
+	@$(GOINST) $(PROTOCGENGO)
+	@$(GOINST) $(OAPICODEGEN)
+	@$(GOINST) $(BUF)
+	@$(GOINST) $(LEFTHOOK)
+	@$(GORUN) $(LEFTHOOK) install
+
+install-tools: ## Install tool dependencies
+	@echo "Installing All Tools"
+	@$(MAKE) install-build-tools
+	@$(MAKE) install-test-tools


### PR DESCRIPTION
### Proposed changes

`make install-tools` should be run during the proxy sanity check to ensure the correct dependencies are in place in the Artifactory module repository.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
