### PR TITLE
Add script to check container images' agent versions

### DIFF
--- a/.github/actions/az-sync/action.yml
+++ b/.github/actions/az-sync/action.yml
@@ -1,5 +1,0 @@
-name: az-sync
-author: s.breen
-description: az-sync
-runs:
-  using:


### PR DESCRIPTION
### Proposed changes

Adds a script `check-images.sh` which can check the agent version and nginx version of all image tags matching a pattern.

Example:

```shell
> scripts/check-images.sh agentv3 alpine
Checking images in docker-registry.nginx.com/nginx/agentv3
892 tags fetched.
165 tags after filtering.
tags matching 'alpine': 81
:: docker-registry.nginx.com/nginx/agentv3:1-alpine
nginx version: nginx/1.29.3
nginx-agent version v3.5.0-34a13e6
...
```
will return all the tags found for the `agentv3` image which match the pattern `alpine`, and run the commands:
- `nginx -v`
- `nginx-agent -v`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
