### PR TITLE
Draft: changing azure credentials to OIDC

### DIFF
--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -94,7 +94,9 @@ jobs:
         if: ${{ inputs.uploadAzure == true }}
         uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZ_KEYVAULT_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZ_KEYVAULT_TENANT_ID }}
+          subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
 
       - name: Azure Upload
         if: ${{ inputs.uploadAzure == true }}


### PR DESCRIPTION
This PR migrates the v3 release pipelines off the legacy `AZURE_CREDENTIALS` secret to OIDC.