### PR TITLE
Security: Add assertion document generation

### DIFF
--- a/.github/workflows/assertion.yml
+++ b/.github/workflows/assertion.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Generate Assertion Document
         id: assertiondoc
-        uses: nginxinc/compliance-rules/.github/actions/assertion@0bd61ed16c8a847b19854af300bb111e676513e7 # update to tag when available
+        uses: nginxinc/compliance-rules/.github/actions/assertion@83e452166aaf0ad8f07caf91a4f1f903b3dea1e6 # v0.3.0
         with:
           artifact-name: nginx-agent_${{ env.branch_name }}_${{ matrix.osarch }}
           artifact-digest: ${{ env.agent-digest }}
@@ -84,6 +84,6 @@ jobs:
 
       - name: Sign and Store Assertion Document
         id: sign
-        uses: nginxinc/compliance-rules/.github/actions/sign@0bd61ed16c8a847b19854af300bb111e676513e7 # update to tag when available
+        uses: nginxinc/compliance-rules/.github/actions/sign@83e452166aaf0ad8f07caf91a4f1f903b3dea1e6 # v0.3.0
         with:
           assertion-doc: ${{ steps.assertiondoc.outputs.assertion-document-path }}


### PR DESCRIPTION
### Proposed changes

Adds the generation of the required Assertion Document using the `nginxinc/compliance-rules/.github/actions/assertion` GitHub Action. Generates the doc for our AMD64 and ARM64 binary files which come out of `make build`. 

Adds the job as a manual job to be run on each release currently, as the total runtime for the document generation is anywhere from 30 minutes to an hour, as this time reduces we will look to automate the doc generation as part of the release workflow.

The checksums here will not match the ones from our packages currently, but I will consolidate the build process in the future to ensure these checksums match.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
