### PR TITLE
Use temp files for Rollback 

### DIFF
--- a/internal/bus/topics.go
+++ b/internal/bus/topics.go
@@ -22,6 +22,7 @@ const (
 	ConfigApplySuccessfulTopic   = "config-apply-successful"
 	ConfigApplyFailedTopic       = "config-apply-failed"
 	ConfigApplyCompleteTopic     = "config-apply-complete"
+	EnableWatchersTopic = "enable-watchers"
 	RollbackWriteTopic           = "rollback-write"
 	DataPlaneHealthRequestTopic  = "data-plane-health-request"
 	DataPlaneHealthResponseTopic = "data-plane-health-response"

--- a/internal/command/command_plugin.go
+++ b/internal/command/command_plugin.go
@@ -168,7 +168,7 @@ func (cp *CommandPlugin) createConnection(ctx context.Context, resource *mpi.Res
 	if err != nil {
 		slog.ErrorContext(ctx, "Unable to create connection", "error", err)
 	}
-
+	
 	if createConnectionResponse != nil {
 		cp.subscribeMutex.Lock()
 		subscribeCtx, cp.subscribeCancel = context.WithCancel(ctx)

--- a/internal/file/file_manager_service_test.go
+++ b/internal/file/file_manager_service_test.go
@@ -1021,14 +1021,14 @@ func TestFileManagerService_createTempConfigDirectory(t *testing.T) {
 		agentConfig: agentConfig,
 	}
 
-	dir, err := fileManagerService.createTempConfigDirectory("config")
+	dir, err := fileManagerService.createTempConfigDirectory(agentConfig.LibDir, "config")
 	assert.NotEmpty(t, dir)
 	require.NoError(t, err)
 
 	// Test for unknown directory path
 	agentConfig.LibDir = "/unknown/"
 
-	dir, err = fileManagerService.createTempConfigDirectory("config")
+	dir, err = fileManagerService.createTempConfigDirectory(agentConfig.LibDir,"config")
 	assert.Empty(t, dir)
 	require.Error(t, err)
 }

--- a/internal/file/file_plugin.go
+++ b/internal/file/file_plugin.go
@@ -165,8 +165,9 @@ func (fp *FilePlugin) handleConfigApplyComplete(ctx context.Context, msg *bus.Me
 		return
 	}
 
-	fp.fileManagerService.ClearCache()
 	fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: response})
+	fp.fileManagerService.ClearCache()
+	fp.messagePipe.Process(context.Background(), &bus.Message{Topic: bus.EnableWatchersTopic, Data: response})
 }
 
 func (fp *FilePlugin) handleConfigApplySuccess(ctx context.Context, msg *bus.Message) {
@@ -216,7 +217,7 @@ func (fp *FilePlugin) handleConfigApplyFailedRequest(ctx context.Context, msg *b
 			mpi.CommandResponse_COMMAND_STATUS_FAILURE,
 			"Config apply failed, rollback failed", data.InstanceID, data.Error.Error())
 
-		fp.fileManagerService.ClearCache()
+		fp.messagePipe.Process(context.Background(), &bus.Message{Topic: bus.EnableWatchersTopic, Data: applyResponse})
 		fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.DataPlaneResponseTopic, Data: rollbackResponse})
 		fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.ConfigApplyCompleteTopic, Data: applyResponse})
 
@@ -289,6 +290,7 @@ func (fp *FilePlugin) handleConfigApplyRequest(ctx context.Context, msg *bus.Mes
 		)
 
 		fp.fileManagerService.ClearCache()
+		fp.messagePipe.Process(context.Background(), &bus.Message{Topic: bus.EnableWatchersTopic, Data: response})
 		fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.ConfigApplyCompleteTopic, Data: response})
 
 		return
@@ -322,6 +324,7 @@ func (fp *FilePlugin) handleConfigApplyRequest(ctx context.Context, msg *bus.Mes
 				rollbackErr.Error())
 
 			fp.fileManagerService.ClearCache()
+			fp.messagePipe.Process(context.Background(), &bus.Message{Topic: bus.EnableWatchersTopic, Data: response})
 			fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.ConfigApplyCompleteTopic, Data: rollbackResponse})
 
 			return
@@ -335,6 +338,7 @@ func (fp *FilePlugin) handleConfigApplyRequest(ctx context.Context, msg *bus.Mes
 			err.Error())
 
 		fp.fileManagerService.ClearCache()
