### PR TITLE
Rename tcplog receiver to tcp_log

### DIFF
--- a/internal/collector/otelcol.tmpl
+++ b/internal/collector/otelcol.tmpl
@@ -120,7 +120,7 @@ receivers:
 {{- end }}
 
 {{- range $index, $tcplogReceiver := .Receivers.TcplogReceivers }}
-  tcplog/{{$index}}:
+  tcp_log/{{$index}}:
     listen_address: "{{- .ListenAddress -}}"
     operators:
 {{- range $index, $operator := .Operators }}
@@ -317,7 +317,7 @@ service:
       receivers:
         {{- range $receiver := $pipeline.Receivers }}
           {{- if eq $receiver "tcplog/nginx_app_protect" }}
-        - tcplog/nginx_app_protect
+        - tcp_log/nginx_app_protect
           {{- else }}
         - {{ $receiver }}
           {{- end }}

--- a/internal/collector/settings_test.go
+++ b/internal/collector/settings_test.go
@@ -200,7 +200,7 @@ func TestTemplateWrite(t *testing.T) {
 	}
 	cfg.Collector.Pipelines.Logs = make(map[string]*config.Pipeline)
 	cfg.Collector.Pipelines.Logs["default"] = &config.Pipeline{
-		Receivers:  []string{"tcplog/default"},
+		Receivers:  []string{"tcp_log/default"},
 		Processors: []string{"securityviolationsfilter/default", "resource/default", "batch/default"},
 		Exporters:  []string{"otlp_grpc/default", "debug"},
 	}

--- a/test/config/collector/test-opentelemetry-collector-agent.yaml
+++ b/test/config/collector/test-opentelemetry-collector-agent.yaml
@@ -53,7 +53,7 @@ receivers:
       location: ""
       ca: ""
     collection_interval: 20s
-  tcplog/default:
+  tcp_log/default:
     listen_address: "localhost:151"
     operators:
       - type: add
@@ -138,7 +138,7 @@ service:
         - debug
     logs/default:
       receivers:
-        - tcplog/default
+        - tcp_log/default
       processors:
         - securityviolationsfilter/default
         - resource/default


### PR DESCRIPTION
### Proposed changes

Issue: The tcplog receiver has been renamed to tcp_log in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47369

Proposed fix: Rename tcplog -> tcp_log

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
