### PR TITLE
fix: Ensure stream closed

### DIFF
--- a/internal/file/file_service_operator.go
+++ b/internal/file/file_service_operator.go
@@ -542,6 +542,7 @@ func (fso *FileServiceOperator) sendFileUpdateStreamChunks(
 	// Ensure the stream is closed and wait for the server's response only
 	// after all chunks are sent
 	_, err = updateFileStreamClient.CloseAndRecv()
+
 	return err
 }
 

--- a/test/mock/grpc/mock_management_file_service.go
+++ b/test/mock/grpc/mock_management_file_service.go
@@ -217,6 +217,8 @@ func (mgs *FileService) UpdateFileStream(streamingServer grpc.ClientStreamingSer
 		return writeChunkedFileError
 	}
 
+	streamingServer.SendAndClose(&v1.UpdateFileResponse{})
+
 	return nil
 }
 


### PR DESCRIPTION
### Proposed changes

This PR fixes the file upload logic in `FileServiceOperator` to ensure that when sending files over 1MB (using chunked streaming), the agent closes the gRPC stream and waits for the NGINX One Console response only after all file chunks have been sent.

### Details

- Previously, the stream might not have been properly closed after sending all chunks, potentially causing incomplete uploads or missing server responses.
- Now, after all chunks are sent in `sendFileUpdateStreamChunks`, the agent calls `CloseAndRecv()` on the stream client, ensuring the stream is closed and the server response is received before proceeding.

### Impact

- Ensures reliable file uploads for large files.
- Prevents issues with incomplete or unacknowledged uploads.

+ @nginx-nickc 