### PR TITLE
chore: update CODEOWNERS for dev-v2 branch ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @nginx/nginx-agent
+* @nginx/nginx-agent-v2


### PR DESCRIPTION
### Proposed changes

Updates `CODEOWNERS` on the `dev-v2` branch to assign ownership to the `@nginx/nginx-agent-v2` team instead of the v3 team (`@nginx/nginx-agent`).

This is required to enforce branch-based team access control across the two active development lines in this repo:

- `main` — owned by `@nginx/nginx-agent` (Agent v3 team)
- `dev-v2` — owned by `@nginx/nginx-agent-v2` (Agent v2 team)

Since GitHub evaluates `CODEOWNERS` from the **base branch** of a PR, each branch independently defines its own required reviewers. After this merges, any PR targeting `dev-v2` will require approval from `@nginx/nginx-agent-v2` members, preventing cross-team merges.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13