### PR TITLE
Fix Performance Benchmark for release-3.3.2

### DIFF
--- a/internal/collector/logsgzipprocessor/processor_benchmark_test.go
+++ b/internal/collector/logsgzipprocessor/processor_benchmark_test.go
@@ -83,7 +83,9 @@ func BenchmarkGzipProcessor_Concurrent(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_ = p.ConsumeLogs(context.Background(), logs)
+			logsCopy := plog.NewLogs()
+			logs.CopyTo(logsCopy)
+			_ = p.ConsumeLogs(context.Background(), logsCopy)
 		}
 	})
 }


### PR DESCRIPTION
### Proposed changes

Updates the release branch with a test fix from main which was added as part of updating the OTel dependencies. It should fix the benchmark test failing in release branch CI pipeline.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
