### PR TITLE
Add vulncheck to dev-v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,17 @@ jobs:
           args: -c ../scripts/.golangci.yml
           skip-cache: true
 
+  vulnerability-scan:
+    name: Vulnerability Scan
+    uses: ./.github/workflows/vulncheck.yml
+    permissions:
+      contents: read
+      security-events: write # for reporting vulnerabilities via code-scanning API
+    with:
+      # Use PR head SHA for pull requests (supports PRs from forks).
+      # Fallback to ref name for other contexts.
+      target-branch: ${{ github.event.pull_request.head.sha || github.ref_name }}
+
   unit-test:
     name: Unit Tests
     runs-on: ubuntu-24.04

--- a/.github/workflows/nightly-scans.yml
+++ b/.github/workflows/nightly-scans.yml
@@ -1,0 +1,18 @@
+name: nightly-scans.yml
+on:
+  schedule:
+    - cron: '0 2 * * *'  # Runs daily at 2:00 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan-v2:
+    name: Vulnerability Scan - dev-v2
+    uses: ./.github/workflows/vulncheck.yml
+    permissions:
+      contents: read
+      security-events: write # for reporting vulnerabilities via code-scanning API
+    with:
+      target-branch: 'dev-v2'

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -1,0 +1,60 @@
+name: vulncheck.yaml
+on:
+  workflow_call:
+    inputs:
+      target-branch:
+        description: 'Target branch to run govulncheck against'
+        type: string
+        required: true
+        default: 'dev-v2'
+  workflow_dispatch:
+    inputs:
+      target-branch:
+        description: 'Target branch to run govulncheck against'
+        required: true
+        default: 'dev-v2'
+
+permissions:
+  contents: read
+
+jobs:
+  vulncheck:
+    name: Vulnerability Check
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write # for reporting vulnerabilities via code-scanning API
+    env:
+      GOPROXY: "https://proxy.golang.org,direct"
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          # Use inputs.target-branch which can be a branch name or SHA.
+          # Falls back to github.ref_name or 'main' if not provided.
+          ref: ${{ inputs.target-branch || github.ref_name || 'dev-v2' }}
+
+      - name: Check Go version
+        id: get-go-version
+        run: |
+          echo "Reading from go.mod"
+          GO_VERSION=$(grep -E "^toolchain " go.mod | awk -F' ' '{print $2}' | tr -d 'go')
+          echo "Found $GO_VERSION"
+          echo "go-version="$GO_VERSION"" >> $GITHUB_OUTPUT
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ steps.get-go-version.outputs.go-version }}
+          check-latest: true
+          cache: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+
+      - name: Run govulncheck
+        id: govulncheck
+        run: |
+          # Scan only non-test packages to avoid false positives from test-only dependencies
+          govulncheck -scan=symbol $(go list ./... | grep -v '/test/')

--- a/docs/proto/proto.md
+++ b/docs/proto/proto.md
@@ -18,9 +18,6 @@
     - [AgentConnectStatus.StatusCode](#f5-nginx-agent-sdk-AgentConnectStatus-StatusCode)
     - [AgentLogging.Level](#f5-nginx-agent-sdk-AgentLogging-Level)
   
-- [command_svc.proto](#command_svc-proto)
-    - [Commander](#f5-nginx-agent-sdk-Commander)
-  
 - [command.proto](#command-proto)
     - [AgentActivityStatus](#f5-nginx-agent-sdk-AgentActivityStatus)
     - [ChunkedResourceChunk](#f5-nginx-agent-sdk-ChunkedResourceChunk)
@@ -41,6 +38,9 @@
     - [CommandStatusResponse.CommandStatus](#f5-nginx-agent-sdk-CommandStatusResponse-CommandStatus)
     - [NginxConfigStatus.Status](#f5-nginx-agent-sdk-NginxConfigStatus-Status)
     - [UploadStatus.TransferStatus](#f5-nginx-agent-sdk-UploadStatus-TransferStatus)
+  
+- [command_svc.proto](#command_svc-proto)
+    - [Commander](#f5-nginx-agent-sdk-Commander)
   
 - [common.proto](#common-proto)
     - [CertificateDates](#f5-nginx-agent-sdk-CertificateDates)
@@ -336,34 +336,6 @@ Log level enum
  
 
  
-
- 
-
-
-
-<a name="command_svc-proto"></a>
-<p align="right"><a href="#top">Top</a></p>
-
-## command_svc.proto
-
-
- 
-
- 
-
- 
-
-
-<a name="f5-nginx-agent-sdk-Commander"></a>
-
-### Commander
-Represents a service used to sent command messages between the management server and the agent.
-
-| Method Name | Request Type | Response Type | Description |
-| ----------- | ------------ | ------------- | ------------|
-| CommandChannel | [Command](#f5-nginx-agent-sdk-Command) stream | [Command](#f5-nginx-agent-sdk-Command) stream | A Bidirectional streaming RPC established by the agent and is kept open |
-| Download | [DownloadRequest](#f5-nginx-agent-sdk-DownloadRequest) | [DataChunk](#f5-nginx-agent-sdk-DataChunk) stream | A streaming RPC established by the agent and is used to download resources associated with commands The download stream will be kept open for the duration of the data transfer and will be closed when its done. The transfer is a stream of chunks as follows: header -&gt; data chunk 1 -&gt; data chunk N. Each data chunk is of a size smaller than the maximum gRPC payload |
-| Upload | [DataChunk](#f5-nginx-agent-sdk-DataChunk) stream | [UploadStatus](#f5-nginx-agent-sdk-UploadStatus) | A streaming RPC established by the agent and is used to upload resources associated with commands |
 
  
 
@@ -675,6 +647,34 @@ Transfer status enum
  
 
  
+
+ 
+
+
+
+<a name="command_svc-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## command_svc.proto
+
+
+ 
+
+ 
+
+ 
+
+
+<a name="f5-nginx-agent-sdk-Commander"></a>
+
+### Commander
+Represents a service used to sent command messages between the management server and the agent.
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| CommandChannel | [Command](#f5-nginx-agent-sdk-Command) stream | [Command](#f5-nginx-agent-sdk-Command) stream | A Bidirectional streaming RPC established by the agent and is kept open |
+| Download | [DownloadRequest](#f5-nginx-agent-sdk-DownloadRequest) | [DataChunk](#f5-nginx-agent-sdk-DataChunk) stream | A streaming RPC established by the agent and is used to download resources associated with commands The download stream will be kept open for the duration of the data transfer and will be closed when its done. The transfer is a stream of chunks as follows: header -&gt; data chunk 1 -&gt; data chunk N. Each data chunk is of a size smaller than the maximum gRPC payload |
+| Upload | [DataChunk](#f5-nginx-agent-sdk-DataChunk) stream | [UploadStatus](#f5-nginx-agent-sdk-UploadStatus) | A streaming RPC established by the agent and is used to upload resources associated with commands |
 
  
 


### PR DESCRIPTION
### Proposed changes

This PR adds automated vulnerability scanning to the dev-v2 branch.
Currently, the dev-v2 workflow does not perform vulnerability checks, which means newly introduced dependencies or changes are not automatically evaluated for known security issues. To improve security visibility and catch vulnerabilities earlier in the development cycle, this PR introduces two new scanning triggers:

Push-based scanning: Run a vulnerability scan whenever code is pushed to the dev-v2 branch.
Scheduled scanning: Run a nightly vulnerability scan to identify newly disclosed vulnerabilities in existing dependencies, even when no code changes have been made.
### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
