### PR TITLE
Ensure stream closed

### DIFF
--- a/internal/file/file_service_operator.go
+++ b/internal/file/file_service_operator.go
@@ -539,7 +539,11 @@ func (fso *FileServiceOperator) sendFileUpdateStreamChunks(
 		chunkID++
 	}
 
-	return nil
+	// Ensure the stream is closed and wait for the server's response only
+	// after all chunks are sent
+	_, err = updateFileStreamClient.CloseAndRecv()
+
+	return err
 }
 
 func (fso *FileServiceOperator) sendFileUpdateStreamChunk(

--- a/test/mock/grpc/mock_management_file_service.go
+++ b/test/mock/grpc/mock_management_file_service.go
@@ -217,6 +217,8 @@ func (mgs *FileService) UpdateFileStream(streamingServer grpc.ClientStreamingSer
 		return writeChunkedFileError
 	}
 
+	streamingServer.SendAndClose(&v1.UpdateFileResponse{})
+
 	return nil
 }
 


### PR DESCRIPTION
### Proposed changes

This PR fixes the file upload logic in FileServiceOperator to ensure that when sending files over 1MB (using chunked streaming), the agent closes the gRPC stream and waits for the NGINX One Console response only after all file chunks have been sent.

### Details
Previously, the stream might not have been properly closed after sending all chunks, potentially causing incomplete uploads or missing server responses.
Now, after all chunks are sent in sendFileUpdateStreamChunks, the agent calls CloseAndRecv() on the stream client, ensuring the stream is closed and the server response is received before proceeding.
### Impact

- Ensures reliable file uploads for large files.
- Prevents issues with incomplete or unacknowledged uploads.

Copy of https://github.com/nginx/agent/pull/1522 due to issue with PR 


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
