### PR TITLE
Ensure watchers are enabled before handling NGINX config context update

### DIFF
--- a/internal/watcher/watcher_plugin.go
+++ b/internal/watcher/watcher_plugin.go
@@ -186,12 +186,6 @@ func (w *Watcher) handleEnableWatchers(ctx context.Context, msg *bus.Message) {
 	instanceID := enableWatchersMessage.InstanceID
 	configContext := enableWatchersMessage.ConfigContext
 
-	// if config apply ended in a reload there is no need to reparse the config so an empty config context is sent
-	// from the file plugin
-	if configContext.InstanceID != "" {
-		w.instanceWatcherService.HandleNginxConfigContextUpdate(ctx, instanceID, configContext)
-	}
-
 	w.watcherMutex.Lock()
 	w.instancesWithConfigApplyInProgress = slices.DeleteFunc(
 		w.instancesWithConfigApplyInProgress,
@@ -203,6 +197,12 @@ func (w *Watcher) handleEnableWatchers(ctx context.Context, msg *bus.Message) {
 	w.fileWatcherService.EnableWatcher(ctx)
 	w.instanceWatcherService.SetEnabled(true)
 	w.watcherMutex.Unlock()
+
+	// if config apply ended in a reload there is no need to reparse the config so an empty config context is sent
+	// from the file plugin
+	if configContext.InstanceID != "" {
+		w.instanceWatcherService.HandleNginxConfigContextUpdate(ctx, instanceID, configContext)
+	}
 }
 
 func (w *Watcher) handleConfigApplyRequest(ctx context.Context, msg *bus.Message) {


### PR DESCRIPTION
### Proposed changes

Ensure watchers are enabled before handling NGINX config context update.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
