### PR TITLE
fix: reject non-NGINX processes, classify nginx master by cmdline role instead of PPID (dev-v2)

### DIFF
--- a/src/core/environment.go
+++ b/src/core/environment.go
@@ -597,12 +597,8 @@ func (env *EnvironmentType) Processes() (result []*Process) {
 		user, _ := nginxProcess.UsernameWithContext(ctx)
 		ppid, _ := nginxProcess.PpidWithContext(ctx)
 		cmd, _ := nginxProcess.CmdlineWithContext(ctx)
-		isMaster := false
 
-		_, ok := nginxProcesses[ppid]
-		if !ok {
-			isMaster = true
-		}
+		isMaster := isNginxMaster(cmd)
 
 		var exe string
 		if isMaster {
@@ -633,30 +629,17 @@ func (env *EnvironmentType) Processes() (result []*Process) {
 	return processList
 }
 
-// nginxCmdPrefixes lists the command-line prefixes real NGINX processes use to
-// identify themselves. Restricting the command match to these prefixes prevents
-// third-party processes that borrow the "nginx:" prefix (for example the
-// Dynatrace "nginx: OneAgent companion process") from being classified as
-// NGINX and mistakenly treated as a master, which would cause reload SIGHUPs
-// to be delivered to the wrong PID.
-var nginxCmdPrefixes = []string{
-	"nginx: master process",
-	"nginx: worker process",
-	"nginx: cache manager process",
-	"nginx: cache loader process",
-}
-
 func (env *EnvironmentType) isNginxProcess(name string, cmd string) bool {
 	isNameValid := name == "nginx" || name == "nginx-debug"
-	if !isNameValid || strings.Contains(cmd, "upgrade") {
-		return false
-	}
-	for _, prefix := range nginxCmdPrefixes {
-		if strings.HasPrefix(cmd, prefix) || strings.HasPrefix(cmd, "{nginx-debug} "+prefix) {
-			return true
-		}
-	}
-	return false
+	isCmdValid := strings.HasPrefix(cmd, "nginx:") || strings.HasPrefix(cmd, "{nginx-debug} nginx:")
+	return !strings.Contains(cmd, "upgrade") && isNameValid && isCmdValid
+}
+
+// isNginxMaster reports whether the given process command line belongs to an
+// nginx master process.
+func isNginxMaster(cmd string) bool {
+	return strings.HasPrefix(cmd, "nginx: master") ||
+		strings.HasPrefix(cmd, "{nginx-debug} nginx: master")
 }
 
 func getNginxProcessExe(nginxProcess *process.Process) string {

--- a/src/core/environment.go
+++ b/src/core/environment.go
@@ -633,10 +633,30 @@ func (env *EnvironmentType) Processes() (result []*Process) {
 	return processList
 }
 
+// nginxCmdPrefixes lists the command-line prefixes real NGINX processes use to
+// identify themselves. Restricting the command match to these prefixes prevents
+// third-party processes that borrow the "nginx:" prefix (for example the
+// Dynatrace "nginx: OneAgent companion process") from being classified as
+// NGINX and mistakenly treated as a master, which would cause reload SIGHUPs
+// to be delivered to the wrong PID.
+var nginxCmdPrefixes = []string{
+	"nginx: master process",
+	"nginx: worker process",
+	"nginx: cache manager process",
+	"nginx: cache loader process",
+}
+
 func (env *EnvironmentType) isNginxProcess(name string, cmd string) bool {
 	isNameValid := name == "nginx" || name == "nginx-debug"
-	isCmdValid := strings.HasPrefix(cmd, "nginx:") || strings.HasPrefix(cmd, "{nginx-debug} nginx:")
-	return !strings.Contains(cmd, "upgrade") && isNameValid && isCmdValid
+	if !isNameValid || strings.Contains(cmd, "upgrade") {
+		return false
+	}
+	for _, prefix := range nginxCmdPrefixes {
+		if strings.HasPrefix(cmd, prefix) || strings.HasPrefix(cmd, "{nginx-debug} "+prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func getNginxProcessExe(nginxProcess *process.Process) string {

--- a/src/core/environment_test.go
+++ b/src/core/environment_test.go
@@ -1157,17 +1157,6 @@ func TestGetNginxProcess(t *testing.T) {
 			cmd:    "{nginx-debug} nginx: master process /usr/sbin/nginx-debug -g daemon off;",
 			expect: true,
 		},
-		{
-			// Third-party APM agents (e.g. Dynatrace OneAgent) inject a
-			// helper process that reports itself as "nginx: OneAgent
-			// companion process" with process name "nginx". It must not
-			// be classified as an NGINX process; otherwise it can be
-			// mistaken for a second master and receive the reload SIGHUP.
-			name:   "OneAgent companion process is not nginx",
-			pName:  "nginx",
-			cmd:    "nginx: OneAgent companion process",
-			expect: false,
-		},
 	}
 
 	for _, tt := range tests {
@@ -1178,4 +1167,11 @@ func TestGetNginxProcess(t *testing.T) {
 		})
 		assert.Equal(t, tt.expect, isNginxProcess)
 	}
+}
+
+func TestIsNginxMaster(t *testing.T) {
+	assert.True(t, isNginxMaster("nginx: master process /usr/sbin/nginx -c /etc/nginx/nginx.conf"))
+	assert.True(t, isNginxMaster("{nginx-debug} nginx: master process /usr/sbin/nginx-debug -g daemon off;"))
+	assert.False(t, isNginxMaster("nginx: worker process"))
+	assert.False(t, isNginxMaster("nginx: OneAgent companion process"))
 }

--- a/src/core/environment_test.go
+++ b/src/core/environment_test.go
@@ -1157,6 +1157,17 @@ func TestGetNginxProcess(t *testing.T) {
 			cmd:    "{nginx-debug} nginx: master process /usr/sbin/nginx-debug -g daemon off;",
 			expect: true,
 		},
+		{
+			// Third-party APM agents (e.g. Dynatrace OneAgent) inject a
+			// helper process that reports itself as "nginx: OneAgent
+			// companion process" with process name "nginx". It must not
+			// be classified as an NGINX process; otherwise it can be
+			// mistaken for a second master and receive the reload SIGHUP.
+			name:   "OneAgent companion process is not nginx",
+			pName:  "nginx",
+			cmd:    "nginx: OneAgent companion process",
+			expect: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
EnvironmentType.Processes() inferred IsMaster by checking whether a candidate nginx process's PPID was itself in the discovered nginx-process set — any nginx-named process whose parent was not another nginx process was flagged as a master.

This breaks when another tool injects a helper process that borrows the nginx: cmdline convention and runs under PID 1. A concrete case observed in the field: Dynatrace OneAgent injects a [nginx: OneAgent companion process] (name nginx, ppid 1), which the PPID heuristic classifies as a second master. Downstream, UpdateNginxDetailsFromProcesses keys nginxDetailsMap by the derived nginxId, both "masters" collide on the same key, and Go's non-deterministic map iteration decides which PID the agent sends the reload SIGHUP to. When the impostor wins, nginx -s reload silently no-ops while the agent still reports success.

Align v2's nginx master-process classification with the approach already used in NGINX Agent v3 [pkg/nginxprocess.Process.IsMaster] identify the master by the nginx-reported role prefix on the process command line rather than by parent-PID inference.

### Proposed changes

Add [isNginxMaster(cmd string) bool] — mirrors the v3 implementation, checks for the nginx: master / {nginx-debug} nginx: master cmdline prefix.
Use it in Processes() in place of the PPID-based inference.
[isNginxProcess] (the collection filter) is unchanged; only role classification moves from PPID to cmdline.


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [x] I have run ```make install-tools``` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [x] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13
