### PR TITLE
fix: nil pointer dereference in containerIDFromMountInfo

### DIFF
--- a/pkg/host/info.go
+++ b/pkg/host/info.go
@@ -267,18 +267,16 @@ func containsContainerReference(cgroupFile string) (bool, error) {
 // Supports cgroup v1 and v2. Reading "/proc/1/cpuset" would only work for cgroups v1
 // mountInfo is the path: "/proc/self/mountinfo"
 func containerIDFromMountInfo(mountInfo string) (string, error) {
-	var errs error
 	mInfoFile, err := os.Open(mountInfo)
+	if err != nil {
+		return "", fmt.Errorf("container ID not found in %s: %w", mountInfo, err)
+	}
 	defer func(f *os.File) {
 		closeErr := f.Close()
 		if closeErr != nil {
-			errs = errors.Join(err, closeErr)
+			err = errors.Join(err, closeErr)
 		}
 	}(mInfoFile)
-
-	if err != nil {
-		return "", errors.Join(errs, err)
-	}
 
 	fileScanner := bufio.NewScanner(mInfoFile)
 	fileScanner.Split(bufio.ScanLines)
@@ -298,7 +296,7 @@ func containerIDFromMountInfo(mountInfo string) (string, error) {
 		}
 	}
 
-	return "", errors.Join(errs, fmt.Errorf("container ID not found in %s", mountInfo))
+	return "", fmt.Errorf("container ID not found in %s", mountInfo)
 }
 
 // containerIDFromPatterns checks a word against multiple regex patterns to extract the container ID.

--- a/pkg/host/info_test.go
+++ b/pkg/host/info_test.go
@@ -637,6 +637,14 @@ func TestInfo_ParseOsReleaseFile(t *testing.T) {
 	}
 }
 
+func TestInfo_containerIDFromMountInfo(t *testing.T) {
+	t.Run("Test 1: non-existent mountinfo file returns error without panic", func(t *testing.T) {
+		_, err := containerIDFromMountInfo("/non/existent/mountinfo/path")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "container ID not found in")
+	})
+}
+
 func TestInfo_containerIDFromECS(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
**Summary**

Code cleanup in `containerIDFromMountInfo` (`pkg/host/info.go`): move the `os.Open` error check before the `defer` registration, consistent with the idiomatic Go pattern used by `readOsRelease` in the same file. Remove the redundant `errs` local variable.

**Context**

As noted by @Akshay2191, the original code does not panic — `(*os.File).Close()` is nil-safe. This is not a bug fix but a stylistic cleanup to align the error-handling pattern with `readOsRelease`.

**Changes**

- Move `os.Open` error check before `defer` registration (matches `readOsRelease`).
- Remove the unnecessary `errs` variable; use `fmt.Errorf` directly.

**Test**

- `TestInfo_containerIDFromMountInfo`: verifies that calling `containerIDFromMountInfo` with a non-existent path returns an error without panicking.
