### PR TITLE
[Release] Update package-check.sh

### DIFF
--- a/scripts/packages/package-check.sh
+++ b/scripts/packages/package-check.sh
@@ -110,11 +110,11 @@ done
 
 # Aggregate all URIs to fetch
 uris=(
-#  ${DEBIAN[@]}
-#  ${UBUNTU[@]}
-#  ${CENTOS[@]}
-#  ${APK[@]}
-#  ${AMZN[@]}
+  ${DEBIAN[@]}
+  ${UBUNTU[@]}
+  ${CENTOS[@]}
+  ${APK[@]}
+  ${AMZN[@]}
   ${SUSE[@]}
 )
 


### PR DESCRIPTION
### Proposed changes

Updates the `package-check.sh` script.

- Adds Ubuntu 25.10 'Questing Quakka' to supported OSes
- fix typo in the url path for sles15 packages

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
