### PR TITLE
Bump Go toolchain to 1.26.7 to remediate standard-library CVEs (dev-v2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nginx/agent/v2
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.7
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -2,7 +2,7 @@ module github.com/nginx/agent/sdk/v2
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.7
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0


### PR DESCRIPTION
### Proposed changes

Bumps the Go `toolchain` directive from `go1.26.5` to `go1.26.7` in both `go.mod` and `sdk/go.mod`.

This is the CVE-remediation change for the **2.46.8** release. It resolves **7 code-reachable Go standard-library CVEs** (net/url, html/template, crypto/tls ×2, net/http ×2, encoding/xml, encoding/asn1) reported by `govulncheck`:

| CVE ID | Package | Fixed in |
|--------|---------|----------|
| GO-2026-6218 | net/url | go1.26.6 |
| GO-2026-6091 | html/template | go1.26.6 |
| GO-2026-6090 | crypto/tls | go1.26.6 |
| GO-2026-6089 | net/http | go1.26.6 |
| GO-2026-6088 | encoding/xml | go1.26.6 |
| GO-2026-5972 | encoding/asn1 | go1.26.6 |
| GO-2026-5026 | net/http (idna) | go1.26.6 |

**Alternative to #1884** (which bumps to 1.27.0). 1.27.0 fixes the same CVEs but additionally breaks CI — golangci-lint (`v2.10.1`, built with Go 1.26) refuses to run against a 1.27 target, and the SDK zip-checksum tests fail (Go 1.27 changed the gzip encoder output; contents unchanged). 1.26.7 delivers the full CVE fix with zero collateral breakage. Reserving 1.27.0 (#1884) for 2.47.0.

Verified locally: `go build ./...` OK; SDK tests pass; `govulncheck -scan=symbol` under go1.26.7 reports **"No vulnerabilities found."**

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/docs/CONTRIBUTING.md) document
- [ ] I have run `make install-tools` and have attached any dependency changes to this pull request
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] If applicable, I have updated any relevant documentation ([`README.md`](https://github.com/nginx/agent/blob/main/README.md))
- [ ] If applicable, I have tested my cross-platform changes on Ubuntu 22, Redhat 8, SUSE 15 and FreeBSD 13