### PR TITLE
added ol in rhel-family distro group

### DIFF
--- a/scripts/packages/postremove.sh
+++ b/scripts/packages/postremove.sh
@@ -63,7 +63,7 @@ case "$ID" in
             cleanup
         fi
         ;;
-    rhel|fedora|centos|amzn|almalinux|rocky)
+    rhel|fedora|centos|amzn|almalinux|rocky|ol)
         if [ "$1" = "0" ]; then
             stop_agent_systemd
             disable_agent_systemd


### PR DESCRIPTION
Ensure Oracle Linux ("ol") is treated as an RHEL-family distro so the RPM uninstall/upgrade path uses the intended rhel-family cleanup branch instead of the wildcard branch.