### PR TITLE
[V2] Add Error Log if NGINX is not running on Startup 

### DIFF
--- a/src/plugins/registration.go
+++ b/src/plugins/registration.go
@@ -45,6 +45,7 @@ type OneTimeRegistration struct {
 	pipeline                      core.MessagePipeInterface
 	dataplaneSoftwareDetailsMutex sync.Mutex
 	processes                     []*core.Process
+	logOnce                       sync.Once
 }
 
 func NewOneTimeRegistration(
@@ -186,6 +187,10 @@ func (r *OneTimeRegistration) registerAgent() {
 				log.Tracef("NGINX non-master process: %d", proc.Pid)
 			}
 		}
+
+		r.logOnce.Do(func() {
+			log.Errorf("NGINX master process not found yet, waiting for NGINX to start...")
+		})
 		return fmt.Errorf("waiting for NGINX master process... ")
 	}
 	err := backoff.WaitUntil(

--- a/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/registration.go
+++ b/test/performance/vendor/github.com/nginx/agent/v2/src/plugins/registration.go
@@ -45,6 +45,7 @@ type OneTimeRegistration struct {
 	pipeline                      core.MessagePipeInterface
 	dataplaneSoftwareDetailsMutex sync.Mutex
 	processes                     []*core.Process
+	logOnce                       sync.Once
 }
 
 func NewOneTimeRegistration(
@@ -186,6 +187,10 @@ func (r *OneTimeRegistration) registerAgent() {
 				log.Tracef("NGINX non-master process: %d", proc.Pid)
 			}
 		}
+
+		r.logOnce.Do(func() {
+			log.Errorf("NGINX master process not found yet, waiting for NGINX to start...")
+		})
 		return fmt.Errorf("waiting for NGINX master process... ")
 	}
 	err := backoff.WaitUntil(


### PR DESCRIPTION
### Proposed changes

If NGINX is not running when Agent starts and tries to register log a Error saying that Agent is waiting for an NGINX master process. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