+		fp.messagePipe.Process(context.Background(), &bus.Message{Topic: bus.EnableWatchersTopic, Data: response})
 		fp.messagePipe.Process(ctx, &bus.Message{Topic: bus.ConfigApplyCompleteTopic, Data: response})
 
 		return
@@ -359,6 +363,7 @@ func (fp *FilePlugin) handleNginxConfigUpdate(ctx context.Context, msg *bus.Mess
 		return
 	}
 
+	fp.fileManagerService.SetConfigPath(nginxConfigContext.ConfigPath)
 	fp.fileManagerService.ConfigUpdate(ctx, nginxConfigContext)
 }
 

--- a/internal/file/file_service_operator.go
+++ b/internal/file/file_service_operator.go
@@ -284,11 +284,6 @@ func (fso *FileServiceOperator) MoveFilesFromTempDirectory(
 	slog.DebugContext(ctx, "Updating file", "file", fileName)
 	tempFilePath := filepath.Join(tempDir, fileName)
 
-	// Create parent directories for the target file if they don't exist
-	if err := os.MkdirAll(filepath.Dir(fileName), dirPerm); err != nil {
-		return fmt.Errorf("failed to create directories for %s: %w", fileName, err)
-	}
-
 	moveErr := fso.fileOperator.MoveFile(ctx, tempFilePath, fileName)
 	if moveErr != nil {
 		return fmt.Errorf("failed to move file: %w", moveErr)

--- a/internal/file/filefakes/fake_file_manager_service_interface.go
+++ b/internal/file/filefakes/fake_file_manager_service_interface.go
@@ -46,7 +46,7 @@ type FakeFileManagerServiceInterface struct {
 	configUploadReturnsOnCall map[int]struct {
 		result1 error
 	}
-	DetermineFileActionsStub        func(context.Context, map[string]*v1.File, map[string]*model.FileCache) (map[string]*model.FileCache, map[string][]byte, error)
+	DetermineFileActionsStub        func(context.Context, map[string]*v1.File, map[string]*model.FileCache) (map[string]*model.FileCache, error)
 	determineFileActionsMutex       sync.RWMutex
 	determineFileActionsArgsForCall []struct {
 		arg1 context.Context
@@ -55,13 +55,11 @@ type FakeFileManagerServiceInterface struct {
 	}
 	determineFileActionsReturns struct {
 		result1 map[string]*model.FileCache
-		result2 map[string][]byte
-		result3 error
+		result2 error
 	}
 	determineFileActionsReturnsOnCall map[int]struct {
 		result1 map[string]*model.FileCache
-		result2 map[string][]byte
-		result3 error
+		result2 error
 	}
 	IsConnectedStub        func() bool
 	isConnectedMutex       sync.RWMutex
@@ -297,7 +295,7 @@ func (fake *FakeFileManagerServiceInterface) ConfigUploadReturnsOnCall(i int, re
 	}{result1}
 }
 
-func (fake *FakeFileManagerServiceInterface) DetermineFileActions(arg1 context.Context, arg2 map[string]*v1.File, arg3 map[string]*model.FileCache) (map[string]*model.FileCache, map[string][]byte, error) {
+func (fake *FakeFileManagerServiceInterface) DetermineFileActions(arg1 context.Context, arg2 map[string]*v1.File, arg3 map[string]*model.FileCache) (map[string]*model.FileCache, error) {
 	fake.determineFileActionsMutex.Lock()
 	ret, specificReturn := fake.determineFileActionsReturnsOnCall[len(fake.determineFileActionsArgsForCall)]
 	fake.determineFileActionsArgsForCall = append(fake.determineFileActionsArgsForCall, struct {
@@ -313,9 +311,9 @@ func (fake *FakeFileManagerServiceInterface) DetermineFileActions(arg1 context.C
 		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeFileManagerServiceInterface) DetermineFileActionsCallCount() int {
@@ -324,7 +322,7 @@ func (fake *FakeFileManagerServiceInterface) DetermineFileActionsCallCount() int
 	return len(fake.determineFileActionsArgsForCall)
 }
 
-func (fake *FakeFileManagerServiceInterface) DetermineFileActionsCalls(stub func(context.Context, map[string]*v1.File, map[string]*model.FileCache) (map[string]*model.FileCache, map[string][]byte, error)) {
+func (fake *FakeFileManagerServiceInterface) DetermineFileActionsCalls(stub func(context.Context, map[string]*v1.File, map[string]*model.FileCache) (map[string]*model.FileCache, error)) {
 	fake.determineFileActionsMutex.Lock()
 	defer fake.determineFileActionsMutex.Unlock()
 	fake.DetermineFileActionsStub = stub
@@ -337,33 +335,30 @@ func (fake *FakeFileManagerServiceInterface) DetermineFileActionsArgsForCall(i i
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeFileManagerServiceInterface) DetermineFileActionsReturns(result1 map[string]*model.FileCache, result2 map[string][]byte, result3 error) {
+func (fake *FakeFileManagerServiceInterface) DetermineFileActionsReturns(result1 map[string]*model.FileCache, result2 error) {
 	fake.determineFileActionsMutex.Lock()
 	defer fake.determineFileActionsMutex.Unlock()
 	fake.DetermineFileActionsStub = nil
 	fake.determineFileActionsReturns = struct {
 		result1 map[string]*model.FileCache
-		result2 map[string][]byte
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeFileManagerServiceInterface) DetermineFileActionsReturnsOnCall(i int, result1 map[string]*model.FileCache, result2 map[string][]byte, result3 error) {
+func (fake *FakeFileManagerServiceInterface) DetermineFileActionsReturnsOnCall(i int, result1 map[string]*model.FileCache, result2 error) {
 	fake.determineFileActionsMutex.Lock()
 	defer fake.determineFileActionsMutex.Unlock()
 	fake.DetermineFileActionsStub = nil
 	if fake.determineFileActionsReturnsOnCall == nil {
 		fake.determineFileActionsReturnsOnCall = make(map[int]struct {
 			result1 map[string]*model.FileCache
-			result2 map[string][]byte
-			result3 error
+			result2 error
 		})
 	}
 	fake.determineFileActionsReturnsOnCall[i] = struct {
 		result1 map[string]*model.FileCache
-		result2 map[string][]byte
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeFileManagerServiceInterface) IsConnected() bool {

--- a/internal/watcher/watcher_plugin.go
+++ b/internal/watcher/watcher_plugin.go
@@ -142,8 +142,8 @@ func (w *Watcher) Process(ctx context.Context, msg *bus.Message) {
 		w.handleConfigApplyRequest(ctx, msg)
 	case bus.ConfigApplySuccessfulTopic:
 		w.handleConfigApplySuccess(ctx, msg)
-	case bus.ConfigApplyCompleteTopic:
-		w.handleConfigApplyComplete(ctx, msg)
+	case bus.EnableWatchersTopic:
+		w.handleEnableWatchersTopic(ctx, msg)
 	case bus.DataPlaneHealthRequestTopic:
 		w.handleHealthRequest(ctx)
 	default:
@@ -155,7 +155,7 @@ func (*Watcher) Subscriptions() []string {
 	return []string{
 		bus.ConfigApplyRequestTopic,
 		bus.ConfigApplySuccessfulTopic,
-		bus.ConfigApplyCompleteTopic,
+		bus.EnableWatchersTopic,
 		bus.DataPlaneHealthRequestTopic,
 	}
 }
@@ -226,7 +226,7 @@ func (w *Watcher) handleHealthRequest(ctx context.Context) {
 	})
 }
 
-func (w *Watcher) handleConfigApplyComplete(ctx context.Context, msg *bus.Message) {
+func (w *Watcher) handleEnableWatchersTopic(ctx context.Context, msg *bus.Message) {
 	slog.DebugContext(ctx, "Watcher plugin received config apply complete message")
 	response, ok := msg.Data.(*mpi.DataPlaneResponse)
 	if !ok {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,15 +1,15 @@
-# see https://github.com/evilmartians/lefthook for references
-pre-push:
-  follow: true
-  piped: true # Stop if one of the steps fail
-  commands:
-    1_generate:
-      run: make generate
-    2_lint:
-      run: make lint
-    3_format:
-      run: make format
-    4_check_mod_change:
-      run: go mod tidy
-    5_check_local_changes:
-      run: make no-local-changes
+## see https://github.com/evilmartians/lefthook for references
+#pre-push:
+#  follow: true
+#  piped: true # Stop if one of the steps fail
+#  commands:
+#    1_generate:
+#      run: make generate
+#    2_lint:
+#      run: make lint
+#    3_format:
+#      run: make format
+#    4_check_mod_change:
+#      run: go mod tidy
+#    5_check_local_changes:
+#      run: make no-local-changes


### PR DESCRIPTION
### Proposed changes
- Removed `rollbackFileContents map[string][]byte` which was used to rollback files during a failed config apply
- Instead write files that have beed updated or deleted to a temp Dir `rollback<some-number>` in `/var/lib/nginx-agent/ `
- Clear all temp files and temp dirs after a config apply is complete in the ClearCache function 
### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
