### PR TITLE
Prevent execute permissions from being set

### DIFF
--- a/internal/file/file_plugin.go
+++ b/internal/file/file_plugin.go
@@ -347,6 +347,26 @@ func (fp *FilePlugin) handleConfigApplyRequest(ctx context.Context, msg *bus.Mes
 		}
 
 		fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.WriteConfigSuccessfulTopic, Data: data})
+	case model.PermissionChange:
+		slog.WarnContext(ctx, "Files with execute permissions found and reset",
+			"details", err.Error())
+		dpResponse := fp.createDataPlaneResponse(
+			correlationID,
+			mpi.CommandResponse_COMMAND_STATUS_OK,
+			"Config apply successful, files updated with permission changes",
+			instanceID,
+			"",
+		)
+
+		successMessage := &model.ConfigApplySuccess{
+			ConfigContext:     &model.NginxConfigContext{},
+			DataPlaneResponse: dpResponse,
+		}
+
+		fp.fileManagerService.ClearCache()
+		fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.ConfigApplySuccessfulTopic, Data: successMessage})
+
+		return
 	}
 }
 

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -75,6 +75,7 @@ const (
 	NoChange
 	Error
 	OK
+	PermissionChange = 5
 )
 
 type ConfigApplySuccess struct {


### PR DESCRIPTION
### Proposed changes

This PR aims to prevent any files from having execute permissions set during config apply.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
