### PR TITLE
Fix nginx-debug binary not found

### DIFF
--- a/src/core/environment.go
+++ b/src/core/environment.go
@@ -606,6 +606,7 @@ func (env *EnvironmentType) Processes() (result []*Process) {
 		cmd, _ := p.CmdlineWithContext(ctx)
 
 		if env.isNginxProcess(name, cmd) {
+			log.Infof("-------------------- %v", name)
 			nginxProcesses[pid] = p
 		}
 
@@ -656,7 +657,9 @@ func (env *EnvironmentType) Processes() (result []*Process) {
 }
 
 func (env *EnvironmentType) isNginxProcess(name string, cmd string) bool {
-	return !strings.Contains(cmd, "upgrade") && (strings.HasPrefix(cmd, "nginx:") || strings.HasPrefix(cmd, "{nginx-debug} nginx:"))
+	isNameValid := name == "nginx" || name == "nginx-debug"
+	isCmdValid := strings.HasPrefix(cmd, "nginx:") || strings.HasPrefix(cmd, "{nginx-debug} nginx:")
+	return !strings.Contains(cmd, "upgrade") && isNameValid && isCmdValid
 }
 
 func getNginxProcessExe(nginxProcess *process.Process) string {

--- a/src/core/environment_test.go
+++ b/src/core/environment_test.go
@@ -1148,6 +1148,12 @@ func TestGetNginxProcess(t *testing.T) {
 		{
 			name:   "nginx-debug process",
 			pName:  "nginx-debug",
+			cmd:    "nginx: master process /usr/sbin/nginx-debug -c /etc/nginx/nginx.conf",
+			expect: true,
+		},
+		{
+			name:   "nginx-debug process",
+			pName:  "nginx-debug",
 			cmd:    "{nginx-debug} nginx: master process /usr/sbin/nginx-debug -g daemon off;",
 			expect: true,
 		},

--- a/test/integration/vendor/github.com/nginx/agent/v2/src/core/environment.go
+++ b/test/integration/vendor/github.com/nginx/agent/v2/src/core/environment.go
@@ -606,6 +606,7 @@ func (env *EnvironmentType) Processes() (result []*Process) {
 		cmd, _ := p.CmdlineWithContext(ctx)
 
 		if env.isNginxProcess(name, cmd) {
+			log.Infof("-------------------- %v", name)
 			nginxProcesses[pid] = p
 		}
 
@@ -656,7 +657,9 @@ func (env *EnvironmentType) Processes() (result []*Process) {
 }
 
 func (env *EnvironmentType) isNginxProcess(name string, cmd string) bool {
-	return !strings.Contains(cmd, "upgrade") && (strings.HasPrefix(cmd, "nginx:") || strings.HasPrefix(cmd, "{nginx-debug} nginx:"))
+	isNameValid := name == "nginx" || name == "nginx-debug"
+	isCmdValid := strings.HasPrefix(cmd, "nginx:") || strings.HasPrefix(cmd, "{nginx-debug} nginx:")
+	return !strings.Contains(cmd, "upgrade") && isNameValid && isCmdValid
 }
 
 func getNginxProcessExe(nginxProcess *process.Process) string {

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/core/environment.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/core/environment.go
@@ -606,6 +606,7 @@ func (env *EnvironmentType) Processes() (result []*Process) {
 		cmd, _ := p.CmdlineWithContext(ctx)
 
 		if env.isNginxProcess(name, cmd) {
+			log.Infof("-------------------- %v", name)
 			nginxProcesses[pid] = p
 		}
 
@@ -656,7 +657,9 @@ func (env *EnvironmentType) Processes() (result []*Process) {
 }
 
 func (env *EnvironmentType) isNginxProcess(name string, cmd string) bool {
-	return !strings.Contains(cmd, "upgrade") && (strings.HasPrefix(cmd, "nginx:") || strings.HasPrefix(cmd, "{nginx-debug} nginx:"))
+	isNameValid := name == "nginx" || name == "nginx-debug"
+	isCmdValid := strings.HasPrefix(cmd, "nginx:") || strings.HasPrefix(cmd, "{nginx-debug} nginx:")
+	return !strings.Contains(cmd, "upgrade") && isNameValid && isCmdValid
 }
 
 func getNginxProcessExe(nginxProcess *process.Process) string {


### PR DESCRIPTION
Currently Agent v2 is not able to discover the agent process if it is running in debug mode. Due to which NIM is not able to register and gets trapped in an infinite backoff loop while trying to find the NGINX master process.

This change should fix the issue.