### PR TITLE
fix: ignore proxy_protocol listen sockets during api discovery (#978)

### DIFF
--- a/internal/datasource/config/nginx_config_parser.go
+++ b/internal/datasource/config/nginx_config_parser.go
@@ -906,6 +906,9 @@ func (ncp *NginxConfigParser) parseAddressFromServerDirective(parent *crossplane
 
 	for _, dir := range parent.Block {
 		if dir.Directive == "listen" {
+			if ncp.isProxyProtocolListenDirective(dir) {
+				continue
+			}
 			for _, host := range hosts {
 				port, host = ncp.parseListenDirectiveAddress(dir, port, host)
 				addresses = append(addresses, host+":"+port)
@@ -949,6 +952,22 @@ func (ncp *NginxConfigParser) isPort(value string) bool {
 	port, err := strconv.Atoi(value)
 
 	return err == nil && port >= 1 && port <= 65535
+}
+
+// checks if any of the arguments contain "proxy_protocol".
+func (ncp *NginxConfigParser) hasProxyProtocolArgument(args []string) bool {
+	for i := 1; i < len(args); i++ {
+		if args[i] == "proxy_protocol" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// checks if a directive is a listen directive with proxy_protocol enabled.
+func (ncp *NginxConfigParser) isProxyProtocolListenDirective(dir *crossplane.Directive) bool {
+	return dir.Directive == "listen" && ncp.hasProxyProtocolArgument(dir.Args)
 }
 
 // checks if any of the arguments contain "ssl".

--- a/internal/datasource/config/nginx_config_parser_test.go
+++ b/internal/datasource/config/nginx_config_parser_test.go
@@ -346,6 +346,32 @@ server {
        }
 }
 `
+	testConfProxyProtocolOnly = `server {
+    server_name   localhost;
+    listen        8888 proxy_protocol;
+    listen        [::]:8888 default_server ipv6only=on proxy_protocol;
+
+    location = /stub_status {
+        stub_status;
+    }
+
+    location /api {
+        api write=on;
+    }
+}`
+	testConfProxyProtocolMixed = `server {
+    server_name   localhost;
+    listen        8888 proxy_protocol;
+    listen        8080;
+
+    location = /stub_status {
+        stub_status;
+    }
+
+    location /api {
+        api write=on;
+    }
+}`
 	testConf27 = `http {
 	access_log /var/log/nginx/access.log;
 	access_log /var/log/nginx/access.log; 
@@ -1302,6 +1328,25 @@ func TestNginxConfigParser_urlsForLocationDirective(t *testing.T) {
 			name: "Test 25: Multiple Plus APIs, Prioritize Write-Enabled (9092)",
 			conf: testConf25,
 		},
+		{
+			oss: &model.APIDetails{
+				URL:      "http://localhost:8080/stub_status",
+				Listen:   "localhost:8080",
+				Location: "/stub_status",
+			},
+			plus: &model.APIDetails{
+				URL:          "http://localhost:8080/api",
+				Listen:       "localhost:8080",
+				Location:     "/api",
+				WriteEnabled: true,
+			},
+			name: "Test 26: Mixed proxy_protocol and standard listen directives - ignore proxy_protocol",
+			conf: testConfProxyProtocolMixed,
+		},
+		{
+			name: "Test 27: Only proxy_protocol listen directives - return no plain HTTP API details",
+			conf: testConfProxyProtocolOnly,
+		},
 	}
 
 	for _, test := range tests {
@@ -1325,10 +1370,16 @@ func TestNginxConfigParser_urlsForLocationDirective(t *testing.T) {
 			oss, plus := traverseConfigForAPIs(t, ctx, payload)
 
 			if test.oss != nil {
+				require.NotEmpty(t, oss)
 				assert.Equal(t, test.oss, oss[0])
+			} else if test.plus == nil {
+				assert.Empty(t, oss)
 			}
 			if test.plus != nil {
+				require.NotEmpty(t, plus)
 				assert.Equal(t, test.plus, plus[0])
+			} else if test.oss == nil {
+				assert.Empty(t, plus)
 			}
 			helpers.ValidateLog(t, test.expectedLog, logBuf)
 


### PR DESCRIPTION
### Proposed changes

When NGINX is configured with `listen ... proxy_protocol;`, connecting to that socket requires an immediate PROXY protocol header. The agent's config parser previously created plain HTTP endpoint URLs for these sockets, causing NGINX connection resets (`broken header: "GET /api HTTP/1.1" while reading PROXY protocol`) and agent scraping failures (`EOF`).

This PR:
- Detects the `proxy_protocol` parameter on `listen` directives via `hasProxyProtocolArgument` and `isProxyProtocolListenDirective`.
- Excludes `proxy_protocol` listen sockets when generating plain HTTP endpoints for `/stub_status` and `/api`.
- Allows mixed configurations (e.g. `proxy_protocol` on port 8888 and standard listener on port 8080 or unix socket) to discover the valid, reachable endpoint.
- Adds table-driven unit tests for both mixed listeners and proxy_protocol-only listeners in `nginx_config_parser_test.go`.

Closes #978

### Checklist

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/agent/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes