### PR TITLE
Add workflow for generating SBOM doc from a binary

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,52 @@
+name: Generate SBOM Document for binary
+
+on:
+  workflow_dispatch:
+    inputs:
+      packageVersion:
+        description: 'Agent version'
+        type: string
+        required: true
+      runId:
+        description: 'Run ID of the workflow that built the artifacts'
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    name: Create SBOM Document
+    runs-on: ubuntu-22.04
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    permissions:
+      id-token: write # for OIDC authentication
+      contents: read # Needed to download artifacts
+    strategy:
+      matrix:
+        osarch: [amd64, arm64]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download nginx-agent binary artifacts
+        if: ${{ inputs.runId != '' }}
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # 7.0.0
+        with:
+          name: nginx-agent-binaries-${{ inputs.packageVersion }}-${{ matrix.osarch }}
+          path: binaries
+          run-id: ${{ inputs.runId }}
+          github-token: ${{ github.token }}
+
+      - name: Generate SBOM from binary
+        uses: nginxinc/compliance-rules/.github/actions/sbom@main
+        with:
+          binary-name: binaries/nginx_agent_${{ inputs.packageVersion }}_${{ matrix.osarch }}
+          product-name: nginx-agent
+          release-version: ${{ inputs.packageVersion }}
+          artifactory-user: ${{ env.artifactory-user }}
+          artifactory-token: ${{ env.artifactory-token }}
+          az-vault-client-id: ${{ env.az_vault_sec_client_id }}
+          az-vault-tenant-id: ${{ env.az_vault_sec_tenant_id }}
+          az-vault-subscription-id: ${{ env.az_vault_sec_subscription_id }}


### PR DESCRIPTION
### Proposed changes

This PR adds a workflow that generates, signs and stores SBOM document for Go binaries.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
