### PR TITLE
Add passthrough for gRPC connection when using a proxy

### DIFF
--- a/internal/grpc/grpc.go
+++ b/internal/grpc/grpc.go
@@ -73,7 +73,7 @@ var (
 func NewGrpcConnection(ctx context.Context, agentConfig *config.Config,
 	commandConfig *config.Command,
 ) (*GrpcConnection, error) {
-	if commandConfig == nil || commandConfig.Server.Type != config.Grpc {
+	if commandConfig == nil || commandConfig.Server == nil || commandConfig.Server.Type != config.Grpc {
 		return nil, errors.New("invalid command server settings")
 	}
 

--- a/internal/grpc/grpc_test.go
+++ b/internal/grpc/grpc_test.go
@@ -638,25 +638,3 @@ func Test_serverAddress(t *testing.T) {
 		})
 	}
 }
-
-func Test_serverAddress_NilCommand(t *testing.T) {
-	ctx := context.Background()
-
-	// Test with nil command config - should panic as the function doesn't handle nil
-	assert.Panics(t, func() {
-		serverAddress(ctx, nil)
-	}, "serverAddress should panic with nil command config")
-}
-
-func Test_serverAddress_NilServer(t *testing.T) {
-	ctx := context.Background()
-
-	// Test with nil server config - should also panic
-	commandConfig := &config.Command{
-		Server: nil,
-	}
-
-	assert.Panics(t, func() {
-		serverAddress(ctx, commandConfig)
-	}, "serverAddress should panic with nil server config")
-}


### PR DESCRIPTION
### Proposed changes

Add passthrough for gRPC connection when using a proxy. This is for scenarios where NGINX Agent has no internet access and can't resolve the hostname of the management server itself.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
