### PR TITLE
Prioritise API with api write=on

### DIFF
--- a/api/grpc/mpi/v1/command.pb.go
+++ b/api/grpc/mpi/v1/command.pb.go
@@ -2180,7 +2180,9 @@ type NGINXPlusRuntimeInfo struct {
 	// List of NGINX dynamic modules.
 	DynamicModules []string `protobuf:"bytes,5,rep,name=dynamic_modules,json=dynamicModules,proto3" json:"dynamic_modules,omitempty"`
 	// the plus API details
-	PlusApi       *APIDetails `protobuf:"bytes,6,opt,name=plus_api,json=plusApi,proto3" json:"plus_api,omitempty"`
+	PlusApi *APIDetails `protobuf:"bytes,6,opt,name=plus_api,json=plusApi,proto3" json:"plus_api,omitempty"`
+	// to store all the endpoints details
+	PlusApis      []*APIDetails `protobuf:"bytes,7,rep,name=plus_apis,json=plusApis,proto3" json:"plus_apis,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2257,6 +2259,13 @@ func (x *NGINXPlusRuntimeInfo) GetPlusApi() *APIDetails {
 	return nil
 }
 
+func (x *NGINXPlusRuntimeInfo) GetPlusApis() []*APIDetails {
+	if x != nil {
+		return x.PlusApis
+	}
+	return nil
+}
+
 type APIDetails struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// the API location directive
@@ -2264,7 +2273,9 @@ type APIDetails struct {
 	// the API listen directive
 	Listen string `protobuf:"bytes,2,opt,name=listen,proto3" json:"listen,omitempty"`
 	// the API CA file path
-	Ca            string `protobuf:"bytes,3,opt,name=Ca,proto3" json:"Ca,omitempty"`
+	Ca string `protobuf:"bytes,3,opt,name=Ca,proto3" json:"Ca,omitempty"`
+	// flag to know if this API location was configured with 'api write=on;'
+	WriteEnabled  bool `protobuf:"varint,4,opt,name=write_enabled,json=writeEnabled,proto3" json:"write_enabled,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2318,6 +2329,13 @@ func (x *APIDetails) GetCa() string {
 		return x.Ca
 	}
 	return ""
+}
+
+func (x *APIDetails) GetWriteEnabled() bool {
+	if x != nil {
+		return x.WriteEnabled
+	}
+	return false
 }
 
 // A set of runtime NGINX App Protect settings
@@ -2871,7 +2889,7 @@ const file_mpi_v1_command_proto_rawDesc = "" +
 	"\n" +
 	"error_logs\x18\x03 \x03(\tR\terrorLogs\x12)\n" +
 	"\x10loadable_modules\x18\x04 \x03(\tR\x0floadableModules\x12'\n" +
-	"\x0fdynamic_modules\x18\x05 \x03(\tR\x0edynamicModules\"\x8e\x02\n" +
+	"\x0fdynamic_modules\x18\x05 \x03(\tR\x0edynamicModules\"\xbf\x02\n" +
 	"\x14NGINXPlusRuntimeInfo\x123\n" +
 	"\vstub_status\x18\x01 \x01(\v2\x12.mpi.v1.APIDetailsR\n" +
 	"stubStatus\x12\x1f\n" +
@@ -2881,12 +2899,14 @@ const file_mpi_v1_command_proto_rawDesc = "" +
 	"error_logs\x18\x03 \x03(\tR\terrorLogs\x12)\n" +
 	"\x10loadable_modules\x18\x04 \x03(\tR\x0floadableModules\x12'\n" +
 	"\x0fdynamic_modules\x18\x05 \x03(\tR\x0edynamicModules\x12-\n" +
-	"\bplus_api\x18\x06 \x01(\v2\x12.mpi.v1.APIDetailsR\aplusApi\"P\n" +
+	"\bplus_api\x18\x06 \x01(\v2\x12.mpi.v1.APIDetailsR\aplusApi\x12/\n" +
+	"\tplus_apis\x18\a \x03(\v2\x12.mpi.v1.APIDetailsR\bplusApis\"u\n" +
 	"\n" +
 	"APIDetails\x12\x1a\n" +
 	"\blocation\x18\x01 \x01(\tR\blocation\x12\x16\n" +
 	"\x06listen\x18\x02 \x01(\tR\x06listen\x12\x0e\n" +
