### PR TITLE
Add Ubuntu 26.04 "resolute" packaging support

### DIFF
--- a/Makefile.packaging
+++ b/Makefile.packaging
@@ -12,7 +12,7 @@ PACKAGE_BUILD       ?= 1
 PACKAGE_VERSION     ?= $(shell echo ${VERSION} | tr -d 'v')
 TARBALL_NAME        := $(PACKAGE_PREFIX).tar.gz
 
-DEB_DISTROS         ?= ubuntu-questing-25.10 ubuntu-plucky-25.04 ubuntu-noble-24.04 ubuntu-jammy-22.04 ubuntu-focal-20.04 debian-trixie-13 debian-bookworm-12 debian-bullseye-11
+DEB_DISTROS         ?= ubuntu-resolute-26.04 ubuntu-questing-25.10 ubuntu-plucky-25.04 ubuntu-noble-24.04 ubuntu-jammy-22.04 ubuntu-focal-20.04 debian-trixie-13 debian-bookworm-12 debian-bullseye-11
 DEB_ARCHS           ?= arm64 amd64
 RPM_DISTROS         ?= suse-15-x86_64 suse-16-x86_64
 RPM_ARCH            := x86_64

--- a/scripts/packages/package-check.sh
+++ b/scripts/packages/package-check.sh
@@ -71,7 +71,7 @@ for alpine_version in "${ALPINE_VERSIONS[@]}"; do
 done
 
 UBUNTU=()
-UBUNTU_VERSIONS=("jammy" "noble" "plucky" "questing")
+UBUNTU_VERSIONS=("resolute" "jammy" "noble" "plucky" "questing")
 DEB_ARCH=("amd64" "arm64")
 for ubuntu_version in "${UBUNTU_VERSIONS[@]}"; do
     for arch in ${DEB_ARCH[@]}; do


### PR DESCRIPTION
### Proposed changes

Add Ubuntu 26.04 "resolute" to packaging support. Closes #1735.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
