### PR TITLE
Remove allowed directories check on additional OTel config paths

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -367,14 +367,6 @@ func (col *Collector) Validate(allowedDirectories []string) error {
 		err = errors.Join(err, nginxReceiver.Validate(allowedDirectories))
 	}
 
-	for _, path := range col.AdditionalConfigPaths {
-		cleanPath := filepath.Clean(path)
-		pathAllowed := isAllowedDir(cleanPath, allowedDirectories)
-		if !pathAllowed {
-			err = errors.Join(err, fmt.Errorf("additional config path %s not in allowed directories", path))
-		}
-	}
-
 	return err
 }
 


### PR DESCRIPTION
### Proposed changes

Remove allowed directories check from additional OTel config paths provided in the Agent config 
### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
