### PR TITLE
Write manifest file updates to a temp file first

### DIFF
--- a/internal/file/file_operator.go
+++ b/internal/file/file_operator.go
@@ -174,13 +174,13 @@ func (fo *FileOperator) WriteManifestFile(
 	tempManifestFilePath := manifestPath + ".tmp"
 	tempFile, err := os.OpenFile(tempManifestFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, filePerm)
 	if err != nil {
-		return fmt.Errorf("failed to open temporary manifest file: %w", err)
+		return fmt.Errorf("failed to open file %s: %w", tempManifestFilePath, err)
 	}
 
 	if _, err = tempFile.Write(manifestJSON); err != nil {
 		closeFile(ctx, tempFile)
 
-		return fmt.Errorf("failed to write to temporary manifest file: %w", err)
+		return fmt.Errorf("failed to write to file %s: %w", tempManifestFilePath, err)
 	}
 
 	closeFile(ctx, tempFile)
@@ -188,7 +188,7 @@ func (fo *FileOperator) WriteManifestFile(
 	// Verify the contents of the temporary file is JSON
 	file, err := os.ReadFile(tempManifestFilePath)
 	if err != nil {
-		return fmt.Errorf("failed to read temporary manifest file: %w", err)
+		return fmt.Errorf("failed to read file %s: %w", tempManifestFilePath, err)
 	}
 
 	var manifestFiles map[string]*model.ManifestFile
@@ -196,15 +196,15 @@ func (fo *FileOperator) WriteManifestFile(
 	err = json.Unmarshal(file, &manifestFiles)
 	if err != nil {
 		if len(file) == 0 {
-			return fmt.Errorf("temporary manifest file is empty: %w", err)
+			return fmt.Errorf("file %s is empty: %w", tempManifestFilePath, err)
 		}
 
-		return fmt.Errorf("failed to parse temporary manifest file: %w", err)
+		return fmt.Errorf("failed to parse file %s: %w", tempManifestFilePath, err)
 	}
 
 	// Rename the temporary file to the actual manifest file path
 	if renameError := os.Rename(tempManifestFilePath, manifestPath); renameError != nil {
-		return fmt.Errorf("failed to rename temporary manifest file: %w", renameError)
+		return fmt.Errorf("failed to file %s to %s: %w", tempManifestFilePath, manifestPath, renameError)
 	}
 
 	return nil


### PR DESCRIPTION
### Proposed changes

Write manifest file updates to a temp file first, then validate that the temp file contains validate JSON before replacing the current manifest file with the temp one.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
