### PR TITLE
Bound NGINX Plus API requests with a timeout

### DIFF
--- a/internal/nginx/nginx_plugin_test.go
+++ b/internal/nginx/nginx_plugin_test.go
@@ -56,9 +56,36 @@ func TestNginx_createPlusAPIError(t *testing.T) {
 	expectedJSON, err := json.Marshal(expectedErr)
 	require.NoError(t, err)
 
-	result := createPlusAPIError(errors.New(s))
+	timeoutErr := errors.New("Get \"http://nginx-plus-api/api/9/http/upstreams/u/servers\": " +
+		"context deadline exceeded (Client.Timeout exceeded while awaiting headers)")
 
-	assert.Equal(t, errors.New(string(expectedJSON)), result)
+	tests := []struct {
+		apiErr   error
+		expected error
+		name     string
+	}{
+		{
+			name:     "Test 1: Structured NGINX Plus API error is reformatted",
+			apiErr:   errors.New(s),
+			expected: errors.New(string(expectedJSON)),
+		},
+		{
+			name:     "Test 2: Non-API error is returned unchanged",
+			apiErr:   timeoutErr,
+			expected: timeoutErr,
+		},
+		{
+			name:     "Test 3: Nil error returns nil",
+			apiErr:   nil,
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			assert.Equal(tt, test.expected, createPlusAPIError(test.apiErr))
+		})
+	}
 }
 
 func TestNginx_Process_APIAction_GetHTTPServers(t *testing.T) {

--- a/internal/nginx/nginx_service.go
+++ b/internal/nginx/nginx_service.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/nginx/agent/v3/pkg/host/exec"
 	"github.com/nginx/agent/v3/pkg/nginxprocess"
@@ -41,6 +42,8 @@ import (
 const (
 	apiFormat         = "http://%s%s"
 	unixPlusAPIFormat = "http://nginx-plus-api%s"
+
+	defaultPlusAPITimeout = 30 * time.Second
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6@v6.11.2 -generate
@@ -392,7 +395,13 @@ func (n *NginxService) createPlusClient(ctx context.Context, instance *mpi.Insta
 		endpoint = fmt.Sprintf(apiFormat, plusAPI.GetListen(), plusAPI.GetLocation())
 	}
 
-	httpClient := http.DefaultClient
+	plusAPITimeout := n.agentConfig.Client.HTTP.Timeout
+	if plusAPITimeout <= 0 {
+		plusAPITimeout = defaultPlusAPITimeout
+	}
+	slog.DebugContext(ctx, "Creating NGINX Plus API client", "timeout", plusAPITimeout)
+
+	httpClient := &http.Client{Timeout: plusAPITimeout}
 	caCertLocation := plusAPI.GetCa()
 	if caCertLocation != "" {
 		slog.DebugContext(ctx, "Reading CA certificate", "file_path", caCertLocation)
@@ -404,6 +413,7 @@ func (n *NginxService) createPlusClient(ctx context.Context, instance *mpi.Insta
 		caCertPool.AppendCertsFromPEM(caCert)
 
 		httpClient = &http.Client{
+			Timeout: plusAPITimeout,
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
 					RootCAs:    caCertPool,
@@ -413,7 +423,8 @@ func (n *NginxService) createPlusClient(ctx context.Context, instance *mpi.Insta
 		}
 	}
 	if strings.HasPrefix(plusAPI.GetListen(), "unix:") {
-		httpClient = socketClient(ctx, strings.TrimPrefix(plusAPI.GetListen(), "unix:"))
+		httpClient = socketClient(plusAPITimeout,
+			strings.TrimPrefix(plusAPI.GetListen(), "unix:"))
 	}
 
 	return client.NewNginxClient(endpoint,
@@ -449,11 +460,12 @@ func (n *NginxService) updateResourceInfo(ctx context.Context) {
 	}
 }
 
-func socketClient(ctx context.Context, socketPath string) *http.Client {
+func socketClient(timeout time.Duration, socketPath string) *http.Client {
 	return &http.Client{
+		Timeout: timeout,
 		Transport: &http.Transport{
-			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				dialer := &net.Dialer{}
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				dialer := &net.Dialer{Timeout: timeout}
 				return dialer.DialContext(ctx, "unix", socketPath)
 			},
 		},
@@ -477,7 +489,7 @@ func createPlusAPIError(apiErr error) error {
 
 	if len(errorSlice) < 5 {
 		slog.Error("Unable to marshal NGINX Plus API error")
-		return nil
+		return apiErr
 	}
 
 	plusErr := plusAPIErr{


### PR DESCRIPTION
The NGINX Plus API HTTP client had no timeout, so a Plus API call that never responds (e.g. an unresponsive Plus API socket) blocks the agent's message bus indefinitely. The agent then never sends a `DataPlaneResponse`, leaving the management plane waiting on it.

- Set the HTTP client timeout from `Client.HTTP.Timeout` (falling back to a default when unset), following the existing datasource/config pattern.
- Timeout the unix socket dial with `net.Dialer.Timeout` and pass the per-request context through, following internal/grpc/proxy_dialer.go, so a stuck socket cannot block the dial.
- Return the original error from createPlusAPIError when it cannot be parsed into the structured Plus API format (e.g. a timeout). Previously it returned nil, so a failed apply was reported to the management plane as `COMMAND_STATUS_OK`instead of a failure.


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