-	"\x02Ca\x18\x03 \x01(\tR\x02Ca\"\xe0\x01\n" +
+	"\x02Ca\x18\x03 \x01(\tR\x02Ca\x12#\n" +
+	"\rwrite_enabled\x18\x04 \x01(\bR\fwriteEnabled\"\xe0\x01\n" +
 	"\x1aNGINXAppProtectRuntimeInfo\x12\x18\n" +
 	"\arelease\x18\x01 \x01(\tR\arelease\x128\n" +
 	"\x18attack_signature_version\x18\x02 \x01(\tR\x16attackSignatureVersion\x126\n" +
@@ -3030,30 +3050,31 @@ var file_mpi_v1_command_proto_depIdxs = []int32{
 	34, // 43: mpi.v1.NGINXRuntimeInfo.stub_status:type_name -> mpi.v1.APIDetails
 	34, // 44: mpi.v1.NGINXPlusRuntimeInfo.stub_status:type_name -> mpi.v1.APIDetails
 	34, // 45: mpi.v1.NGINXPlusRuntimeInfo.plus_api:type_name -> mpi.v1.APIDetails
-	38, // 46: mpi.v1.AgentConfig.command:type_name -> mpi.v1.CommandServer
-	40, // 47: mpi.v1.AgentConfig.metrics:type_name -> mpi.v1.MetricsServer
-	41, // 48: mpi.v1.AgentConfig.file:type_name -> mpi.v1.FileServer
-	45, // 49: mpi.v1.AgentConfig.labels:type_name -> google.protobuf.Struct
-	39, // 50: mpi.v1.AgentConfig.auxiliary_command:type_name -> mpi.v1.AuxiliaryCommandServer
-	46, // 51: mpi.v1.CommandServer.server:type_name -> mpi.v1.ServerSettings
-	47, // 52: mpi.v1.CommandServer.auth:type_name -> mpi.v1.AuthSettings
-	48, // 53: mpi.v1.CommandServer.tls:type_name -> mpi.v1.TLSSettings
-	46, // 54: mpi.v1.AuxiliaryCommandServer.server:type_name -> mpi.v1.ServerSettings
-	47, // 55: mpi.v1.AuxiliaryCommandServer.auth:type_name -> mpi.v1.AuthSettings
-	48, // 56: mpi.v1.AuxiliaryCommandServer.tls:type_name -> mpi.v1.TLSSettings
-	2,  // 57: mpi.v1.CommandService.CreateConnection:input_type -> mpi.v1.CreateConnectionRequest
-	8,  // 58: mpi.v1.CommandService.UpdateDataPlaneStatus:input_type -> mpi.v1.UpdateDataPlaneStatusRequest
-	11, // 59: mpi.v1.CommandService.UpdateDataPlaneHealth:input_type -> mpi.v1.UpdateDataPlaneHealthRequest
-	13, // 60: mpi.v1.CommandService.Subscribe:input_type -> mpi.v1.DataPlaneResponse
-	7,  // 61: mpi.v1.CommandService.CreateConnection:output_type -> mpi.v1.CreateConnectionResponse
-	9,  // 62: mpi.v1.CommandService.UpdateDataPlaneStatus:output_type -> mpi.v1.UpdateDataPlaneStatusResponse
-	12, // 63: mpi.v1.CommandService.UpdateDataPlaneHealth:output_type -> mpi.v1.UpdateDataPlaneHealthResponse
-	14, // 64: mpi.v1.CommandService.Subscribe:output_type -> mpi.v1.ManagementPlaneRequest
-	61, // [61:65] is the sub-list for method output_type
-	57, // [57:61] is the sub-list for method input_type
-	57, // [57:57] is the sub-list for extension type_name
-	57, // [57:57] is the sub-list for extension extendee
-	0,  // [0:57] is the sub-list for field type_name
+	34, // 46: mpi.v1.NGINXPlusRuntimeInfo.plus_apis:type_name -> mpi.v1.APIDetails
+	38, // 47: mpi.v1.AgentConfig.command:type_name -> mpi.v1.CommandServer
+	40, // 48: mpi.v1.AgentConfig.metrics:type_name -> mpi.v1.MetricsServer
+	41, // 49: mpi.v1.AgentConfig.file:type_name -> mpi.v1.FileServer
+	45, // 50: mpi.v1.AgentConfig.labels:type_name -> google.protobuf.Struct
+	39, // 51: mpi.v1.AgentConfig.auxiliary_command:type_name -> mpi.v1.AuxiliaryCommandServer
+	46, // 52: mpi.v1.CommandServer.server:type_name -> mpi.v1.ServerSettings
+	47, // 53: mpi.v1.CommandServer.auth:type_name -> mpi.v1.AuthSettings
+	48, // 54: mpi.v1.CommandServer.tls:type_name -> mpi.v1.TLSSettings
+	46, // 55: mpi.v1.AuxiliaryCommandServer.server:type_name -> mpi.v1.ServerSettings
+	47, // 56: mpi.v1.AuxiliaryCommandServer.auth:type_name -> mpi.v1.AuthSettings
+	48, // 57: mpi.v1.AuxiliaryCommandServer.tls:type_name -> mpi.v1.TLSSettings
+	2,  // 58: mpi.v1.CommandService.CreateConnection:input_type -> mpi.v1.CreateConnectionRequest
+	8,  // 59: mpi.v1.CommandService.UpdateDataPlaneStatus:input_type -> mpi.v1.UpdateDataPlaneStatusRequest
+	11, // 60: mpi.v1.CommandService.UpdateDataPlaneHealth:input_type -> mpi.v1.UpdateDataPlaneHealthRequest
+	13, // 61: mpi.v1.CommandService.Subscribe:input_type -> mpi.v1.DataPlaneResponse
+	7,  // 62: mpi.v1.CommandService.CreateConnection:output_type -> mpi.v1.CreateConnectionResponse
+	9,  // 63: mpi.v1.CommandService.UpdateDataPlaneStatus:output_type -> mpi.v1.UpdateDataPlaneStatusResponse
+	12, // 64: mpi.v1.CommandService.UpdateDataPlaneHealth:output_type -> mpi.v1.UpdateDataPlaneHealthResponse
+	14, // 65: mpi.v1.CommandService.Subscribe:output_type -> mpi.v1.ManagementPlaneRequest
+	62, // [62:66] is the sub-list for method output_type
+	58, // [58:62] is the sub-list for method input_type
+	58, // [58:58] is the sub-list for extension type_name
+	58, // [58:58] is the sub-list for extension extendee
+	0,  // [0:58] is the sub-list for field type_name
 }
 
 func init() { file_mpi_v1_command_proto_init() }

--- a/api/grpc/mpi/v1/command.pb.validate.go
+++ b/api/grpc/mpi/v1/command.pb.validate.go
@@ -4787,6 +4787,40 @@ func (m *NGINXPlusRuntimeInfo) validate(all bool) error {
 		}
 	}
 
+	for idx, item := range m.GetPlusApis() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, NGINXPlusRuntimeInfoValidationError{
+						field:  fmt.Sprintf("PlusApis[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, NGINXPlusRuntimeInfoValidationError{
+						field:  fmt.Sprintf("PlusApis[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return NGINXPlusRuntimeInfoValidationError{
+					field:  fmt.Sprintf("PlusApis[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
 	if len(errors) > 0 {
 		return NGINXPlusRuntimeInfoMultiError(errors)
 	}
@@ -4894,6 +4928,8 @@ func (m *APIDetails) validate(all bool) error {
 	// no validation rules for Listen
 
 	// no validation rules for Ca
+
+	// no validation rules for WriteEnabled
 
 	if len(errors) > 0 {
 		return APIDetailsMultiError(errors)

--- a/api/grpc/mpi/v1/command.proto
+++ b/api/grpc/mpi/v1/command.proto
@@ -345,6 +345,8 @@ message NGINXPlusRuntimeInfo {
     repeated string dynamic_modules = 5;
     // the plus API details
     APIDetails plus_api = 6;
+    // to store all the endpoints details
+    repeated APIDetails plus_apis = 7;
 }
 
 message APIDetails {
@@ -354,6 +356,8 @@ message APIDetails {
     string listen =  2;
     // the API CA file path
     string Ca = 3;
+    // flag to know if this API location was configured with 'api write=on;'
+    bool write_enabled = 4;
 }
 
 // A set of runtime NGINX App Protect settings

--- a/docs/proto/protos.md
+++ b/docs/proto/protos.md
@@ -697,6 +697,7 @@ Perform an associated API action on an instance
 | location | [string](#string) |  | the API location directive |
 | listen | [string](#string) |  | the API listen directive |
 | Ca | [string](#string) |  | the API CA file path |
+| write_enabled | [bool](#bool) |  | flag to know if this API location was configured with &#39;api write=on;&#39; |
 
 
 
@@ -1131,6 +1132,7 @@ A set of runtime NGINX Plus settings
 | loadable_modules | [string](#string) | repeated | List of NGINX potentially loadable modules (installed but not loaded). |
 | dynamic_modules | [string](#string) | repeated | List of NGINX dynamic modules. |
 | plus_api | [APIDetails](#mpi-v1-APIDetails) |  | the plus API details |
+| plus_apis | [APIDetails](#mpi-v1-APIDetails) | repeated | to store all the endpoints details |
 
 
 

--- a/internal/datasource/config/configfakes/fake_config_parser.go
+++ b/internal/datasource/config/configfakes/fake_config_parser.go
@@ -11,6 +11,18 @@ import (
 )
 
 type FakeConfigParser struct {
+	FindAllPlusAPIsStub        func(context.Context, *model.NginxConfigContext) []*model.APIDetails
+	findAllPlusAPIsMutex       sync.RWMutex
+	findAllPlusAPIsArgsForCall []struct {
+		arg1 context.Context
+		arg2 *model.NginxConfigContext
+	}
+	findAllPlusAPIsReturns struct {
+		result1 []*model.APIDetails
+	}
+	findAllPlusAPIsReturnsOnCall map[int]struct {
+		result1 []*model.APIDetails
+	}
 	FindPlusAPIStub        func(context.Context, *model.NginxConfigContext) *model.APIDetails
 	findPlusAPIMutex       sync.RWMutex
 	findPlusAPIArgsForCall []struct {
@@ -51,6 +63,68 @@ type FakeConfigParser struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeConfigParser) FindAllPlusAPIs(arg1 context.Context, arg2 *model.NginxConfigContext) []*model.APIDetails {
+	fake.findAllPlusAPIsMutex.Lock()
+	ret, specificReturn := fake.findAllPlusAPIsReturnsOnCall[len(fake.findAllPlusAPIsArgsForCall)]
+	fake.findAllPlusAPIsArgsForCall = append(fake.findAllPlusAPIsArgsForCall, struct {
+		arg1 context.Context
+		arg2 *model.NginxConfigContext
+	}{arg1, arg2})
+	stub := fake.FindAllPlusAPIsStub
+	fakeReturns := fake.findAllPlusAPIsReturns
+	fake.recordInvocation("FindAllPlusAPIs", []interface{}{arg1, arg2})
+	fake.findAllPlusAPIsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeConfigParser) FindAllPlusAPIsCallCount() int {
+	fake.findAllPlusAPIsMutex.RLock()
+	defer fake.findAllPlusAPIsMutex.RUnlock()
+	return len(fake.findAllPlusAPIsArgsForCall)
+}
+
+func (fake *FakeConfigParser) FindAllPlusAPIsCalls(stub func(context.Context, *model.NginxConfigContext) []*model.APIDetails) {
+	fake.findAllPlusAPIsMutex.Lock()
+	defer fake.findAllPlusAPIsMutex.Unlock()
+	fake.FindAllPlusAPIsStub = stub
+}
+
+func (fake *FakeConfigParser) FindAllPlusAPIsArgsForCall(i int) (context.Context, *model.NginxConfigContext) {
+	fake.findAllPlusAPIsMutex.RLock()
+	defer fake.findAllPlusAPIsMutex.RUnlock()
+	argsForCall := fake.findAllPlusAPIsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeConfigParser) FindAllPlusAPIsReturns(result1 []*model.APIDetails) {
+	fake.findAllPlusAPIsMutex.Lock()
+	defer fake.findAllPlusAPIsMutex.Unlock()
+	fake.FindAllPlusAPIsStub = nil
+	fake.findAllPlusAPIsReturns = struct {
+		result1 []*model.APIDetails
+	}{result1}
+}
+
+func (fake *FakeConfigParser) FindAllPlusAPIsReturnsOnCall(i int, result1 []*model.APIDetails) {
+	fake.findAllPlusAPIsMutex.Lock()
+	defer fake.findAllPlusAPIsMutex.Unlock()
+	fake.FindAllPlusAPIsStub = nil
+	if fake.findAllPlusAPIsReturnsOnCall == nil {
+		fake.findAllPlusAPIsReturnsOnCall = make(map[int]struct {
+			result1 []*model.APIDetails
+		})
+	}
+	fake.findAllPlusAPIsReturnsOnCall[i] = struct {
+		result1 []*model.APIDetails
+	}{result1}
 }
 
 func (fake *FakeConfigParser) FindPlusAPI(arg1 context.Context, arg2 *model.NginxConfigContext) *model.APIDetails {
@@ -245,6 +319,8 @@ func (fake *FakeConfigParser) ParseReturnsOnCall(i int, result1 *model.NginxConf
 func (fake *FakeConfigParser) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.findAllPlusAPIsMutex.RLock()
+	defer fake.findAllPlusAPIsMutex.RUnlock()
 	fake.findPlusAPIMutex.RLock()
 	defer fake.findPlusAPIMutex.RUnlock()
 	fake.findStubStatusAPIMutex.RLock()

--- a/internal/datasource/config/nginx_config_parser_test.go
+++ b/internal/datasource/config/nginx_config_parser_test.go
@@ -150,7 +150,7 @@ var (
     listen [::]:8000;
 	server_name _;
     location /api/ {
-        api write=on;
+        api write=off;
         allow 127.0.0.1;
         deny all;
     }
@@ -275,7 +275,7 @@ var (
 	}
 
 	location /api {
-		api write=on;
+		api write=off;
 	}
 }
 
@@ -286,6 +286,14 @@ server {
 	return 418;
 }
 `
+	testConf23 = `server {
+       listen 127.0.0.1:9090;
+       location /writeapi {
+          api write=on;
+          allow 127.0.0.1;
+          deny all;
+       }
+}`
 )
 
 //nolint:maintidx // The test cannot be refactored
@@ -815,108 +823,120 @@ func TestNginxConfigParser_urlsForLocationDirective(t *testing.T) {
 	}{
 		{
 			plus: &model.APIDetails{
-				URL:      "http://localhost:80/api/",
-				Listen:   "localhost:80",
-				Location: "/api/",
+				URL:          "http://localhost:80/api/",
+				Listen:       "localhost:80",
+				Location:     "/api/",
+				WriteEnabled: true,
 			},
 			name: "Test 1: listen localhost 80, allow 127.0.0.1 - Plus",
 			conf: testConf01,
 		},
 		{
 			plus: &model.APIDetails{
-				URL:      "http://localhost:80/api/",
-				Listen:   "localhost:80",
-				Location: "/api/",
+				URL:          "http://localhost:80/api/",
+				Listen:       "localhost:80",
+				Location:     "/api/",
+				WriteEnabled: true,
 			},
 			name: "Test 2: listen *:80 - Plus",
 			conf: testConf02,
 		},
 		{
 			plus: &model.APIDetails{
-				URL:      "http://localhost:80/api/",
-				Listen:   "localhost:80",
-				Location: "/api/",
+				URL:          "http://localhost:80/api/",
+				Listen:       "localhost:80",
+				Location:     "/api/",
+				WriteEnabled: true,
 			},
 			name: "Test 3: server_name _ - Plus",
 			conf: testConf03,
 		},
 		{
 			plus: &model.APIDetails{
-				URL:      "http://localhost:8888/api/",
-				Listen:   "localhost:8888",
-				Location: "/api/",
+				URL:          "http://localhost:8888/api/",
+				Listen:       "localhost:8888",
+				Location:     "/api/",
+				WriteEnabled: true,
 			},
 			name: "Test 4:  server_name status.internal.com - Plus",
 			conf: testConf04,
 		},
 		{
 			plus: &model.APIDetails{
-				URL:      "http://localhost:8080/privateapi",
-				Listen:   "localhost:8080",
-				Location: "/privateapi",
+				URL:          "http://localhost:8080/privateapi",
+				Listen:       "localhost:8080",
+				Location:     "/privateapi",
+				WriteEnabled: true,
 			},
 			name: "Test 5:  location /privateapi - Plus",
 			conf: testConf05,
 		},
 		{
 			plus: &model.APIDetails{
-				URL:      "http://localhost:80/api/",
-				Listen:   "localhost:80",
-				Location: "/api/",
+				URL:          "http://localhost:80/api/",
+				Listen:       "localhost:80",
+				Location:     "/api/",
+				WriteEnabled: true,
 			},
 			name: "Test 6:  listen [::]:80 default_server - Plus",
 			conf: testConf06,
 		},
 		{
 			plus: &model.APIDetails{
-				URL:      "http://localhost:80/api/",
-				Listen:   "localhost:80",
-				Location: "/api/",
+				URL:          "http://localhost:80/api/",
+				Listen:       "localhost:80",
+				Location:     "/api/",
+				WriteEnabled: true,
 			},
 			name: "Test 7:  listen 127.0.0.1, server_name _ - Plus",
 			conf: testConf07,
 		},
 		{
 			plus: &model.APIDetails{
-				URL:      "http://localhost:80/api/",
-				Listen:   "localhost:80",
-				Location: "/api/",
+				URL:          "http://localhost:80/api/",
+				Listen:       "localhost:80",
+				Location:     "/api/",
+				WriteEnabled: true,
 			},
 			name: "Test 8: location = /api/, listen 127.0.0.1 - Plus",
 			conf: testConf08,
 		},
 		{
 			plus: &model.APIDetails{
-				URL:      "http://localhost:80/api/",
-				Listen:   "localhost:80",
-				Location: "/api/",
+				URL:          "http://localhost:80/api/",
+				Listen:       "localhost:80",
+				Location:     "/api/",
+				WriteEnabled: true,
 			},
 			name: "Test 9:  location = /api/ , listen 80 - Plus",
 			conf: testConf09,
 		},
 		{
 			plus: &model.APIDetails{
-				URL:      "http://localhost:80/api/",
-				Listen:   "localhost:80",
-				Location: "/api/",
+				URL:          "http://localhost:80/api/",
+				Listen:       "localhost:80",
+				Location:     "/api/",
+				WriteEnabled: true,
 			},
 			name: "Test 10: listen :80 - Plus",
 			conf: testConf10,
 		},
 		{
 			plus: &model.APIDetails{
-				URL:      "http://localhost:80/api/",
-				Listen:   "localhost:80",
-				Location: "/api/",
+				URL:          "http://localhost:80/api/",
+				Listen:       "localhost:80",
+				Location:     "/api/",
+				WriteEnabled: true,
 			},
 			name: "Test 11: listen localhost - Plus",
 			conf: testConf11,
 		},
 		{
 			plus: &model.APIDetails{
-				URL:      "http://localhost:80/api/",
-				Listen:   "localhost:80",
-				Location: "/api/",
+				URL:          "http://localhost:80/api/",
+				Listen:       "localhost:80",
+				Location:     "/api/",
+				WriteEnabled: true,
 			},
 			name: "Test 12: listen [::1] - Plus",
 			conf: testConf12,
@@ -973,9 +993,10 @@ func TestNginxConfigParser_urlsForLocationDirective(t *testing.T) {
 				Location: "/stub_status",
 			},
 			plus: &model.APIDetails{
-				URL:      "http://localhost:80/api/",
-				Listen:   "localhost:80",
-				Location: "/api/",
+				URL:          "http://localhost:80/api/",
+				Listen:       "localhost:80",
+				Location:     "/api/",
+				WriteEnabled: true,
 			},
 			name: "Test 18: listen 80 - OSS & Plus",
 			conf: testConf18,
@@ -1000,9 +1021,10 @@ func TestNginxConfigParser_urlsForLocationDirective(t *testing.T) {
 		},
 		{
 			plus: &model.APIDetails{
-				URL:      "http://nginx-plus-api/api",
-				Listen:   "unix:/var/run/nginx/nginx-plus-api.sock",
-				Location: "/api",
+				URL:          "http://nginx-plus-api/api",
+				Listen:       "unix:/var/run/nginx/nginx-plus-api.sock",
+				Location:     "/api",
+				WriteEnabled: true,
 			},
 			name: "Test 21: listen unix:/var/run/nginx/nginx-plus-api.sock - Plus Unix Socket",
 			conf: testConf21,
@@ -1015,6 +1037,16 @@ func TestNginxConfigParser_urlsForLocationDirective(t *testing.T) {
 			},
 			name: "Test 22: Multiple Plus Unix Sockets",
 			conf: testConf22,
+		},
+		{
+			plus: &model.APIDetails{
+				URL:          "http://localhost:9090/writeapi",
+				Listen:       "localhost:9090",
+				Location:     "/writeapi",
+				WriteEnabled: true,
+			},
+			name: "Test 23: Explicitly Write-Enabled Plus API",
+			conf: testConf23,
 		},
 	}
 

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -26,10 +26,11 @@ type NginxConfigContext struct {
 }
 
 type APIDetails struct {
-	URL      string
-	Listen   string
-	Location string
-	Ca       string
+	URL          string
+	Listen       string
+	Location     string
+	Ca           string
+	WriteEnabled bool
 }
 
 type ManifestFile struct {

--- a/internal/resource/resource_service.go
+++ b/internal/resource/resource_service.go
@@ -361,21 +361,42 @@ func convertToStreamUpstreamServer(streamUpstreams []*structpb.Struct) []client.
 }
 
 func (r *ResourceService) createPlusClient(ctx context.Context, instance *mpi.Instance) (*client.NginxClient, error) {
-	plusAPI := instance.GetInstanceRuntime().GetNginxPlusRuntimeInfo().GetPlusApi()
+	plusAPIs := instance.GetInstanceRuntime().GetNginxPlusRuntimeInfo().GetPlusApis()
 	var endpoint string
+	var selectedAPI *mpi.APIDetails
 
-	if plusAPI.GetLocation() == "" || plusAPI.GetListen() == "" {
+	if len(plusAPIs) == 0 {
 		return nil, errors.New("failed to preform API action, NGINX Plus API is not configured")
 	}
 
-	if strings.HasPrefix(plusAPI.GetListen(), "unix:") {
-		endpoint = fmt.Sprintf(unixPlusAPIFormat, plusAPI.GetLocation())
+	for _, api := range plusAPIs {
+		if api.GetWriteEnabled() {
+			selectedAPI = api
+			slog.DebugContext(ctx, "Selected write-enabled NGINX Plus API for action",
+				"url", selectedAPI.GetLocation(), "listen", selectedAPI.GetListen())
+
+			break
+		}
+	}
+
+	if selectedAPI == nil {
+		selectedAPI = plusAPIs[0]
+		slog.InfoContext(ctx, "No write-enabled NGINX Plus API found. Write operations may fail.",
+			"url", selectedAPI.GetLocation(), "listen", selectedAPI.GetListen())
+	}
+
+	if selectedAPI.GetLocation() == "" || selectedAPI.GetListen() == "" {
+		return nil, errors.New("failed to preform API action, NGINX Plus API is not configured")
+	}
+
+	if strings.HasPrefix(selectedAPI.GetListen(), "unix:") {
+		endpoint = fmt.Sprintf(unixPlusAPIFormat, selectedAPI.GetLocation())
 	} else {
-		endpoint = fmt.Sprintf(apiFormat, plusAPI.GetListen(), plusAPI.GetLocation())
+		endpoint = fmt.Sprintf(apiFormat, selectedAPI.GetListen(), selectedAPI.GetLocation())
 	}
 
 	httpClient := http.DefaultClient
-	caCertLocation := plusAPI.GetCa()
+	caCertLocation := selectedAPI.GetCa()
 	if caCertLocation != "" {
 		slog.DebugContext(ctx, "Reading CA certificate", "file_path", caCertLocation)
 		caCert, err := os.ReadFile(caCertLocation)
@@ -394,8 +415,8 @@ func (r *ResourceService) createPlusClient(ctx context.Context, instance *mpi.In
 			},
 		}
 	}
-	if strings.HasPrefix(plusAPI.GetListen(), "unix:") {
-		httpClient = socketClient(ctx, strings.TrimPrefix(plusAPI.GetListen(), "unix:"))
+	if strings.HasPrefix(selectedAPI.GetListen(), "unix:") {
+		httpClient = socketClient(ctx, strings.TrimPrefix(selectedAPI.GetListen(), "unix:"))
 	}
 
 	return client.NewNginxClient(endpoint,


### PR DESCRIPTION
Issue:
Currently, if more than one Plus API is defined in NGINX config, Agent will always select the first working API URL, and if that API has  "api write=off", that leads to "MethodDisabled" error while trying to update upstream using an API.

Fix:
With this change agent is parsing all the Plus API's defined in the NGINX config to find if any of them have "api write=on" and if yes, then we are selecting that as the default api; else we are selecting the first API defined in the NGINX config as the default one, which is the current behaviour.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
